### PR TITLE
feat: add function based styling for all modes and styles

### DIFF
--- a/guides/GETTING_STARTED.md
+++ b/guides/GETTING_STARTED.md
@@ -290,3 +290,43 @@ draw.start();
 ```
 
 Please note at the moment it is not possible to style against specific modes but only universally against geometry type (Point, LineString, Polygon)
+
+## Styling Specific Features
+
+Terra Draw supports styling overrides of individual features if required. This can be achieved by providing a styling function rather than a string or a number to a feature. As an example here we can style each polygon feature as a random color:
+
+```typescript
+// Function to generate a random hex color - can adjust as needed
+function getRandomColor() {
+	const letters = "0123456789ABCDEF";
+	let color = "#";
+	for (let i = 0; i < 6; i++) {
+		color += letters[Math.floor(Math.random() * 16)];
+	}
+	return color;
+}
+
+// Cache for each feature id mapped to a hex color string
+const colorCache: Record<string, HexColor> = {};
+
+const draw = new TerraDraw({
+	adapter: new TerraDrawMapboxGLAdapter({
+		map, // Assume this is defined further up
+		coordinatePrecision: 9,
+	}),
+	modes: {
+		polygon: new TerraDrawPolygonMode({
+			styles: {
+				fillColor: ({ id }) => {
+					// Get the color from the cache or generate a new one
+					colorCache[id] = colorCache[id] || getRandomColor();
+					return colorCache[id];
+				},
+			},
+		}),
+	},
+});
+
+// Ensure the color cache is clead up on deletion of features
+draw.on("delete", (ids) => ids.forEach((id) => delete cache[id]));
+```

--- a/src/common.ts
+++ b/src/common.ts
@@ -6,6 +6,14 @@ import {
 
 export type HexColor = `#${string}`;
 
+export type HexColorStyling =
+	| HexColor
+	| ((feature: GeoJSONStoreFeatures) => HexColor);
+
+export type NumericStyling =
+	| number
+	| ((feature: GeoJSONStoreFeatures) => number);
+
 export interface TerraDrawAdapterStyling {
 	pointColor: HexColor;
 	pointWidth: number;

--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -1,5 +1,6 @@
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
 import {
+	HexColor,
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	TerraDrawModeRegisterConfig,
@@ -13,7 +14,13 @@ import {
 } from "../store/store";
 import { isValidStoreFeature } from "../store/store-feature-validation";
 
-type CustomStyling = Record<string, string | number>;
+type CustomStyling = Record<
+	string,
+	| string
+	| number
+	| ((feature: GeoJSONStoreFeatures) => HexColor)
+	| ((feature: GeoJSONStoreFeatures) => number)
+>;
 
 export enum ModeTypes {
 	Drawing = "drawing",
@@ -156,4 +163,34 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void
 	) {}
+
+	protected getHexColorStylingValue(
+		value: HexColor | ((feature: GeoJSONStoreFeatures) => HexColor) | undefined,
+		defaultValue: HexColor,
+		feature: GeoJSONStoreFeatures
+	): HexColor {
+		return this.getStylingValue(value, defaultValue, feature);
+	}
+
+	protected getNumericStylingValue(
+		value: number | ((feature: GeoJSONStoreFeatures) => number) | undefined,
+		defaultValue: number,
+		feature: GeoJSONStoreFeatures
+	): number {
+		return this.getStylingValue(value, defaultValue, feature);
+	}
+
+	private getStylingValue<T extends string | number>(
+		value: T | ((feature: GeoJSONStoreFeatures) => T) | undefined,
+		defaultValue: T,
+		feature: GeoJSONStoreFeatures
+	) {
+		if (value === undefined) {
+			return defaultValue;
+		} else if (typeof value === "function") {
+			return value(feature);
+		} else {
+			return value;
+		}
+	}
 }

--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -4,6 +4,8 @@ import {
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import { circle } from "../../geometry/shape/create-circle";
@@ -18,10 +20,10 @@ type TerraDrawCircleModeKeyEvents = {
 };
 
 type FreehandPolygonStyling = {
-	fillColor: HexColor;
-	outlineColor: HexColor;
-	outlineWidth: number;
-	fillOpacity: number;
+	fillColor: HexColorStyling;
+	outlineColor: HexColorStyling;
+	outlineWidth: NumericStyling;
+	fillOpacity: NumericStyling;
 };
 
 export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<FreehandPolygonStyling> {
@@ -174,18 +176,29 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<FreehandPolygonSt
 			feature.geometry.type === "Polygon" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.fillColor) {
-				styles.polygonFillColor = this.styles.fillColor;
-			}
-			if (this.styles.outlineColor) {
-				styles.polygonOutlineColor = this.styles.outlineColor;
-			}
-			if (this.styles.outlineWidth) {
-				styles.polygonOutlineWidth = this.styles.outlineWidth;
-			}
-			if (this.styles.fillOpacity) {
-				styles.polygonFillOpacity = this.styles.fillOpacity;
-			}
+			styles.polygonFillColor = this.getHexColorStylingValue(
+				this.styles.fillColor,
+				styles.polygonFillColor,
+				feature
+			);
+
+			styles.polygonOutlineColor = this.getHexColorStylingValue(
+				this.styles.outlineColor,
+				styles.polygonOutlineColor,
+				feature
+			);
+
+			styles.polygonOutlineWidth = this.getNumericStylingValue(
+				this.styles.outlineWidth,
+				styles.polygonOutlineWidth,
+				feature
+			);
+
+			styles.polygonFillOpacity = this.getNumericStylingValue(
+				this.styles.fillOpacity,
+				styles.polygonFillOpacity,
+				feature
+			);
 
 			return styles;
 		}

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -3,6 +3,8 @@ import {
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { Polygon } from "geojson";
 
@@ -18,14 +20,14 @@ type TerraDrawFreehandModeKeyEvents = {
 };
 
 type FreehandPolygonStyling = {
-	fillColor: HexColor;
-	outlineColor: HexColor;
-	outlineWidth: number;
-	fillOpacity: number;
-	closingPointColor: HexColor;
-	closingPointWidth: number;
-	closingPointOutlineColor: HexColor;
-	closingPointOutlineWidth: number;
+	fillColor: HexColorStyling;
+	outlineColor: HexColorStyling;
+	outlineWidth: NumericStyling;
+	fillOpacity: NumericStyling;
+	closingPointColor: HexColorStyling;
+	closingPointWidth: NumericStyling;
+	closingPointOutlineColor: HexColorStyling;
+	closingPointOutlineWidth: NumericStyling;
 };
 
 export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygonStyling> {
@@ -236,18 +238,29 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			feature.geometry.type === "Polygon" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.fillColor) {
-				styles.polygonFillColor = this.styles.fillColor;
-			}
-			if (this.styles.outlineColor) {
-				styles.polygonOutlineColor = this.styles.outlineColor;
-			}
-			if (this.styles.outlineWidth) {
-				styles.polygonOutlineWidth = this.styles.outlineWidth;
-			}
-			if (this.styles.fillOpacity) {
-				styles.polygonFillOpacity = this.styles.fillOpacity;
-			}
+			styles.polygonFillColor = this.getHexColorStylingValue(
+				this.styles.fillColor,
+				styles.polygonFillColor,
+				feature
+			);
+
+			styles.polygonOutlineColor = this.getHexColorStylingValue(
+				this.styles.outlineColor,
+				styles.polygonOutlineColor,
+				feature
+			);
+
+			styles.polygonOutlineWidth = this.getNumericStylingValue(
+				this.styles.outlineWidth,
+				styles.polygonOutlineWidth,
+				feature
+			);
+
+			styles.polygonFillOpacity = this.getNumericStylingValue(
+				this.styles.fillOpacity,
+				styles.polygonFillOpacity,
+				feature
+			);
 
 			return styles;
 		} else if (
@@ -255,21 +268,29 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			feature.geometry.type === "Point" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.closingPointColor) {
-				styles.pointColor = this.styles.closingPointColor;
-			}
-			if (this.styles.closingPointWidth) {
-				styles.pointWidth = this.styles.closingPointWidth;
-			}
+			styles.pointWidth = this.getNumericStylingValue(
+				this.styles.closingPointWidth,
+				styles.pointWidth,
+				feature
+			);
 
-			styles.pointOutlineColor =
-				this.styles.closingPointOutlineColor !== undefined
-					? this.styles.closingPointOutlineColor
-					: "#ffffff";
-			styles.pointOutlineWidth =
-				this.styles.closingPointOutlineWidth !== undefined
-					? this.styles.closingPointOutlineWidth
-					: 2;
+			styles.pointColor = this.getHexColorStylingValue(
+				this.styles.closingPointColor,
+				styles.pointColor,
+				feature
+			);
+
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				this.styles.closingPointOutlineColor,
+				styles.pointOutlineColor,
+				feature
+			);
+
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				this.styles.closingPointOutlineWidth,
+				2,
+				feature
+			);
 
 			return styles;
 		}

--- a/src/modes/greatcircle/great-circle.mode.ts
+++ b/src/modes/greatcircle/great-circle.mode.ts
@@ -3,6 +3,8 @@ import {
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { LineString } from "geojson";
 import { TerraDrawBaseDrawMode } from "../base.mode";
@@ -20,12 +22,12 @@ type TerraDrawGreateCircleModeKeyEvents = {
 };
 
 type GreateCircleStyling = {
-	lineStringWidth: number;
-	lineStringColor: HexColor;
-	closingPointColor: HexColor;
-	closingPointWidth: number;
-	closingPointOutlineColor: HexColor;
-	closingPointOutlineWidth: number;
+	lineStringWidth: NumericStyling;
+	lineStringColor: HexColorStyling;
+	closingPointColor: HexColorStyling;
+	closingPointWidth: NumericStyling;
+	closingPointOutlineColor: HexColorStyling;
+	closingPointOutlineWidth: NumericStyling;
 };
 
 export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircleStyling> {
@@ -251,12 +253,17 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.lineStringColor) {
-				styles.lineStringColor = this.styles.lineStringColor;
-			}
-			if (this.styles.lineStringWidth) {
-				styles.lineStringWidth = this.styles.lineStringWidth;
-			}
+			styles.lineStringColor = this.getHexColorStylingValue(
+				this.styles.lineStringColor,
+				styles.lineStringColor,
+				feature
+			);
+
+			styles.lineStringWidth = this.getNumericStylingValue(
+				this.styles.lineStringWidth,
+				styles.lineStringWidth,
+				feature
+			);
 
 			return styles;
 		} else if (
@@ -264,21 +271,29 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 			feature.geometry.type === "Point" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.closingPointColor) {
-				styles.pointColor = this.styles.closingPointColor;
-			}
-			if (this.styles.closingPointWidth) {
-				styles.pointWidth = this.styles.closingPointWidth;
-			}
+			styles.pointColor = this.getHexColorStylingValue(
+				this.styles.closingPointColor,
+				styles.pointColor,
+				feature
+			);
 
-			styles.pointOutlineColor =
-				this.styles.closingPointOutlineColor !== undefined
-					? this.styles.closingPointOutlineColor
-					: "#ffffff";
-			styles.pointOutlineWidth =
-				this.styles.closingPointOutlineWidth !== undefined
-					? this.styles.closingPointOutlineWidth
-					: 2;
+			styles.pointWidth = this.getNumericStylingValue(
+				this.styles.closingPointWidth,
+				styles.pointWidth,
+				feature
+			);
+
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				this.styles.closingPointOutlineColor,
+				"#ffffff",
+				feature
+			);
+
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				this.styles.closingPointOutlineWidth,
+				2,
+				feature
+			);
 
 			return styles;
 		}

--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -767,6 +767,108 @@ describe("TerraDrawLineStringMode", () => {
 		});
 	});
 
+	describe("styleFeature", () => {
+		it("returns the correct styles for point", () => {
+			const lineStringMode = new TerraDrawLineStringMode({
+				styles: {
+					lineStringColor: "#ffffff",
+					lineStringWidth: 4,
+					closingPointColor: "#111111",
+					closingPointWidth: 3,
+					closingPointOutlineColor: "#222222",
+					closingPointOutlineWidth: 2,
+				},
+			});
+
+			expect(
+				lineStringMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [] },
+					properties: { mode: "linestring" },
+				})
+			).toMatchObject({
+				pointColor: "#111111",
+				pointWidth: 3,
+				pointOutlineColor: "#222222",
+				pointOutlineWidth: 2,
+			});
+		});
+
+		it("returns the correct styles for point using functions", () => {
+			const lineStringMode = new TerraDrawLineStringMode({
+				styles: {
+					lineStringColor: () => "#ffffff",
+					lineStringWidth: () => 4,
+					closingPointColor: () => "#111111",
+					closingPointWidth: () => 3,
+					closingPointOutlineColor: () => "#222222",
+					closingPointOutlineWidth: () => 2,
+				},
+			});
+
+			expect(
+				lineStringMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [] },
+					properties: { mode: "linestring" },
+				})
+			).toMatchObject({
+				pointColor: "#111111",
+				pointWidth: 3,
+				pointOutlineColor: "#222222",
+				pointOutlineWidth: 2,
+			});
+		});
+
+		it("returns the correct styles for linestring", () => {
+			const lineStringMode = new TerraDrawLineStringMode({
+				styles: {
+					lineStringColor: "#ffffff",
+					lineStringWidth: 4,
+					closingPointColor: "#111111",
+					closingPointWidth: 3,
+					closingPointOutlineColor: "#222222",
+					closingPointOutlineWidth: 2,
+				},
+			});
+
+			expect(
+				lineStringMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "LineString", coordinates: [] },
+					properties: { mode: "linestring" },
+				})
+			).toMatchObject({
+				lineStringColor: "#ffffff",
+				lineStringWidth: 4,
+			});
+		});
+
+		it("returns the correct styles for linestring using functions", () => {
+			const lineStringMode = new TerraDrawLineStringMode({
+				styles: {
+					lineStringColor: () => "#ffffff",
+					lineStringWidth: () => 4,
+					closingPointColor: () => "#111111",
+					closingPointWidth: () => 3,
+					closingPointOutlineColor: () => "#222222",
+					closingPointOutlineWidth: () => 2,
+				},
+			});
+
+			expect(
+				lineStringMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "LineString", coordinates: [] },
+					properties: { mode: "linestring" },
+				})
+			).toMatchObject({
+				lineStringColor: "#ffffff",
+				lineStringWidth: 4,
+			});
+		});
+	});
+
 	describe("validateFeature", () => {
 		it("returns false for invalid linestring feature", () => {
 			const lineStringMode = new TerraDrawLineStringMode({

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -3,6 +3,8 @@ import {
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { LineString } from "geojson";
 import { selfIntersects } from "../../geometry/boolean/self-intersects";
@@ -21,12 +23,12 @@ type TerraDrawLineStringModeKeyEvents = {
 };
 
 type LineStringStyling = {
-	lineStringWidth: number;
-	lineStringColor: HexColor;
-	closingPointColor: HexColor;
-	closingPointWidth: number;
-	closingPointOutlineColor: HexColor;
-	closingPointOutlineWidth: number;
+	lineStringWidth: NumericStyling;
+	lineStringColor: HexColorStyling;
+	closingPointColor: HexColorStyling;
+	closingPointWidth: NumericStyling;
+	closingPointOutlineColor: HexColorStyling;
+	closingPointOutlineWidth: NumericStyling;
 };
 
 export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringStyling> {
@@ -365,12 +367,17 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.lineStringColor) {
-				styles.lineStringColor = this.styles.lineStringColor;
-			}
-			if (this.styles.lineStringWidth) {
-				styles.lineStringWidth = this.styles.lineStringWidth;
-			}
+			styles.lineStringColor = this.getHexColorStylingValue(
+				this.styles.lineStringColor,
+				styles.lineStringColor,
+				feature
+			);
+
+			styles.lineStringWidth = this.getNumericStylingValue(
+				this.styles.lineStringWidth,
+				styles.lineStringWidth,
+				feature
+			);
 
 			return styles;
 		} else if (
@@ -378,21 +385,29 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			feature.geometry.type === "Point" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.closingPointColor) {
-				styles.pointColor = this.styles.closingPointColor;
-			}
-			if (this.styles.closingPointWidth) {
-				styles.pointWidth = this.styles.closingPointWidth;
-			}
+			styles.pointColor = this.getHexColorStylingValue(
+				this.styles.closingPointColor,
+				styles.pointColor,
+				feature
+			);
 
-			styles.pointOutlineColor =
-				this.styles.closingPointOutlineColor !== undefined
-					? this.styles.closingPointOutlineColor
-					: "#ffffff";
-			styles.pointOutlineWidth =
-				this.styles.closingPointOutlineWidth !== undefined
-					? this.styles.closingPointOutlineWidth
-					: 2;
+			styles.pointWidth = this.getNumericStylingValue(
+				this.styles.closingPointWidth,
+				styles.pointWidth,
+				feature
+			);
+
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				this.styles.closingPointOutlineColor,
+				"#ffffff",
+				feature
+			);
+
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				this.styles.closingPointOutlineWidth,
+				2,
+				feature
+			);
 
 			return styles;
 		}

--- a/src/modes/point/point.mode.spec.ts
+++ b/src/modes/point/point.mode.spec.ts
@@ -219,6 +219,56 @@ describe("TerraDrawPointMode", () => {
 		});
 	});
 
+	describe("styleFeature", () => {
+		it("returns the correct styles for point", () => {
+			const pointMode = new TerraDrawPointMode({
+				styles: {
+					pointColor: "#ffffff",
+					pointWidth: 4,
+					pointOutlineColor: "#111111",
+					pointOutlineWidth: 2,
+				},
+			});
+
+			expect(
+				pointMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [] },
+					properties: { mode: "point" },
+				})
+			).toMatchObject({
+				pointColor: "#ffffff",
+				pointWidth: 4,
+				pointOutlineColor: "#111111",
+				pointOutlineWidth: 2,
+			});
+		});
+
+		it("returns the correct styles for point using functions", () => {
+			const pointMode = new TerraDrawPointMode({
+				styles: {
+					pointColor: () => "#ffffff",
+					pointWidth: () => 4,
+					pointOutlineColor: () => "#111111",
+					pointOutlineWidth: () => 2,
+				},
+			});
+
+			expect(
+				pointMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [] },
+					properties: { mode: "point" },
+				})
+			).toMatchObject({
+				pointColor: "#ffffff",
+				pointWidth: 4,
+				pointOutlineColor: "#111111",
+				pointOutlineWidth: 2,
+			});
+		});
+	});
+
 	describe("validateFeature", () => {
 		it("returns false for invalid point feature", () => {
 			const pointMode = new TerraDrawPointMode({

--- a/src/modes/point/point.mode.ts
+++ b/src/modes/point/point.mode.ts
@@ -1,7 +1,8 @@
 import {
 	TerraDrawMouseEvent,
 	TerraDrawAdapterStyling,
-	HexColor,
+	NumericStyling,
+	HexColorStyling,
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
@@ -9,10 +10,10 @@ import { TerraDrawBaseDrawMode } from "../base.mode";
 import { isValidPoint } from "../../geometry/boolean/is-valid-point";
 
 type PointModeStyling = {
-	pointWidth: number;
-	pointColor: HexColor;
-	pointOutlineColor: HexColor;
-	pointOutlineWidth: number;
+	pointWidth: NumericStyling;
+	pointColor: HexColorStyling;
+	pointOutlineColor: HexColorStyling;
+	pointOutlineWidth: NumericStyling;
 };
 export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> {
 	mode = "point";
@@ -84,21 +85,29 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			feature.geometry.type === "Point" &&
 			feature.properties.mode === this.mode
 		) {
-			styles.pointColor = this.styles.pointColor
-				? this.styles.pointColor
-				: styles.pointColor;
+			styles.pointWidth = this.getNumericStylingValue(
+				this.styles.pointWidth,
+				styles.pointWidth,
+				feature
+			);
 
-			styles.pointOutlineColor = this.styles.pointOutlineColor
-				? this.styles.pointOutlineColor
-				: styles.pointOutlineColor;
+			styles.pointColor = this.getHexColorStylingValue(
+				this.styles.pointColor,
+				styles.pointColor,
+				feature
+			);
 
-			styles.pointOutlineWidth = this.styles.pointOutlineWidth
-				? this.styles.pointOutlineWidth
-				: styles.pointOutlineWidth;
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				this.styles.pointOutlineColor,
+				styles.pointOutlineColor,
+				feature
+			);
 
-			styles.pointWidth = this.styles.pointWidth
-				? this.styles.pointWidth
-				: styles.pointWidth;
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				this.styles.pointOutlineWidth,
+				2,
+				feature
+			);
 		}
 
 		return styles;

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -1393,7 +1393,35 @@ describe("styleFeature", () => {
 		});
 	});
 
-	it("returns the correct styles for poiny", () => {
+	it("returns the correct styles for polygon using function", () => {
+		const polygonMode = new TerraDrawPolygonMode({
+			styles: {
+				fillColor: (_) => "#ffffff",
+				outlineColor: () => "#111111",
+				outlineWidth: () => 2,
+				fillOpacity: () => 0.5,
+				closingPointWidth: () => 2,
+				closingPointColor: () => "#dddddd",
+				closingPointOutlineWidth: () => 1,
+				closingPointOutlineColor: () => "#222222",
+			},
+		});
+
+		expect(
+			polygonMode.styleFeature({
+				type: "Feature",
+				geometry: { type: "Polygon", coordinates: [] },
+				properties: { mode: "polygon" },
+			})
+		).toMatchObject({
+			polygonFillColor: "#ffffff",
+			polygonOutlineColor: "#111111",
+			polygonOutlineWidth: 2,
+			polygonFillOpacity: 0.5,
+		});
+	});
+
+	it("returns the correct styles for point", () => {
 		const polygonMode = new TerraDrawPolygonMode({
 			styles: {
 				fillColor: "#ffffff",
@@ -1420,68 +1448,68 @@ describe("styleFeature", () => {
 			pointOutlineWidth: 1,
 		});
 	});
+});
 
-	describe("validateFeature", () => {
-		it("returns false for invalid polygon feature", () => {
-			const polygonMode = new TerraDrawPolygonMode({
-				styles: {
-					fillColor: "#ffffff",
-					outlineColor: "#ffffff",
-					outlineWidth: 2,
-					fillOpacity: 0.5,
-				},
-			});
-
-			expect(
-				polygonMode.validateFeature({
-					id: "29da86c2-92e2-4095-a1b3-22103535ebfa",
-					type: "Feature",
-					geometry: {
-						type: "Polygon",
-						coordinates: [[]],
-					},
-					properties: {
-						mode: "circle",
-						createdAt: 1685568434891,
-						updatedAt: 1685568435434,
-					},
-				})
-			).toBe(false);
+describe("validateFeature", () => {
+	it("returns false for invalid polygon feature", () => {
+		const polygonMode = new TerraDrawPolygonMode({
+			styles: {
+				fillColor: "#ffffff",
+				outlineColor: "#ffffff",
+				outlineWidth: 2,
+				fillOpacity: 0.5,
+			},
 		});
 
-		it("returns true for valid polygon feature", () => {
-			const polygonMode = new TerraDrawPolygonMode({
-				styles: {
-					fillColor: "#ffffff",
-					outlineColor: "#ffffff",
-					outlineWidth: 2,
-					fillOpacity: 0.5,
+		expect(
+			polygonMode.validateFeature({
+				id: "29da86c2-92e2-4095-a1b3-22103535ebfa",
+				type: "Feature",
+				geometry: {
+					type: "Polygon",
+					coordinates: [[]],
 				},
-			});
+				properties: {
+					mode: "circle",
+					createdAt: 1685568434891,
+					updatedAt: 1685568435434,
+				},
+			})
+		).toBe(false);
+	});
 
-			expect(
-				polygonMode.validateFeature({
-					id: "66608334-7cf1-4f9e-a7f9-75e5ac135e68",
-					type: "Feature",
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[-1.812744141, 52.429222278],
-								[-1.889648438, 51.652110862],
-								[0.505371094, 52.052490476],
-								[-0.417480469, 52.476089041],
-								[-1.812744141, 52.429222278],
-							],
+	it("returns true for valid polygon feature", () => {
+		const polygonMode = new TerraDrawPolygonMode({
+			styles: {
+				fillColor: "#ffffff",
+				outlineColor: "#ffffff",
+				outlineWidth: 2,
+				fillOpacity: 0.5,
+			},
+		});
+
+		expect(
+			polygonMode.validateFeature({
+				id: "66608334-7cf1-4f9e-a7f9-75e5ac135e68",
+				type: "Feature",
+				geometry: {
+					type: "Polygon",
+					coordinates: [
+						[
+							[-1.812744141, 52.429222278],
+							[-1.889648438, 51.652110862],
+							[0.505371094, 52.052490476],
+							[-0.417480469, 52.476089041],
+							[-1.812744141, 52.429222278],
 						],
-					},
-					properties: {
-						mode: "polygon",
-						createdAt: 1685655516297,
-						updatedAt: 1685655518118,
-					},
-				})
-			).toBe(true);
-		});
+					],
+				},
+				properties: {
+					mode: "polygon",
+					createdAt: 1685655516297,
+					updatedAt: 1685655518118,
+				},
+			})
+		).toBe(true);
 	});
 });

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -2,7 +2,8 @@ import {
 	TerraDrawMouseEvent,
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
-	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { Polygon } from "geojson";
 import { selfIntersects } from "../../geometry/boolean/self-intersects";
@@ -24,14 +25,14 @@ type TerraDrawPolygonModeKeyEvents = {
 };
 
 type PolygonStyling = {
-	fillColor: HexColor;
-	outlineColor: HexColor;
-	outlineWidth: number;
-	fillOpacity: number;
-	closingPointWidth: number;
-	closingPointColor: HexColor;
-	closingPointOutlineWidth: number;
-	closingPointOutlineColor: HexColor;
+	fillColor: HexColorStyling;
+	outlineColor: HexColorStyling;
+	outlineWidth: NumericStyling;
+	fillOpacity: NumericStyling;
+	closingPointWidth: NumericStyling;
+	closingPointColor: HexColorStyling;
+	closingPointOutlineWidth: NumericStyling;
+	closingPointOutlineColor: HexColorStyling;
 };
 
 export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> {
@@ -456,30 +457,56 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 		if (feature.properties.mode === this.mode) {
 			if (feature.geometry.type === "Polygon") {
-				styles.polygonFillColor =
-					this.styles.fillColor || styles.polygonFillColor;
-				styles.polygonOutlineColor =
-					this.styles.outlineColor || styles.polygonOutlineColor;
-				styles.polygonOutlineWidth =
-					this.styles.outlineWidth || styles.polygonOutlineWidth;
-				styles.polygonFillColor =
-					this.styles.fillColor || styles.polygonFillColor;
-				styles.polygonFillOpacity =
-					this.styles.fillOpacity || styles.polygonFillOpacity;
+				styles.polygonFillColor = this.getHexColorStylingValue(
+					this.styles.fillColor,
+					styles.polygonFillColor,
+					feature
+				);
+
+				styles.polygonOutlineColor = this.getHexColorStylingValue(
+					this.styles.outlineColor,
+					styles.polygonOutlineColor,
+					feature
+				);
+
+				styles.polygonOutlineWidth = this.getNumericStylingValue(
+					this.styles.outlineWidth,
+					styles.polygonOutlineWidth,
+					feature
+				);
+
+				styles.polygonFillOpacity = this.getNumericStylingValue(
+					this.styles.fillOpacity,
+					styles.polygonFillOpacity,
+					feature
+				);
+
 				styles.zIndex = 10;
 				return styles;
 			} else if (feature.geometry.type === "Point") {
-				styles.pointWidth =
-					this.styles.closingPointWidth !== undefined
-						? this.styles.closingPointWidth
-						: styles.pointWidth;
-				styles.pointColor = this.styles.closingPointColor || styles.pointColor;
-				styles.pointOutlineColor =
-					this.styles.closingPointOutlineColor || "#ffffff";
-				styles.pointOutlineWidth =
-					this.styles.closingPointOutlineWidth !== undefined
-						? this.styles.closingPointOutlineWidth
-						: 2;
+				styles.pointWidth = this.getNumericStylingValue(
+					this.styles.closingPointWidth,
+					styles.pointWidth,
+					feature
+				);
+
+				styles.pointColor = this.getHexColorStylingValue(
+					this.styles.closingPointColor,
+					styles.pointColor,
+					feature
+				);
+
+				styles.pointOutlineColor = this.getHexColorStylingValue(
+					this.styles.closingPointOutlineColor,
+					styles.pointOutlineColor,
+					feature
+				);
+
+				styles.pointOutlineWidth = this.getNumericStylingValue(
+					this.styles.closingPointOutlineWidth,
+					2,
+					feature
+				);
 				styles.zIndex = 30;
 				return styles;
 			}

--- a/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/src/modes/rectangle/rectangle.mode.spec.ts
@@ -464,9 +464,59 @@ describe("TerraDrawRectangleMode", () => {
 		});
 	});
 
+	describe("styleFeature", () => {
+		it("returns the correct styles for polygon", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				styles: {
+					fillColor: "#ffffff",
+					outlineColor: "#111111",
+					outlineWidth: 2,
+					fillOpacity: 0.5,
+				},
+			});
+
+			expect(
+				rectangleMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "rectangle" },
+				})
+			).toMatchObject({
+				polygonFillColor: "#ffffff",
+				polygonOutlineColor: "#111111",
+				polygonOutlineWidth: 2,
+				polygonFillOpacity: 0.5,
+			});
+		});
+
+		it("returns the correct styles for polygon using function", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				styles: {
+					fillColor: (_) => "#ffffff",
+					outlineColor: () => "#111111",
+					outlineWidth: () => 2,
+					fillOpacity: () => 0.5,
+				},
+			});
+
+			expect(
+				rectangleMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "rectangle" },
+				})
+			).toMatchObject({
+				polygonFillColor: "#ffffff",
+				polygonOutlineColor: "#111111",
+				polygonOutlineWidth: 2,
+				polygonFillOpacity: 0.5,
+			});
+		});
+	});
+
 	describe("validateFeature", () => {
 		it("returns false for invalid rectangle feature", () => {
-			const polygonMode = new TerraDrawRectangleMode({
+			const rectangleMode = new TerraDrawRectangleMode({
 				styles: {
 					fillColor: "#ffffff",
 					outlineColor: "#ffffff",
@@ -476,7 +526,7 @@ describe("TerraDrawRectangleMode", () => {
 			});
 
 			expect(
-				polygonMode.validateFeature({
+				rectangleMode.validateFeature({
 					id: "29da86c2-92e2-4095-a1b3-22103535ebfa",
 					type: "Feature",
 					geometry: {
@@ -493,7 +543,7 @@ describe("TerraDrawRectangleMode", () => {
 		});
 
 		it("returns false for self intersecting polygon feature", () => {
-			const polygonMode = new TerraDrawRectangleMode({
+			const rectangleMode = new TerraDrawRectangleMode({
 				styles: {
 					fillColor: "#ffffff",
 					outlineColor: "#ffffff",
@@ -503,7 +553,7 @@ describe("TerraDrawRectangleMode", () => {
 			});
 
 			expect(
-				polygonMode.validateFeature({
+				rectangleMode.validateFeature({
 					id: "66608334-7cf1-4f9e-a7f9-75e5ac135e68",
 					type: "Feature",
 					geometry: {

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -4,6 +4,8 @@ import {
 	TerraDrawAdapterStyling,
 	TerraDrawKeyboardEvent,
 	HexColor,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
@@ -16,10 +18,10 @@ type TerraDrawRectangleModeKeyEvents = {
 };
 
 type RectanglePolygonStyling = {
-	fillColor: HexColor;
-	outlineColor: HexColor;
-	outlineWidth: number;
-	fillOpacity: number;
+	fillColor: HexColorStyling;
+	outlineColor: HexColorStyling;
+	outlineWidth: NumericStyling;
+	fillOpacity: NumericStyling;
 };
 
 export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolygonStyling> {
@@ -180,18 +182,29 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			feature.geometry.type === "Polygon" &&
 			feature.properties.mode === this.mode
 		) {
-			if (this.styles.fillColor) {
-				styles.polygonFillColor = this.styles.fillColor;
-			}
-			if (this.styles.outlineColor) {
-				styles.polygonOutlineColor = this.styles.outlineColor;
-			}
-			if (this.styles.outlineWidth) {
-				styles.polygonOutlineWidth = this.styles.outlineWidth;
-			}
-			if (this.styles.fillOpacity) {
-				styles.polygonFillOpacity = this.styles.fillOpacity;
-			}
+			styles.polygonFillColor = this.getHexColorStylingValue(
+				this.styles.fillColor,
+				styles.polygonFillColor,
+				feature
+			);
+
+			styles.polygonOutlineColor = this.getHexColorStylingValue(
+				this.styles.outlineColor,
+				styles.polygonOutlineColor,
+				feature
+			);
+
+			styles.polygonOutlineWidth = this.getNumericStylingValue(
+				this.styles.outlineWidth,
+				styles.polygonOutlineWidth,
+				feature
+			);
+
+			styles.polygonFillOpacity = this.getNumericStylingValue(
+				this.styles.fillOpacity,
+				styles.polygonFillOpacity,
+				feature
+			);
 
 			return styles;
 		}

--- a/src/modes/render/render.mode.spec.ts
+++ b/src/modes/render/render.mode.spec.ts
@@ -172,7 +172,63 @@ describe("TerraDrawRenderMode", () => {
 		it("gets styling correctly", () => {
 			const renderMode = new TerraDrawRenderMode(stylingOptions);
 
-			expect(renderMode.styleFeature().pointColor).toEqual("#12121");
+			expect(
+				renderMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "polygon" },
+				}).pointColor
+			).toEqual("#12121");
+		});
+	});
+
+	describe("styleFeature", () => {
+		it("returns the correct styles for polygon", () => {
+			const renderMode = new TerraDrawRenderMode({
+				styles: {
+					polygonFillColor: "#ffffff",
+					polygonFillOpacity: 0.2,
+					polygonOutlineColor: "#111111",
+					polygonOutlineWidth: 3,
+				},
+			});
+
+			expect(
+				renderMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "render" },
+				})
+			).toMatchObject({
+				polygonFillColor: "#ffffff",
+				polygonOutlineColor: "#111111",
+				polygonOutlineWidth: 3,
+				polygonFillOpacity: 0.2,
+			});
+		});
+
+		it("returns the correct styles for polygon using function", () => {
+			const renderMode = new TerraDrawRenderMode({
+				styles: {
+					polygonFillColor: () => "#ffffff",
+					polygonFillOpacity: () => 0.2,
+					polygonOutlineColor: () => "#111111",
+					polygonOutlineWidth: () => 3,
+				},
+			});
+
+			expect(
+				renderMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "render" },
+				})
+			).toMatchObject({
+				polygonFillColor: "#ffffff",
+				polygonOutlineColor: "#111111",
+				polygonOutlineWidth: 3,
+				polygonFillOpacity: 0.2,
+			});
 		});
 	});
 

--- a/src/modes/render/render.mode.ts
+++ b/src/modes/render/render.mode.ts
@@ -1,4 +1,8 @@
-import { TerraDrawAdapterStyling } from "../../common";
+import {
+	HexColorStyling,
+	NumericStyling,
+	TerraDrawAdapterStyling,
+} from "../../common";
 import { ModeTypes, TerraDrawBaseDrawMode } from "../base.mode";
 import { BehaviorConfig } from "../base.behavior";
 import { getDefaultStyling } from "../../util/styling";
@@ -7,15 +11,25 @@ import { isValidPoint } from "../../geometry/boolean/is-valid-point";
 import { isValidPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
 import { isValidLineStringFeature } from "../../geometry/boolean/is-valid-linestring-feature";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type RenderModeStylingExt<T extends TerraDrawAdapterStyling> = {};
-type RenderModeStyling = RenderModeStylingExt<TerraDrawAdapterStyling>;
+type RenderModeStyling = {
+	pointColor: HexColorStyling;
+	pointWidth: NumericStyling;
+	pointOutlineColor: HexColorStyling;
+	pointOutlineWidth: NumericStyling;
+	polygonFillColor: HexColorStyling;
+	polygonFillOpacity: NumericStyling;
+	polygonOutlineColor: HexColorStyling;
+	polygonOutlineWidth: NumericStyling;
+	lineStringWidth: NumericStyling;
+	lineStringColor: HexColorStyling;
+	zIndex: NumericStyling;
+};
 
 export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling> {
 	public type = ModeTypes.Render; // The type of the mode
 	public mode = "render"; // This gets changed dynamically
 
-	constructor(options: { styles: Partial<TerraDrawAdapterStyling> }) {
+	constructor(options: { styles: Partial<RenderModeStyling> }) {
 		super({ styles: options.styles });
 	}
 
@@ -63,10 +77,65 @@ export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling
 	cleanUp() {}
 
 	/** @internal */
-	styleFeature(): TerraDrawAdapterStyling {
+	styleFeature(feature: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
+		const defaultStyles = getDefaultStyling();
+
 		return {
-			...getDefaultStyling(),
-			...this.styles,
+			pointColor: this.getHexColorStylingValue(
+				this.styles.pointColor,
+				defaultStyles.pointColor,
+				feature
+			),
+			pointWidth: this.getNumericStylingValue(
+				this.styles.pointWidth,
+				defaultStyles.pointWidth,
+				feature
+			),
+			pointOutlineColor: this.getHexColorStylingValue(
+				this.styles.pointOutlineColor,
+				defaultStyles.pointOutlineColor,
+				feature
+			),
+			pointOutlineWidth: this.getNumericStylingValue(
+				this.styles.pointOutlineWidth,
+				defaultStyles.pointOutlineWidth,
+				feature
+			),
+			polygonFillColor: this.getHexColorStylingValue(
+				this.styles.polygonFillColor,
+				defaultStyles.polygonFillColor,
+				feature
+			),
+			polygonFillOpacity: this.getNumericStylingValue(
+				this.styles.polygonFillOpacity,
+				defaultStyles.polygonFillOpacity,
+				feature
+			),
+			polygonOutlineColor: this.getHexColorStylingValue(
+				this.styles.polygonOutlineColor,
+				defaultStyles.polygonOutlineColor,
+				feature
+			),
+			polygonOutlineWidth: this.getNumericStylingValue(
+				this.styles.polygonOutlineWidth,
+				defaultStyles.polygonOutlineWidth,
+				feature
+			),
+			lineStringWidth: this.getNumericStylingValue(
+				this.styles.lineStringWidth,
+				defaultStyles.lineStringWidth,
+				feature
+			),
+			lineStringColor: this.getHexColorStylingValue(
+				this.styles.lineStringColor,
+				defaultStyles.lineStringColor,
+				feature
+			),
+			zIndex: this.getNumericStylingValue(
+				this.styles.zIndex,
+				defaultStyles.zIndex,
+				feature
+			),
 		};
 	}
 

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -2493,5 +2493,41 @@ describe("TerraDrawSelectMode", () => {
 				polygonOutlineColor: "#3f97e0",
 			});
 		});
+
+		it("returns the correct styles for polygon from polygon mode when using a function", () => {
+			const polygonMode = new TerraDrawSelectMode({
+				styles: {
+					selectedPolygonOutlineWidth: () => 4,
+					selectedPolygonColor: () => "#222222",
+					selectedPolygonOutlineColor: () => "#111111",
+					selectedPolygonFillOpacity: () => 1,
+				},
+			});
+
+			expect(
+				polygonMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "polygon", selected: true },
+				})
+			).toMatchObject({
+				polygonFillColor: "#222222",
+				polygonOutlineColor: "#111111",
+				polygonOutlineWidth: 4,
+				polygonFillOpacity: 1,
+			});
+
+			expect(
+				polygonMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Polygon", coordinates: [] },
+					properties: { mode: "polygon" },
+				})
+			).toMatchObject({
+				polygonFillColor: "#3f97e0",
+				polygonFillOpacity: 0.3,
+				polygonOutlineColor: "#3f97e0",
+			});
+		});
 	});
 });

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -4,6 +4,8 @@ import {
 	SELECT_PROPERTIES,
 	HexColor,
 	TerraDrawAdapterStyling,
+	HexColorStyling,
+	NumericStyling,
 } from "../../common";
 import { Point, Position } from "geojson";
 import { ModeTypes, TerraDrawBaseDrawMode } from "../base.mode";
@@ -42,32 +44,32 @@ type ModeFlags = {
 
 type SelectionStyling = {
 	// Point
-	selectedPointColor: HexColor;
-	selectedPointWidth: number;
-	selectedPointOutlineColor: HexColor;
-	selectedPointOutlineWidth: number;
+	selectedPointColor: HexColorStyling;
+	selectedPointWidth: NumericStyling;
+	selectedPointOutlineColor: HexColorStyling;
+	selectedPointOutlineWidth: NumericStyling;
 
 	// LineString
-	selectedLineStringColor: HexColor;
-	selectedLineStringWidth: number;
+	selectedLineStringColor: HexColorStyling;
+	selectedLineStringWidth: NumericStyling;
 
 	// Polygon
-	selectedPolygonColor: HexColor;
-	selectedPolygonFillOpacity: number;
-	selectedPolygonOutlineColor: HexColor;
-	selectedPolygonOutlineWidth: number;
+	selectedPolygonColor: HexColorStyling;
+	selectedPolygonFillOpacity: NumericStyling;
+	selectedPolygonOutlineColor: HexColorStyling;
+	selectedPolygonOutlineWidth: NumericStyling;
 
 	// Selection Points (points at vertices of a polygon/linestring feature)
-	selectionPointWidth: number;
-	selectionPointColor: HexColor;
-	selectionPointOutlineColor: HexColor;
-	selectionPointOutlineWidth: number;
+	selectionPointWidth: NumericStyling;
+	selectionPointColor: HexColorStyling;
+	selectionPointOutlineColor: HexColorStyling;
+	selectionPointOutlineWidth: NumericStyling;
 
 	// Mid points (points at mid point of a polygon/linestring feature)
-	midPointColor: HexColor;
-	midPointOutlineColor: HexColor;
-	midPointWidth: number;
-	midPointOutlineWidth: number;
+	midPointColor: HexColorStyling;
+	midPointOutlineColor: HexColorStyling;
+	midPointWidth: NumericStyling;
+	midPointOutlineWidth: NumericStyling;
 };
 
 export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling> {
@@ -665,35 +667,60 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 			feature.geometry.type === "Point"
 		) {
 			if (feature.properties.selectionPoint) {
-				styles.pointColor =
-					this.styles.selectionPointColor || styles.pointColor;
-				styles.pointOutlineColor =
-					this.styles.selectionPointOutlineColor || styles.pointOutlineColor;
-				styles.pointWidth =
-					this.styles.selectionPointWidth !== undefined
-						? this.styles.selectionPointWidth
-						: styles.pointWidth;
-				styles.pointOutlineWidth =
-					this.styles.selectionPointOutlineWidth !== undefined
-						? this.styles.selectionPointOutlineWidth
-						: 2;
+				styles.pointColor = this.getHexColorStylingValue(
+					this.styles.selectionPointColor,
+					styles.pointColor,
+					feature
+				);
+
+				styles.pointOutlineColor = this.getHexColorStylingValue(
+					this.styles.selectionPointOutlineColor,
+					styles.pointOutlineColor,
+					feature
+				);
+
+				styles.pointWidth = this.getNumericStylingValue(
+					this.styles.selectionPointWidth,
+					styles.pointWidth,
+					feature
+				);
+
+				styles.pointOutlineWidth = this.getNumericStylingValue(
+					this.styles.selectionPointOutlineWidth,
+					2,
+					feature
+				);
+
 				styles.zIndex = 30;
 
 				return styles;
 			}
 
 			if (feature.properties.midPoint) {
-				styles.pointColor = this.styles.midPointColor || styles.pointColor;
-				styles.pointOutlineColor =
-					this.styles.midPointOutlineColor || styles.pointOutlineColor;
-				styles.pointWidth =
-					this.styles.midPointWidth !== undefined
-						? this.styles.midPointWidth
-						: 4;
-				styles.pointOutlineWidth =
-					this.styles.midPointOutlineWidth !== undefined
-						? this.styles.midPointOutlineWidth
-						: 2;
+				styles.pointColor = this.getHexColorStylingValue(
+					this.styles.midPointColor,
+					styles.pointColor,
+					feature
+				);
+
+				styles.pointOutlineColor = this.getHexColorStylingValue(
+					this.styles.midPointOutlineColor,
+					styles.pointOutlineColor,
+					feature
+				);
+
+				styles.pointWidth = this.getNumericStylingValue(
+					this.styles.midPointWidth,
+					4,
+					feature
+				);
+
+				styles.pointOutlineWidth = this.getNumericStylingValue(
+					this.styles.midPointOutlineWidth,
+					2,
+					feature
+				);
+
 				styles.zIndex = 40;
 
 				return styles;
@@ -703,41 +730,71 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 			// A selected feature from another mode will end up in this block
 
 			if (feature.geometry.type === "Polygon") {
-				if (this.styles.selectedPolygonColor) {
-					styles.polygonFillColor = this.styles.selectedPolygonColor;
-				}
-				if (this.styles.selectedPolygonOutlineWidth) {
-					styles.polygonOutlineWidth = this.styles.selectedPolygonOutlineWidth;
-				}
-				if (this.styles.selectedPolygonOutlineColor) {
-					styles.polygonOutlineColor = this.styles.selectedPolygonOutlineColor;
-				}
-				if (this.styles.selectedPolygonFillOpacity) {
-					styles.polygonFillOpacity = this.styles.selectedPolygonFillOpacity;
-				}
+				styles.polygonFillColor = this.getHexColorStylingValue(
+					this.styles.selectedPolygonColor,
+					styles.polygonFillColor,
+					feature
+				);
+
+				styles.polygonOutlineWidth = this.getNumericStylingValue(
+					this.styles.selectedPolygonOutlineWidth,
+					styles.polygonOutlineWidth,
+					feature
+				);
+
+				styles.polygonOutlineColor = this.getHexColorStylingValue(
+					this.styles.selectedPolygonOutlineColor,
+					styles.polygonOutlineColor,
+					feature
+				);
+
+				styles.polygonFillOpacity = this.getNumericStylingValue(
+					this.styles.selectedPolygonFillOpacity,
+					styles.polygonFillOpacity,
+					feature
+				);
+
 				styles.zIndex = 10;
 				return styles;
 			} else if (feature.geometry.type === "LineString") {
-				if (this.styles.selectedLineStringColor) {
-					styles.lineStringColor = this.styles.selectedLineStringColor;
-				}
-				if (this.styles.selectedLineStringWidth) {
-					styles.lineStringWidth = this.styles.selectedLineStringWidth;
-				}
+				styles.lineStringColor = this.getHexColorStylingValue(
+					this.styles.selectedLineStringColor,
+					styles.lineStringColor,
+					feature
+				);
+
+				styles.lineStringWidth = this.getNumericStylingValue(
+					this.styles.selectedLineStringWidth,
+					styles.lineStringWidth,
+					feature
+				);
+
 				styles.zIndex = 10;
 				return styles;
 			} else if (feature.geometry.type === "Point") {
-				if (this.styles.selectedPointWidth) {
-					styles.pointWidth = this.styles.selectedPointWidth;
-				}
-				if (this.styles.selectedPointColor) {
-					styles.pointColor = this.styles.selectedPointColor;
-				}
-				if (this.styles.selectedPointOutlineColor) {
-					styles.pointOutlineColor = this.styles.selectedPointOutlineColor;
-				}
+				styles.pointWidth = this.getNumericStylingValue(
+					this.styles.selectedPointWidth,
+					styles.pointWidth,
+					feature
+				);
 
-				styles.pointOutlineWidth = this.styles.selectedPointOutlineWidth || 2;
+				styles.pointColor = this.getHexColorStylingValue(
+					this.styles.selectedPointColor,
+					styles.pointColor,
+					feature
+				);
+
+				styles.pointOutlineColor = this.getHexColorStylingValue(
+					this.styles.selectedPointOutlineColor,
+					styles.pointOutlineColor,
+					feature
+				);
+
+				styles.pointOutlineWidth = this.getNumericStylingValue(
+					this.styles.selectedPointOutlineWidth,
+					styles.pointOutlineWidth,
+					feature
+				);
 
 				styles.zIndex = 10;
 				return styles;


### PR DESCRIPTION
This PR resolves #59 - it allows the ability to style any feature in a given mode using styling functions. This means that features can be styled on other values such as a cached random colour based on the feature id. However this could be extended in the future to be based on properties or be based on other external data if required.

A small example is provided in the getting started guide to help show to to make that happen.