### PR TITLE
feat: allow cursors to be configured for built in modes

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -195,6 +195,7 @@ export abstract class TerraDrawBaseAdapter {
 					}
 
 					const drawEvent = this.getDrawEventFromEvent(event);
+
 					if (!drawEvent) {
 						return;
 					}

--- a/src/common.ts
+++ b/src/common.ts
@@ -48,8 +48,21 @@ export interface TerraDrawKeyboardEvent {
 	preventDefault: () => void;
 }
 
+export type Required<T> = {
+	[P in keyof T]-?: T[P];
+};
+
+export type Cursor = Parameters<SetCursor>[0];
+
 export type SetCursor = (
-	cursor: "unset" | "grab" | "grabbing" | "crosshair" | "pointer" | "wait"
+	cursor:
+		| "unset"
+		| "grab"
+		| "grabbing"
+		| "crosshair"
+		| "pointer"
+		| "wait"
+		| "move"
 ) => void;
 
 export type Project = (lng: number, lat: number) => { x: number; y: number };

--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -6,6 +6,8 @@ import {
 	HexColor,
 	HexColorStyling,
 	NumericStyling,
+	SetCursor,
+	Cursor,
 } from "../../common";
 import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import { circle } from "../../geometry/shape/create-circle";
@@ -19,25 +21,41 @@ type TerraDrawCircleModeKeyEvents = {
 	finish: KeyboardEvent["key"] | null;
 };
 
-type FreehandPolygonStyling = {
+type CirclePolygonStyling = {
 	fillColor: HexColorStyling;
 	outlineColor: HexColorStyling;
 	outlineWidth: NumericStyling;
 	fillOpacity: NumericStyling;
 };
 
-export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<FreehandPolygonStyling> {
+interface Cursors {
+	start?: Cursor;
+}
+
+export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyling> {
 	mode = "circle";
 	private center: Position | undefined;
 	private clickCount = 0;
 	private currentCircleId: string | undefined;
 	private keyEvents: TerraDrawCircleModeKeyEvents;
+	private cursors: Required<Cursors>;
 
 	constructor(options?: {
-		styles?: Partial<FreehandPolygonStyling>;
+		styles?: Partial<CirclePolygonStyling>;
 		keyEvents?: TerraDrawCircleModeKeyEvents | null;
+		cursors?: Cursors;
 	}) {
 		super(options);
+
+		const defaultCursors = {
+			start: "crosshair",
+		} as Required<Cursors>;
+
+		if (options && options.cursors) {
+			this.cursors = { ...defaultCursors, ...options.cursors };
+		} else {
+			this.cursors = defaultCursors;
+		}
 
 		// We want to have some defaults, but also allow key bindings
 		// to be explicitly turned off
@@ -74,7 +92,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<FreehandPolygonSt
 	/** @internal */
 	start() {
 		this.setStarted();
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.start);
 	}
 
 	/** @internal */

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -5,6 +5,7 @@ import {
 	HexColor,
 	HexColorStyling,
 	NumericStyling,
+	Cursor,
 } from "../../common";
 import { Polygon } from "geojson";
 
@@ -30,6 +31,11 @@ type FreehandPolygonStyling = {
 	closingPointOutlineWidth: NumericStyling;
 };
 
+interface Cursors {
+	start?: Cursor;
+	close?: Cursor;
+}
+
 export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygonStyling> {
 	mode = "freehand";
 
@@ -38,13 +44,26 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	private closingPointId: string | undefined;
 	private minDistance: number;
 	private keyEvents: TerraDrawFreehandModeKeyEvents;
+	private cursors: Required<Cursors>;
 
 	constructor(options?: {
 		styles?: Partial<FreehandPolygonStyling>;
 		minDistance?: number;
 		keyEvents?: TerraDrawFreehandModeKeyEvents | null;
+		cursors?: Cursors;
 	}) {
 		super(options);
+
+		const defaultCursors = {
+			start: "crosshair",
+			close: "pointer",
+		} as Required<Cursors>;
+
+		if (options && options.cursors) {
+			this.cursors = { ...defaultCursors, ...options.cursors };
+		} else {
+			this.cursors = defaultCursors;
+		}
 
 		this.minDistance = (options && options.minDistance) || 20;
 
@@ -84,7 +103,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	/** @internal */
 	start() {
 		this.setStarted();
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.start);
 	}
 
 	/** @internal */
@@ -122,9 +141,9 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 		);
 
 		if (closingDistance < this.pointerDistance) {
-			this.setCursor("pointer");
+			this.setCursor(this.cursors.close);
 		} else {
-			this.setCursor("crosshair");
+			this.setCursor(this.cursors.start);
 		}
 
 		// The cusor must have moved a minimum distance

--- a/src/modes/greatcircle/great-circle.mode.ts
+++ b/src/modes/greatcircle/great-circle.mode.ts
@@ -5,6 +5,7 @@ import {
 	HexColor,
 	HexColorStyling,
 	NumericStyling,
+	Cursor,
 } from "../../common";
 import { LineString } from "geojson";
 import { TerraDrawBaseDrawMode } from "../base.mode";
@@ -30,6 +31,11 @@ type GreateCircleStyling = {
 	closingPointOutlineWidth: NumericStyling;
 };
 
+interface Cursors {
+	start?: Cursor;
+	close?: Cursor;
+}
+
 export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircleStyling> {
 	mode = "greatcircle";
 
@@ -38,6 +44,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	private closingPointId: string | undefined;
 	private keyEvents: TerraDrawGreateCircleModeKeyEvents;
 	private snappingEnabled: boolean;
+	private cursors: Required<Cursors>;
 
 	// Behaviors
 	private snapping!: GreatCircleSnappingBehavior;
@@ -47,8 +54,20 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 		pointerDistance?: number;
 		styles?: Partial<GreateCircleStyling>;
 		keyEvents?: TerraDrawGreateCircleModeKeyEvents | null;
+		cursors?: Cursors;
 	}) {
 		super(options);
+
+		const defaultCursors = {
+			start: "crosshair",
+			close: "pointer",
+		} as Required<Cursors>;
+
+		if (options && options.cursors) {
+			this.cursors = { ...defaultCursors, ...options.cursors };
+		} else {
+			this.cursors = defaultCursors;
+		}
 
 		this.snappingEnabled =
 			options && options.snapping !== undefined ? options.snapping : false;
@@ -99,7 +118,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	/** @internal */
 	start() {
 		this.setStarted();
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.start);
 	}
 
 	/** @internal */
@@ -111,7 +130,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 
 	/** @internal */
 	onMouseMove(event: TerraDrawMouseEvent) {
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.start);
 
 		if (!this.currentId && this.currentCoordinate === 0) {
 			return;

--- a/src/modes/point/point.mode.ts
+++ b/src/modes/point/point.mode.ts
@@ -3,6 +3,7 @@ import {
 	TerraDrawAdapterStyling,
 	NumericStyling,
 	HexColorStyling,
+	Cursor,
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
@@ -15,17 +16,36 @@ type PointModeStyling = {
 	pointOutlineColor: HexColorStyling;
 	pointOutlineWidth: NumericStyling;
 };
+
+interface Cursors {
+	create?: Cursor;
+}
+
 export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> {
 	mode = "point";
 
-	constructor(options?: { styles?: Partial<PointModeStyling> }) {
+	private cursors: Required<Cursors>;
+
+	constructor(options?: {
+		styles?: Partial<PointModeStyling>;
+		cursors?: Cursors;
+	}) {
 		super(options);
+		const defaultCursors = {
+			create: "crosshair",
+		} as Required<Cursors>;
+
+		if (options && options.cursors) {
+			this.cursors = { ...defaultCursors, ...options.cursors };
+		} else {
+			this.cursors = defaultCursors;
+		}
 	}
 
 	/** @internal */
 	start() {
 		this.setStarted();
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.create);
 	}
 
 	/** @internal */

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -6,6 +6,7 @@ import {
 	HexColor,
 	HexColorStyling,
 	NumericStyling,
+	Cursor,
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
@@ -24,18 +25,35 @@ type RectanglePolygonStyling = {
 	fillOpacity: NumericStyling;
 };
 
+interface Cursors {
+	start?: Cursor;
+}
+
 export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolygonStyling> {
 	mode = "rectangle";
 	private center: Position | undefined;
 	private clickCount = 0;
 	private currentRectangleId: string | undefined;
 	private keyEvents: TerraDrawRectangleModeKeyEvents;
+	private cursors: Required<Cursors>;
 
 	constructor(options?: {
 		styles?: Partial<RectanglePolygonStyling>;
 		keyEvents?: TerraDrawRectangleModeKeyEvents | null;
+		cursors?: Cursors;
 	}) {
 		super(options);
+
+		const defaultCursors = {
+			start: "crosshair",
+		} as Required<Cursors>;
+
+		if (options && options.cursors) {
+			this.cursors = { ...defaultCursors, ...options.cursors };
+		} else {
+			this.cursors = defaultCursors;
+		}
+
 		// We want to have some defaults, but also allow key bindings
 		// to be explicitly turned off
 		if (options?.keyEvents === null) {
@@ -91,7 +109,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	/** @internal */
 	start() {
 		this.setStarted();
-		this.setCursor("crosshair");
+		this.setCursor(this.cursors.start);
 	}
 
 	/** @internal */

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -1603,6 +1603,10 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
+			// Pointer set to move when teh cursor is
+			expect(setCursor).toHaveBeenCalledTimes(1);
+			expect(setCursor).toBeCalledWith("move");
+
 			expect(onSelect).toBeCalledTimes(1);
 
 			const setMapDraggability = jest.fn();
@@ -1617,7 +1621,7 @@ describe("TerraDrawSelectMode", () => {
 				},
 				setMapDraggability
 			);
-			expect(setCursor).not.toBeCalled();
+
 			expect(setMapDraggability).not.toBeCalled();
 		});
 
@@ -2359,7 +2363,7 @@ describe("TerraDrawSelectMode", () => {
 			expect(setMapDraggability).toBeCalledTimes(1);
 			expect(setMapDraggability).toBeCalledWith(true);
 			expect(setCursor).toBeCalledTimes(1);
-			expect(setCursor).toBeCalledWith("grab");
+			expect(setCursor).toBeCalledWith("move");
 		});
 	});
 


### PR DESCRIPTION
Resolves #49 

Allows cursors to be configured via a config option in each mode

Changes default cursor for dragging features/coordinates to the move icon rather than grab
