### PR TITLE
Preventing Polygon Self-Intersection with Select Mode

### DIFF
--- a/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -1,10 +1,11 @@
 import { TerraDrawMouseEvent } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 
-import { LineString, Polygon, Position, Point } from "geojson";
+import { LineString, Polygon, Position, Point, Feature } from "geojson";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
+import { selfIntersects } from "../../../geometry/boolean/self-intersects";
 
 export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -83,7 +84,10 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		return closestCoordinate.index;
 	}
 
-	public drag(event: TerraDrawMouseEvent): boolean {
+	public drag(
+		event: TerraDrawMouseEvent,
+		allowSelfIntersection: boolean
+	): boolean {
 		if (!this.draggedCoordinate.id) {
 			return false;
 		}
@@ -135,6 +139,18 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 			: [];
 
 		const updatedMidPoints = this.midPoints.getUpdated(geomCoordinates) || [];
+
+		if (
+			geometry.type !== "Point" &&
+			!allowSelfIntersection &&
+			selfIntersects({
+				type: "Feature",
+				geometry: geometry,
+				properties: {},
+			} as Feature<Polygon>)
+		) {
+			return false;
+		}
 
 		// Apply all the updates
 		this.store.updateGeometry([

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -36,6 +36,7 @@ type ModeFlags = {
 		draggable?: boolean;
 		rotateable?: boolean;
 		scaleable?: boolean;
+		selfIntersectable?: boolean;
 		coordinates?: {
 			midpoints?: boolean;
 			draggable?: boolean;
@@ -588,6 +589,10 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 
 		const properties = this.store.getPropertiesCopy(selectedId);
 		const modeFlags = this.flags[properties.mode as string];
+		const canSelfIntersect: boolean =
+			(modeFlags &&
+				modeFlags.feature &&
+				modeFlags.feature.selfIntersectable) === true;
 
 		// Ensure drag count is incremented
 		this.dragEventCount++;
@@ -624,7 +629,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 
 		// Check if coordinate is draggable and is dragged
 		if (this.dragCoordinate.isDragging()) {
-			this.dragCoordinate.drag(event);
+			this.dragCoordinate.drag(event, canSelfIntersect);
 			return;
 		}
 


### PR DESCRIPTION
The constructor for TerraDrawSelectMode may now contain an additional field called "selfIntersectable" that, when toggled true, will allow Polygons or LineStrings to become self-intersecting through edits in select mode. When the selfIntersectable field is omitted from teh TerraDrawSelectMode constructor, the default behavior is to prohibit self-intersections from occurring in select mode.

I added an additional parameter in the drag() function of drag-coordinate.behavior.ts to specify whether or not geometry updates containing self-intersections should be saved to the store. If self-intersections are prohibited and the registered mouse event would cause a self-intersection, the attempted geometry changes will not save to the store, and the function will return false. I also wrote new tests and updated existing tests to accomodate this extra parameter.