### PR TITLE
feat: add getFeaturesAtLngLat and getFeaturesAtPointerEvent methods

### DIFF
--- a/guides/COMMON_PATTERNS.md
+++ b/guides/COMMON_PATTERNS.md
@@ -4,14 +4,14 @@
 
 To change mode we need to set the current mode to match the name of the mode we want. You can see the name of the mode in each modes 'mode' property in the modes source file. For convenience here are the built in mode names listed out:
 
-* TerraDrawStaticMode - 'static' 
-* TerraDrawPolygonMode - 'polygon'
-* TerraDrawPointMode - 'point'
-* TerraDrawCircleMode - 'circle'
-* TerraDrawLineStringMode - 'linestring'
-* TerraDrawSelectMode - 'select'
-* TerraDrawLineStringMode - 'freehand'
-* TerraDraqwGreatCircleMode - 'greatcircle'
+- TerraDrawStaticMode - 'static'
+- TerraDrawPolygonMode - 'polygon'
+- TerraDrawPointMode - 'point'
+- TerraDrawCircleMode - 'circle'
+- TerraDrawLineStringMode - 'linestring'
+- TerraDrawSelectMode - 'select'
+- TerraDrawLineStringMode - 'freehand'
+- TerraDraqwGreatCircleMode - 'greatcircle'
 
 We can then create these modes and change to them like so:
 
@@ -24,20 +24,18 @@ const draw = new TerraDraw({
 	}),
 	modes: [
 		new TerraDrawPolygonMode(), // Polygon mode has a builtin name 'polygon'
-		new TerraDrawRenderMode({ modeName: 'arbitary' }) // Render modes are given custom names
+		new TerraDrawRenderMode({ modeName: "arbitary" }), // Render modes are given custom names
 	],
 });
 
 draw.start();
 
 // Change to our TerraDrawPolygonMode instance
-draw.setMode('polygon')
+draw.setMode("polygon");
 
 // We can use our custom render mode name to change to it.
-draw.setMode('arbitary') 
-
+draw.setMode("arbitary");
 ```
-
 
 ### Loading in External Data
 
@@ -62,7 +60,7 @@ const draw = new TerraDraw({
 		map,
 		coordinatePrecision: 9,
 	}),
-	modes: [new TerraDrawRenderMode({ modeName: 'arbitary' })],
+	modes: [new TerraDrawRenderMode({ modeName: "arbitary" })],
 });
 
 draw.start();
@@ -108,7 +106,7 @@ const draw = new TerraDraw({
 				selectedPolygonOutlineWidth: 2, // Integer
 			},
 		}),
-	]
+	],
 });
 
 draw.start();
@@ -149,9 +147,45 @@ const draw = new TerraDraw({
 				},
 			},
 		}),
-	]
+	],
 });
 
 // Ensure the color cache is clead up on deletion of features
 draw.on("delete", (ids) => ids.forEach((id) => delete cache[id]));
 ```
+
+### Getting Features from a Mouse/Pointer Event
+
+Getting features at a given mouse event can be done like so:
+
+```typescript
+document.addEventListener("mousemove", (event) => {
+	const featuresAtMouseEvent = draw.getFeaturesAtPointerEvent(event, {
+		pointerDistance: 40, // the number pixels to search around input point
+		ignoreSelectFeatures: true,
+	});
+	console.log({ featuresAtMouseEvent });
+});
+```
+
+The second argument is optional, with defaults set to ignoreSelectFeatures: false and pointerDistance: 30
+
+### Getting Features at a given Longitude/Latitude
+
+Getting features at a given longitude and latitude can be done like so:
+
+```typescript
+map.on("mousemove", (event) => {
+	const { lng, lat } = event.lngLat;
+	const featuresAtLngLat = draw.getFeaturesAtLngLat(
+		{ lng, lat },
+		{
+			pointerDistance: 40, // the number pixels to search around input point
+			ignoreSelectFeatures: true,
+		}
+	);
+	console.log({ featuresAtLngLat });
+});
+```
+
+The second argument is optional, with defaults set to ignoreSelectFeatures: false and pointerDistance: 30

--- a/src/common.ts
+++ b/src/common.ts
@@ -129,6 +129,7 @@ export interface TerraDrawAdapter {
 	project: Project;
 	unproject: Unproject;
 	setCursor: SetCursor;
+	getLngLatFromEvent: GetLngLatFromEvent;
 	setDoubleClickToZoom: (enabled: boolean) => void;
 	getMapContainer: () => HTMLElement;
 	register(callbacks: TerraDrawCallbacks): void;

--- a/src/geometry/shape/create-bbox.spec.ts
+++ b/src/geometry/shape/create-bbox.spec.ts
@@ -1,0 +1,35 @@
+import { Unproject } from "../../common";
+import { createBBoxFromPoint } from "./create-bbox";
+
+describe("Geometry", () => {
+	describe("bbox", () => {
+		it("creates a bbox polygon", () => {
+			const unproject = jest.fn((x, y) => ({
+				lng: x,
+				lat: y,
+			})) as unknown as Unproject;
+
+			const result = createBBoxFromPoint({
+				point: {
+					x: 10,
+					y: 10,
+				},
+				unproject,
+				pointerDistance: 30,
+			});
+
+			console.log(JSON.stringify(result));
+
+			expect(result.geometry.type).toBe("Polygon");
+			expect(result.geometry.coordinates).toEqual([
+				[
+					[-5, -5],
+					[25, -5],
+					[25, 25],
+					[-5, 25],
+					[-5, -5],
+				],
+			]);
+		});
+	});
+});

--- a/src/geometry/shape/create-bbox.ts
+++ b/src/geometry/shape/create-bbox.ts
@@ -1,0 +1,35 @@
+import { Feature, Polygon } from "geojson";
+import { Unproject } from "../../common";
+
+export function createBBoxFromPoint({
+	unproject,
+	point,
+	pointerDistance,
+}: {
+	point: {
+		x: number;
+		y: number;
+	};
+	unproject: Unproject;
+	pointerDistance: number;
+}) {
+	const halfDist = pointerDistance / 2;
+	const { x, y } = point;
+
+	return {
+		type: "Feature",
+		properties: {},
+		geometry: {
+			type: "Polygon",
+			coordinates: [
+				[
+					unproject(x - halfDist, y - halfDist), // TopLeft
+					unproject(x + halfDist, y - halfDist), // TopRight
+					unproject(x + halfDist, y + halfDist), // BottomRight
+					unproject(x - halfDist, y + halfDist), // BottomLeft
+					unproject(x - halfDist, y - halfDist), // TopLeft
+				].map((c) => [c.lng, c.lat]),
+			],
+		},
+	} as Feature<Polygon>;
+}

--- a/src/modes/click-bounding-box.behavior.ts
+++ b/src/modes/click-bounding-box.behavior.ts
@@ -1,7 +1,6 @@
-import { Feature, Polygon } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
-
 import { TerraDrawMouseEvent } from "../common";
+import { createBBoxFromPoint } from "../geometry/shape/create-bbox";
 
 export class ClickBoundingBoxBehavior extends TerraDrawModeBehavior {
 	constructor(config: BehaviorConfig) {
@@ -10,25 +9,10 @@ export class ClickBoundingBoxBehavior extends TerraDrawModeBehavior {
 
 	public create(event: TerraDrawMouseEvent) {
 		const { containerX: x, containerY: y } = event;
-		const halfDist = this.pointerDistance / 2;
-
-		const bbox = {
-			type: "Feature",
-			properties: {},
-			geometry: {
-				type: "Polygon",
-				coordinates: [
-					[
-						this.unproject(x - halfDist, y - halfDist), // TopLeft
-						this.unproject(x + halfDist, y - halfDist), // TopRight
-						this.unproject(x + halfDist, y + halfDist), // BottomRight
-						this.unproject(x - halfDist, y + halfDist), // BottomLeft
-						this.unproject(x - halfDist, y - halfDist), // TopLeft
-					].map((c) => [c.lng, c.lat]),
-				],
-			},
-		} as Feature<Polygon>;
-
-		return bbox;
+		return createBBoxFromPoint({
+			unproject: this.unproject,
+			point: { x, y },
+			pointerDistance: this.pointerDistance,
+		});
 	}
 }

--- a/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -6,7 +6,7 @@ import { BehaviorConfig } from "../../base.behavior";
 import { ClickBoundingBoxBehavior } from "../../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { DragFeatureBehavior } from "./drag-feature.behavior";
-import { FeaturesAtMouseEventBehavior } from "./features-at-mouse-event.behavior";
+import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 
@@ -15,7 +15,7 @@ describe("DragFeatureBehavior", () => {
 		it("constructs", () => {
 			const config = mockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
-			const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+			const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 				config,
 				new ClickBoundingBoxBehavior(config),
 				new PixelDistanceBehavior(config)
@@ -27,7 +27,7 @@ describe("DragFeatureBehavior", () => {
 
 			new DragFeatureBehavior(
 				config,
-				featuresAtMouseEventBehavior,
+				featureAtPointerEventBehavior,
 				selectionPointBehavior,
 				midpointBehavior
 			);
@@ -41,7 +41,7 @@ describe("DragFeatureBehavior", () => {
 		beforeEach(() => {
 			config = mockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
-			const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+			const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 				config,
 				new ClickBoundingBoxBehavior(config),
 				new PixelDistanceBehavior(config)
@@ -53,7 +53,7 @@ describe("DragFeatureBehavior", () => {
 
 			dragFeatureBehavior = new DragFeatureBehavior(
 				config,
-				featuresAtMouseEventBehavior,
+				featureAtPointerEventBehavior,
 				selectionPointBehavior,
 				midpointBehavior
 			);

--- a/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -1,6 +1,6 @@
 import { TerraDrawMouseEvent } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
-import { FeaturesAtMouseEventBehavior } from "./features-at-mouse-event.behavior";
+import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
@@ -9,7 +9,7 @@ import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 export class DragFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
-		private readonly featuresAtMouseEvent: FeaturesAtMouseEventBehavior,
+		private readonly featuresAtMouseEvent: FeatureAtPointerEventBehavior,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior
 	) {
@@ -19,28 +19,6 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 	private draggedFeatureId: string | null = null;
 
 	private dragPosition: Position | undefined;
-
-	// get position() {
-	// 	return this.dragPosition ? this.dragPosition.concat() : undefined;
-	// }
-
-	// set position(newPosition: undefined | Position) {
-	// 	if (newPosition === undefined) {
-	// 		this.dragPosition = undefined;
-	// 		return;
-	// 	}
-
-	// 	if (
-	// 		!Array.isArray(newPosition) ||
-	// 		newPosition.length !== 2 ||
-	// 		typeof newPosition[0] !== "number" ||
-	// 		typeof newPosition[1] !== "number"
-	// 	) {
-	// 		throw new Error("Position must be [number, number] array");
-	// 	}
-
-	// 	this.dragPosition = newPosition.concat();
-	// }
 
 	startDragging(event: TerraDrawMouseEvent, id: string) {
 		this.draggedFeatureId = id;

--- a/src/modes/select/behaviors/feature-at-pointer-event.behavior.spec.ts
+++ b/src/modes/select/behaviors/feature-at-pointer-event.behavior.spec.ts
@@ -7,20 +7,16 @@ import {
 } from "../../../test/create-store-features";
 import { mockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { mockDrawEvent } from "../../../test/mock-mouse-event";
-import {
-	mockBoundingBoxUnproject,
-	mockUnproject,
-} from "../../../test/mock-unproject";
-import { createPolygon } from "../../../util/geoms";
+import { mockBoundingBoxUnproject } from "../../../test/mock-unproject";
 import { ClickBoundingBoxBehavior } from "../../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
-import { FeaturesAtMouseEventBehavior } from "./features-at-mouse-event.behavior";
+import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 
-describe("FeaturesAtMouseEventBehavior", () => {
+describe("FeatureAtPointerEventBehavior", () => {
 	describe("constructor", () => {
 		it("constructs", () => {
 			const config = mockBehaviorConfig("test");
-			new FeaturesAtMouseEventBehavior(
+			new FeatureAtPointerEventBehavior(
 				config,
 				new ClickBoundingBoxBehavior(config),
 				new PixelDistanceBehavior(config)
@@ -32,7 +28,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 		describe("find", () => {
 			it("returns nothing if nothing in store", () => {
 				const config = mockBehaviorConfig("test");
-				const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+				const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 					config,
 					new ClickBoundingBoxBehavior(config),
 					new PixelDistanceBehavior(config)
@@ -41,7 +37,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 				// of bbox coordinates
 				mockBoundingBoxUnproject(config.unproject as jest.Mock);
 
-				const result = featuresAtMouseEventBehavior.find(
+				const result = featureAtPointerEventBehavior.find(
 					mockDrawEvent(),
 					false
 				);
@@ -53,7 +49,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 
 			it("ignores selection point", () => {
 				const config = mockBehaviorConfig("test");
-				const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+				const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 					config,
 					new ClickBoundingBoxBehavior(config),
 					new PixelDistanceBehavior(config)
@@ -75,7 +71,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 				// of bbox coordinates
 				mockBoundingBoxUnproject(config.unproject as jest.Mock);
 
-				const result = featuresAtMouseEventBehavior.find(
+				const result = featureAtPointerEventBehavior.find(
 					mockDrawEvent(),
 					false
 				);
@@ -88,7 +84,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 
 			it("returns clicked feature", () => {
 				const config = mockBehaviorConfig("test");
-				const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+				const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 					config,
 					new ClickBoundingBoxBehavior(config),
 					new PixelDistanceBehavior(config)
@@ -116,7 +112,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 						y: 0,
 					}));
 
-				const result = featuresAtMouseEventBehavior.find(
+				const result = featureAtPointerEventBehavior.find(
 					mockDrawEvent(),
 					false
 				);
@@ -126,7 +122,7 @@ describe("FeaturesAtMouseEventBehavior", () => {
 
 			it("returns midpoint", () => {
 				const config = mockBehaviorConfig("test");
-				const featuresAtMouseEventBehavior = new FeaturesAtMouseEventBehavior(
+				const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 					config,
 					new ClickBoundingBoxBehavior(config),
 					new PixelDistanceBehavior(config)
@@ -153,7 +149,10 @@ describe("FeaturesAtMouseEventBehavior", () => {
 						y: 0,
 					}));
 
-				const result = featuresAtMouseEventBehavior.find(mockDrawEvent(), true);
+				const result = featureAtPointerEventBehavior.find(
+					mockDrawEvent(),
+					true
+				);
 
 				expect((result.clickedMidPoint as GeoJSONStoreFeatures).id).toBeUUID4();
 			});

--- a/src/modes/select/behaviors/feature-at-pointer-event.behavior.ts
+++ b/src/modes/select/behaviors/feature-at-pointer-event.behavior.ts
@@ -8,7 +8,7 @@ import { pointInPolygon } from "../../../geometry/boolean/point-in-polygon";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { pixelDistanceToLine } from "../../../geometry/measure/pixel-distance-to-line";
 
-export class FeaturesAtMouseEventBehavior extends TerraDrawModeBehavior {
+export class FeatureAtPointerEventBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
 		private readonly createClickBoundingBox: ClickBoundingBoxBehavior,
@@ -43,7 +43,6 @@ export class FeaturesAtMouseEventBehavior extends TerraDrawModeBehavior {
 
 				const distance = this.pixelDistance.measure(
 					event,
-
 					geometry.coordinates
 				);
 

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -12,7 +12,7 @@ import { Point, Position } from "geojson";
 import { ModeTypes, TerraDrawBaseDrawMode } from "../base.mode";
 import { MidPointBehavior } from "./behaviors/midpoint.behavior";
 import { SelectionPointBehavior } from "./behaviors/selection-point.behavior";
-import { FeaturesAtMouseEventBehavior } from "./behaviors/features-at-mouse-event.behavior";
+import { FeatureAtPointerEventBehavior } from "./behaviors/feature-at-pointer-event.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { DragFeatureBehavior } from "./behaviors/drag-feature.behavior";
@@ -22,7 +22,6 @@ import { RotateFeatureBehavior } from "./behaviors/rotate-feature.behavior";
 import { ScaleFeatureBehavior } from "./behaviors/scale-feature.behavior";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
-import { SetCursor } from "../../terra-draw";
 
 type TerraDrawSelectModeKeyEvents = {
 	deselect: KeyboardEvent["key"] | null;
@@ -96,7 +95,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 	// Behaviors
 	private selectionPoints!: SelectionPointBehavior;
 	private midPoints!: MidPointBehavior;
-	private featuresAtMouseEvent!: FeaturesAtMouseEventBehavior;
+	private featuresAtMouseEvent!: FeatureAtPointerEventBehavior;
 	private pixelDistance!: PixelDistanceBehavior;
 	private clickBoundingBox!: ClickBoundingBoxBehavior;
 	private dragFeature!: DragFeatureBehavior;
@@ -162,7 +161,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 	registerBehaviors(config: BehaviorConfig) {
 		this.pixelDistance = new PixelDistanceBehavior(config);
 		this.clickBoundingBox = new ClickBoundingBoxBehavior(config);
-		this.featuresAtMouseEvent = new FeaturesAtMouseEventBehavior(
+		this.featuresAtMouseEvent = new FeatureAtPointerEventBehavior(
 			config,
 			this.clickBoundingBox,
 			this.pixelDistance


### PR DESCRIPTION
Adds two methods to the main Terra Draw API:


`.getFeaturesAtLngLat`

Allows for retrieval of features at a given latitude and longitude

and:

`.getFeaturesAtPointerEvent`

Allows for retrieval of features at a given mouse or pointer event

Resolves #74 