### PR TITLE
feat: allow custom limits of microdrags whilst selecting

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -21,11 +21,17 @@ export abstract class TerraDrawBaseAdapter {
 		coordinatePrecision?: number;
 		minPixelDragDistanceDrawing?: number;
 		minPixelDragDistance?: number;
+		minPixelDragDistanceSelecting?: number;
 	}) {
 		this._minPixelDragDistance =
 			typeof config.minPixelDragDistance === "number"
 				? config.minPixelDragDistance
 				: 1;
+
+		this._minPixelDragDistanceSelecting =
+			typeof config.minPixelDragDistanceSelecting === "number"
+				? config.minPixelDragDistanceSelecting
+				: 8;
 
 		this._minPixelDragDistanceDrawing =
 			typeof config.minPixelDragDistanceDrawing === "number"
@@ -111,22 +117,29 @@ export abstract class TerraDrawBaseAdapter {
 							currentEventXY
 						);
 
+						// We start off assuming it is not a microdrag
+						let isMicroDrag = false;
+
 						if (modeState === "drawing") {
 							// We want to ignore very small pointer movements when holding
 							// the map down as these are normally done by accident when
 							// drawing and is not an intended drag
-							const isMicroDrag =
+							isMicroDrag =
 								pixelDistanceToCheck < this._minPixelDragDistanceDrawing;
-							if (isMicroDrag) {
-								return;
-							}
+						} else if (modeState === "selecting") {
+							// Simiarly when selecting, we want to ignore very small pointer
+							// movements when holding the map down as these are normally done
+							// by accident when drawing and is not an intended drag
+							isMicroDrag =
+								pixelDistanceToCheck < this._minPixelDragDistanceSelecting;
 						} else {
 							// Same as above, but when not drawing we generally want a much lower tolerance
-							const isMicroDrag =
-								pixelDistanceToCheck < this._minPixelDragDistance;
-							if (isMicroDrag) {
-								return;
-							}
+							isMicroDrag = pixelDistanceToCheck < this._minPixelDragDistance;
+						}
+
+						// If it is a microdrag we do not register it by returning early
+						if (isMicroDrag) {
+							return;
 						}
 
 						this._dragState = "dragging";
@@ -280,6 +293,7 @@ export abstract class TerraDrawBaseAdapter {
 
 	protected _minPixelDragDistance: number;
 	protected _minPixelDragDistanceDrawing: number;
+	protected _minPixelDragDistanceSelecting: number;
 	protected _lastDrawEvent: TerraDrawMouseEvent | undefined;
 	protected _coordinatePrecision: number;
 	protected _heldKeys: Set<string> = new Set();

--- a/src/common.ts
+++ b/src/common.ts
@@ -90,7 +90,7 @@ export type TerraDrawModeState =
 	| "registered"
 	| "started"
 	| "drawing"
-	| "selected"
+	| "selecting"
 	| "stopped";
 
 export interface TerraDrawCallbacks {

--- a/src/geometry/shape/create-bbox.spec.ts
+++ b/src/geometry/shape/create-bbox.spec.ts
@@ -18,8 +18,6 @@ describe("Geometry", () => {
 				pointerDistance: 30,
 			});
 
-			console.log(JSON.stringify(result));
-
 			expect(result.geometry.type).toBe("Polygon");
 			expect(result.geometry.coordinates).toEqual([
 				[

--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -90,7 +90,8 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 		if (
 			this._state === "stopped" ||
 			this._state === "registered" ||
-			this._state === "drawing"
+			this._state === "drawing" ||
+			this._state === "selecting"
 		) {
 			this._state = "started";
 			this.setDoubleClickToZoom(false);

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -202,7 +202,7 @@ describe("TerraDrawSelectMode", () => {
 			selectMode.register(getMockModeConfig(selectMode.mode));
 			selectMode.start();
 
-			expect(selectMode.state).toBe("started");
+			expect(selectMode.state).toBe("selecting");
 		});
 
 		it("can stop correctly", () => {

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -158,6 +158,14 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 			5;
 	}
 
+	setSelecting() {
+		if (this._state === "started") {
+			this._state = "selecting";
+		} else {
+			throw new Error("Mode must be started to move to selecting state");
+		}
+	}
+
 	registerBehaviors(config: BehaviorConfig) {
 		this.pixelDistance = new PixelDistanceBehavior(config);
 		this.clickBoundingBox = new ClickBoundingBoxBehavior(config);
@@ -431,11 +439,13 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 	/** @internal */
 	start() {
 		this.setStarted();
+		this.setSelecting();
 	}
 
 	/** @internal */
 	stop() {
 		this.cleanUp();
+		this.setStarted();
 		this.setStopped();
 	}
 


### PR DESCRIPTION
Creates a new state called `selecting` and then allows for setting custom threshold for micro drags, as per for drawing and regular interactions around the map.

Aims to resolve #77 