### PR TITLE
fix: fire an onFinish event when finished dragging a coordinate or feature

### DIFF
--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -657,6 +657,15 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 		setMapDraggability: (enabled: boolean) => void
 	) {
 		this.setCursor(this.cursors.dragEnd);
+
+		// If we have finished dragging a coordinate or a feature
+		// lets fire an onFinish event which can be listened to
+		if (this.dragCoordinate.isDragging()) {
+			this.onFinish(this.selected[0]);
+		} else if (this.dragFeature.isDragging()) {
+			this.onFinish(this.selected[0]);
+		}
+
 		this.dragCoordinate.stopDragging();
 		this.dragFeature.stopDragging();
 		this.rotateFeature.reset();


### PR DESCRIPTION
Resolves #80 

`onFinished` event should now be fired at the end of dragging a feature or coordinate in Select mode. Includes unit tests to help ensure it works.