### PR TITLE
test: improve test coverage of Google Maps adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"eslint-plugin-prettier": "^5.0.0",
 				"husky": "^7.0.0",
 				"jest": "^29.3.1",
+				"jest-environment-jsdom": "^29.7.0",
 				"leaflet": "^1.8.0",
 				"mapbox-gl": "^2.13.0",
 				"maplibre-gl": "3.2.0",
@@ -2925,15 +2926,15 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.3.1.tgz",
-			"integrity": "sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/fake-timers": "^29.3.1",
-				"@jest/types": "^29.3.1",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.3.1"
+				"jest-mock": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2974,17 +2975,17 @@
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.3.1.tgz",
-			"integrity": "sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.3.1",
-				"@sinonjs/fake-timers": "^9.1.2",
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.3.1",
-				"jest-mock": "^29.3.1",
-				"jest-util": "^29.3.1"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3235,12 +3236,12 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-			"integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.0.0",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -3252,21 +3253,21 @@
 			}
 		},
 		"node_modules/@jest/types/node_modules/@jest/schemas": {
-			"version": "29.0.0",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-			"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"dev": true,
 			"dependencies": {
-				"@sinclair/typebox": "^0.24.1"
+				"@sinclair/typebox": "^0.27.8"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/types/node_modules/@sinclair/typebox": {
-			"version": "0.24.51",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-			"integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -3707,21 +3708,21 @@
 			"dev": true
 		},
 		"node_modules/@sinonjs/commons": {
-			"version": "1.8.6",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-			"integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+			"integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
 			"dev": true,
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-			"integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"dev": true,
 			"dependencies": {
-				"@sinonjs/commons": "^1.7.0"
+				"@sinonjs/commons": "^3.0.0"
 			}
 		},
 		"node_modules/@stencil/core": {
@@ -4085,6 +4086,15 @@
 			"optional": true,
 			"peer": true
 		},
+		"node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/@trysound/sax": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -4266,6 +4276,17 @@
 				"pretty-format": "^28.0.0"
 			}
 		},
+		"node_modules/@types/jsdom": {
+			"version": "20.0.1",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.13",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -4368,6 +4389,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"dev": true
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
+			"integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==",
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
@@ -4892,6 +4919,12 @@
 			"integrity": "sha512-/J4WBTpWtQ4itN1rb3ao8LfClmVcmz2pO6oYb7Qd4h7VSqUhIbJIvrykz9Ew1WMg6eFWsKdsMHc5uPbFxqlCpg==",
 			"dev": true
 		},
+		"node_modules/abab": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+			"dev": true
+		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4906,15 +4939,25 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-globals": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.1.0",
+				"acorn-walk": "^8.0.2"
 			}
 		},
 		"node_modules/acorn-import-assertions": {
@@ -4949,6 +4992,41 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
 			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+			"dev": true
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/agent-base/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/agent-base/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
 		"node_modules/ajv": {
@@ -5137,6 +5215,12 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"node_modules/asyncro": {
@@ -5889,6 +5973,18 @@
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
 			"dev": true
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
@@ -6671,6 +6767,30 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"dev": true
+		},
+		"node_modules/cssstyle": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"dev": true,
+			"dependencies": {
+				"cssom": "~0.3.6"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cssstyle/node_modules/cssom": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"dev": true
+		},
 		"node_modules/dargs": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -6678,6 +6798,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+			"dev": true,
+			"dependencies": {
+				"abab": "^2.0.6",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/dateformat": {
@@ -6734,6 +6868,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+			"dev": true
 		},
 		"node_modules/dedent": {
 			"version": "0.7.0",
@@ -6934,6 +7074,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -7019,6 +7168,18 @@
 					"url": "https://github.com/sponsors/fb55"
 				}
 			]
+		},
+		"node_modules/domexception": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+			"dev": true,
+			"dependencies": {
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/domhandler": {
 			"version": "4.3.1",
@@ -7285,6 +7446,36 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/escodegen/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -8084,6 +8275,20 @@
 				"tabbable": "^6.1.2"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/form-request-submit-polyfill": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
@@ -8743,10 +8948,95 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-encoding": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"dev": true,
+			"dependencies": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/http-proxy-agent/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/http-proxy-agent/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/https-proxy-agent/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/https-proxy-agent/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
 		"node_modules/human-signals": {
@@ -8771,6 +9061,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/icss-replace-symbols": {
@@ -9194,6 +9496,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
 		},
 		"node_modules/is-reference": {
 			"version": "1.2.1",
@@ -10023,6 +10331,33 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/jsdom": "^20.0.0",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jsdom": "^20.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^2.5.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/jest-environment-node": {
 			"version": "29.3.1",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.3.1.tgz",
@@ -10131,18 +10466,18 @@
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-			"integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.3.1",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
@@ -10151,21 +10486,21 @@
 			}
 		},
 		"node_modules/jest-message-util/node_modules/@jest/schemas": {
-			"version": "29.0.0",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-			"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"dev": true,
 			"dependencies": {
-				"@sinclair/typebox": "^0.24.1"
+				"@sinclair/typebox": "^0.27.8"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-message-util/node_modules/@sinclair/typebox": {
-			"version": "0.24.51",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-			"integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
 		},
 		"node_modules/jest-message-util/node_modules/ansi-styles": {
@@ -10181,12 +10516,12 @@
 			}
 		},
 		"node_modules/jest-message-util/node_modules/pretty-format": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-			"integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/schemas": "^29.0.0",
+				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^18.0.0"
 			},
@@ -10195,14 +10530,14 @@
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
-			"integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.3.1"
+				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10777,12 +11112,12 @@
 			}
 		},
 		"node_modules/jest-util": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-			"integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -10920,6 +11255,51 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"dev": true,
+			"dependencies": {
+				"abab": "^2.0.6",
+				"acorn": "^8.8.1",
+				"acorn-globals": "^7.0.0",
+				"cssom": "^0.5.0",
+				"cssstyle": "^2.3.0",
+				"data-urls": "^3.0.2",
+				"decimal.js": "^10.4.2",
+				"domexception": "^4.0.0",
+				"escodegen": "^2.0.0",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^3.0.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.2",
+				"parse5": "^7.1.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.2",
+				"w3c-xmlserializer": "^4.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^2.0.0",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0",
+				"ws": "^8.11.0",
+				"xml-name-validator": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"canvas": "^2.5.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/jsesc": {
@@ -11908,6 +12288,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/nwsapi": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+			"integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+			"dev": true
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12160,6 +12546,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^4.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -12951,10 +13361,16 @@
 			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
 			"dev": true
 		},
+		"node_modules/psl": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+			"dev": true
+		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -12969,6 +13385,12 @@
 				"node": ">=0.6.0",
 				"teleport": ">=0.2.0"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -13302,6 +13724,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.1",
@@ -13714,6 +14142,24 @@
 			"resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
 			"integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
 			"dev": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
 		},
 		"node_modules/schema-utils": {
 			"version": "3.1.1",
@@ -14590,6 +15036,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
+		},
 		"node_modules/synckit": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -14771,6 +15223,42 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+			"dev": true,
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/trim-newlines": {
@@ -15169,6 +15657,16 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15237,6 +15735,18 @@
 				"pbf": "^3.2.1"
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+			"dev": true,
+			"dependencies": {
+				"xml-name-validator": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/walker": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -15265,6 +15775,15 @@
 			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
 			"integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
 			"dev": true
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/webpack": {
 			"version": "5.73.0",
@@ -15322,6 +15841,40 @@
 			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"dev": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "^3.0.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/which": {
@@ -15471,10 +16024,46 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
+		"node_modules/ws": {
+			"version": "8.14.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/xml-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
 			"integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA==",
+			"dev": true
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"node_modules/xss": {
@@ -17672,15 +18261,15 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.3.1.tgz",
-			"integrity": "sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^29.3.1",
-				"@jest/types": "^29.3.1",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-mock": "^29.3.1"
+				"jest-mock": "^29.7.0"
 			}
 		},
 		"@jest/expect": {
@@ -17711,17 +18300,17 @@
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.3.1.tgz",
-			"integrity": "sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.3.1",
-				"@sinonjs/fake-timers": "^9.1.2",
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^29.3.1",
-				"jest-mock": "^29.3.1",
-				"jest-util": "^29.3.1"
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
 			}
 		},
 		"@jest/globals": {
@@ -17922,12 +18511,12 @@
 			}
 		},
 		"@jest/types": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-			"integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.0.0",
+				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
@@ -17936,18 +18525,18 @@
 			},
 			"dependencies": {
 				"@jest/schemas": {
-					"version": "29.0.0",
-					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-					"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+					"version": "29.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+					"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 					"dev": true,
 					"requires": {
-						"@sinclair/typebox": "^0.24.1"
+						"@sinclair/typebox": "^0.27.8"
 					}
 				},
 				"@sinclair/typebox": {
-					"version": "0.24.51",
-					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-					"integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+					"version": "0.27.8",
+					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+					"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 					"dev": true
 				}
 			}
@@ -18287,21 +18876,21 @@
 			"dev": true
 		},
 		"@sinonjs/commons": {
-			"version": "1.8.6",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-			"integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+			"integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"@sinonjs/fake-timers": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-			"integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.7.0"
+				"@sinonjs/commons": "^3.0.0"
 			}
 		},
 		"@stencil/core": {
@@ -18534,6 +19123,12 @@
 			"optional": true,
 			"peer": true
 		},
+		"@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true
+		},
 		"@trysound/sax": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -18712,6 +19307,17 @@
 				"pretty-format": "^28.0.0"
 			}
 		},
+		"@types/jsdom": {
+			"version": "20.0.1",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.13",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -18814,6 +19420,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"dev": true
+		},
+		"@types/tough-cookie": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
+			"integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==",
 			"dev": true
 		},
 		"@types/yargs": {
@@ -19209,6 +19821,12 @@
 			"integrity": "sha512-/J4WBTpWtQ4itN1rb3ao8LfClmVcmz2pO6oYb7Qd4h7VSqUhIbJIvrykz9Ew1WMg6eFWsKdsMHc5uPbFxqlCpg==",
 			"dev": true
 		},
+		"abab": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+			"dev": true
+		},
 		"accepts": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -19220,10 +19838,20 @@
 			}
 		},
 		"acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true
+		},
+		"acorn-globals": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.1.0",
+				"acorn-walk": "^8.0.2"
+			}
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
@@ -19251,6 +19879,32 @@
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
 			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
+		},
+		"agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"requires": {
+				"debug": "4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -19384,6 +20038,12 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
 			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"asyncro": {
@@ -19922,6 +20582,15 @@
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
 			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
 		},
 		"commander": {
 			"version": "2.20.3",
@@ -20541,11 +21210,45 @@
 				"css-tree": "^1.1.2"
 			}
 		},
+		"cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"dev": true,
+			"requires": {
+				"cssom": "~0.3.6"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+					"dev": true
+				}
+			}
+		},
 		"dargs": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
 			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
 			"dev": true
+		},
+		"data-urls": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.6",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0"
+			}
 		},
 		"dateformat": {
 			"version": "3.0.3",
@@ -20591,6 +21294,12 @@
 					"dev": true
 				}
 			}
+		},
+		"decimal.js": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+			"dev": true
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -20721,6 +21430,12 @@
 				"object-keys": "^1.1.1"
 			}
 		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true
+		},
 		"detect-indent": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -20779,6 +21494,15 @@
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
 			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
 			"dev": true
+		},
+		"domexception": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^7.0.0"
+			}
 		},
 		"domhandler": {
 			"version": "4.3.1",
@@ -20985,6 +21709,26 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
+		},
+		"escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"requires": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
+				}
+			}
 		},
 		"eslint": {
 			"version": "8.24.0",
@@ -21580,6 +22324,17 @@
 				"tabbable": "^6.1.2"
 			}
 		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"form-request-submit-polyfill": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
@@ -22084,11 +22839,75 @@
 				"lru-cache": "^6.0.0"
 			}
 		},
+		"html-encoding-sniffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^2.0.0"
+			}
+		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
+		},
+		"http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"dev": true,
+			"requires": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"requires": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"human-signals": {
 			"version": "2.1.0",
@@ -22101,6 +22920,15 @@
 			"resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
 			"integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
 			"dev": true
+		},
+		"iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			}
 		},
 		"icss-replace-symbols": {
 			"version": "1.1.0",
@@ -22375,6 +23203,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
 			"integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+			"dev": true
+		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true
 		},
 		"is-reference": {
@@ -22986,6 +23820,22 @@
 				}
 			}
 		},
+		"jest-environment-jsdom": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/jsdom": "^20.0.0",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jsdom": "^20.0.0"
+			}
+		},
 		"jest-environment-node": {
 			"version": "29.3.1",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.3.1.tgz",
@@ -23069,35 +23919,35 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-			"integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.9",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^29.3.1",
+				"pretty-format": "^29.7.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
 			"dependencies": {
 				"@jest/schemas": {
-					"version": "29.0.0",
-					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-					"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+					"version": "29.6.3",
+					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+					"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 					"dev": true,
 					"requires": {
-						"@sinclair/typebox": "^0.24.1"
+						"@sinclair/typebox": "^0.27.8"
 					}
 				},
 				"@sinclair/typebox": {
-					"version": "0.24.51",
-					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-					"integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+					"version": "0.27.8",
+					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+					"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -23107,12 +23957,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "29.3.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-					"integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+					"version": "29.7.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+					"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 					"dev": true,
 					"requires": {
-						"@jest/schemas": "^29.0.0",
+						"@jest/schemas": "^29.6.3",
 						"ansi-styles": "^5.0.0",
 						"react-is": "^18.0.0"
 					}
@@ -23120,14 +23970,14 @@
 			}
 		},
 		"jest-mock": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
-			"integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"jest-util": "^29.3.1"
+				"jest-util": "^29.7.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -23598,12 +24448,12 @@
 			}
 		},
 		"jest-util": {
-			"version": "29.3.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-			"integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.3.1",
+				"@jest/types": "^29.6.3",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"ci-info": "^3.2.0",
@@ -23713,6 +24563,40 @@
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
+			}
+		},
+		"jsdom": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.6",
+				"acorn": "^8.8.1",
+				"acorn-globals": "^7.0.0",
+				"cssom": "^0.5.0",
+				"cssstyle": "^2.3.0",
+				"data-urls": "^3.0.2",
+				"decimal.js": "^10.4.2",
+				"domexception": "^4.0.0",
+				"escodegen": "^2.0.0",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^3.0.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.2",
+				"parse5": "^7.1.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.2",
+				"w3c-xmlserializer": "^4.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^2.0.0",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0",
+				"ws": "^8.11.0",
+				"xml-name-validator": "^4.0.0"
 			}
 		},
 		"jsesc": {
@@ -24500,6 +25384,12 @@
 			"integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
 			"dev": true
 		},
+		"nwsapi": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+			"integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+			"dev": true
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -24682,6 +25572,23 @@
 				"error-ex": "^1.3.1",
 				"json-parse-even-better-errors": "^2.3.0",
 				"lines-and-columns": "^1.1.6"
+			}
+		},
+		"parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"dev": true,
+			"requires": {
+				"entities": "^4.4.0"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+					"dev": true
+				}
 			}
 		},
 		"path-exists": {
@@ -25191,16 +26098,28 @@
 			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
 			"dev": true
 		},
+		"psl": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+			"dev": true
+		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true
 		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
 			"integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+			"dev": true
+		},
+		"querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -25460,6 +26379,12 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
 			"dev": true
 		},
 		"resolve": {
@@ -25763,6 +26688,21 @@
 			"resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
 			"integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
 			"dev": true
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"requires": {
+				"xmlchars": "^2.2.0"
+			}
 		},
 		"schema-utils": {
 			"version": "3.1.1",
@@ -26454,6 +27394,12 @@
 				}
 			}
 		},
+		"symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true
+		},
 		"synckit": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -26581,6 +27527,35 @@
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
+			}
+		},
+		"tough-cookie": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+			"integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+					"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+					"dev": true
+				}
+			}
+		},
+		"tr46": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.1"
 			}
 		},
 		"trim-newlines": {
@@ -26839,6 +27814,16 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"requires": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -26901,6 +27886,15 @@
 				"pbf": "^3.2.1"
 			}
 		},
+		"w3c-xmlserializer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+			"dev": true,
+			"requires": {
+				"xml-name-validator": "^4.0.0"
+			}
+		},
 		"walker": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -26925,6 +27919,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
 			"integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
+			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
 			"dev": true
 		},
 		"webpack": {
@@ -26966,6 +27966,31 @@
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true,
 			"peer": true
+		},
+		"whatwg-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.6.3"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"dev": true,
+			"requires": {
+				"tr46": "^3.0.0",
+				"webidl-conversions": "^7.0.0"
+			}
 		},
 		"which": {
 			"version": "2.0.2",
@@ -27071,10 +28096,29 @@
 				"signal-exit": "^3.0.7"
 			}
 		},
+		"ws": {
+			"version": "8.14.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"dev": true,
+			"requires": {}
+		},
+		"xml-name-validator": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+			"dev": true
+		},
 		"xml-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
 			"integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA==",
+			"dev": true
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"xss": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"eslint-plugin-prettier": "^5.0.0",
 		"husky": "^7.0.0",
 		"jest": "^29.3.1",
+		"jest-environment-jsdom": "^29.7.0",
 		"leaflet": "^1.8.0",
 		"mapbox-gl": "^2.13.0",
 		"maplibre-gl": "3.2.0",

--- a/src/adapters/google-maps.adapter.spec.ts
+++ b/src/adapters/google-maps.adapter.spec.ts
@@ -1,6 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TerraDrawAdapterStyling } from "../common";
+import { GeoJSONStoreFeatures } from "../store/store";
+import {
+	createMockLineString,
+	createMockPoint,
+	createMockPolygonSquare,
+} from "../test/mock-features";
+import { getMockPointerEvent } from "../test/mock-pointer-event";
 import { TerraDrawGoogleMapsAdapter } from "./google-maps.adapter";
 
-const createMockGoogleMap = () => {
+const createMockGoogleMap = (overrides?: Partial<google.maps.Map>) => {
 	return {
 		setValues: jest.fn(),
 		unbind: jest.fn(),
@@ -38,10 +49,15 @@ const createMockGoogleMap = () => {
 		setStreetView: jest.fn(),
 		setTilt: jest.fn(),
 		setZoom: jest.fn(),
+		...overrides,
 	} as google.maps.Map;
 };
 
 describe("TerraDrawGoogleMapsAdapter", () => {
+	// Google, of course
+	const testLng = -122.084252077;
+	const testLat = 37.422592266;
+
 	describe("constructor", () => {
 		it("instantiates the adapter correctly", () => {
 			const adapter = new TerraDrawGoogleMapsAdapter({
@@ -64,4 +80,938 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 			expect(adapter.setCursor).toBeDefined();
 		});
 	});
+
+	describe("getContainer", () => {
+		it("returns map div", () => {
+			const div = {} as HTMLDivElement;
+			const mapMock = createMockGoogleMap({
+				getDiv: jest.fn(() => div),
+			});
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(() => undefined),
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(adapter.getMapContainer()).toBe(div);
+		});
+	});
+
+	describe("getLngLatFromEvent", () => {
+		it("returns null for unitialized map", () => {
+			const mapMock = createMockGoogleMap();
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(() => undefined),
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(adapter.getLngLatFromEvent(getMockPointerEvent())).toBeNull();
+			expect(mapMock.getBounds).toHaveBeenCalled();
+		});
+
+		it("returns null when no projection available", () => {
+			const mapMock = createMockGoogleMap({
+				getBounds: jest.fn(
+					() =>
+						({
+							getNorthEast: jest.fn(),
+							getSouthWest: jest.fn(),
+						}) as unknown as google.maps.LatLngBounds,
+				),
+				getDiv: jest.fn(
+					() =>
+						({
+							getBoundingClientRect: jest.fn(() => ({})),
+						}) as unknown as HTMLDivElement,
+				),
+			});
+
+			const getProjectionMock = jest.fn(() => undefined);
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					LatLngBounds: jest.fn(),
+					Point: jest.fn(),
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(adapter.getLngLatFromEvent(getMockPointerEvent())).toBeNull();
+			expect(getProjectionMock).toHaveBeenCalled();
+		});
+
+		it("returns long & lat for click within bounds", () => {
+			const mapMock = createMockGoogleMap({
+				getBounds: jest.fn(
+					() =>
+						({
+							getNorthEast: jest.fn(),
+							getSouthWest: jest.fn(),
+						}) as unknown as google.maps.LatLngBounds,
+				),
+				getDiv: jest.fn(
+					() =>
+						({
+							getBoundingClientRect: jest.fn(() => ({})),
+						}) as unknown as HTMLDivElement,
+				),
+			});
+
+			const getProjectionMock = jest.fn(() => ({
+				fromContainerPixelToLatLng: jest.fn(() => ({
+					lng: () => testLng,
+					lat: () => testLat,
+				})),
+			}));
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					LatLngBounds: jest.fn(() => ({
+						contains: jest.fn(() => true),
+					})),
+					Point: jest.fn(),
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			const lngLatFromEvent = adapter.getLngLatFromEvent(getMockPointerEvent());
+			expect(lngLatFromEvent?.lng).toEqual(testLng);
+			expect(lngLatFromEvent?.lat).toEqual(testLat);
+		});
+	});
+
+	describe("project", () => {
+		it("throws for invalid long & lat", () => {
+			const mapMock = createMockGoogleMap({
+				getBounds: jest.fn(() => undefined),
+			});
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(() => undefined),
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(() => {
+				adapter.project(-1, -2);
+			}).toThrowError();
+
+			expect(mapMock.getBounds).toHaveBeenCalled();
+		});
+
+		it("throws when projection unavailable", () => {
+			const mapMock = createMockGoogleMap();
+			// For now the bounds are just used to determine if within the map (existence only)
+			mapMock.getBounds = jest.fn(() => ({}) as google.maps.LatLngBounds);
+
+			const getProjectionMock = jest.fn();
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(() => {
+				adapter.project(testLng, testLat);
+			}).toThrowError();
+
+			expect(getProjectionMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("throws when coordinates cannot be projected", () => {
+			const mapMock = createMockGoogleMap();
+			// For now the bounds are just used to determine if within the map (existence only)
+			mapMock.getBounds = jest.fn(() => ({}) as google.maps.LatLngBounds);
+
+			const fromLatLngToContainerPixelMock = jest.fn(() => null);
+			const getProjectionMock = jest.fn(() => ({
+				fromLatLngToContainerPixel: fromLatLngToContainerPixelMock,
+			}));
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			expect(() => {
+				adapter.project(testLng, testLat);
+			}).toThrowError();
+
+			expect(getProjectionMock).toHaveBeenCalledTimes(1);
+			expect(fromLatLngToContainerPixelMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("projects valid long & lat", () => {
+			const mapMock = createMockGoogleMap();
+			// For now the bounds are just used to determine if within the map (existence only)
+			mapMock.getBounds = jest.fn(() => ({}) as google.maps.LatLngBounds);
+
+			const getProjectionMock = jest.fn(() => ({
+				fromLatLngToContainerPixel: jest.fn(() => ({
+					x: 50,
+					y: 80,
+				})),
+			}));
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: mapMock,
+			});
+
+			const projected = adapter.project(testLng, testLat);
+
+			expect(getProjectionMock).toHaveBeenCalledTimes(1);
+
+			expect(projected.x).toEqual(50);
+			expect(projected.y).toEqual(80);
+		});
+	});
+
+	describe("unproject", () => {
+		it("throws when projection unavailable", () => {
+			const getProjectionMock = jest.fn(() => undefined);
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+				} as any,
+				map: createMockGoogleMap(),
+			});
+
+			expect(() => {
+				adapter.unproject(-1, -2);
+			}).toThrowError();
+
+			expect(getProjectionMock).toHaveBeenCalled();
+		});
+
+		it("unprojects valid points", () => {
+			const getProjectionMock = jest.fn(() => ({
+				fromContainerPixelToLatLng: jest.fn(() => ({
+					lng: () => testLng,
+					lat: () => testLat,
+				})),
+			}));
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					LatLng: jest.fn(),
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: getProjectionMock,
+					})),
+					Point: jest.fn(),
+				} as any,
+				map: createMockGoogleMap(),
+			});
+
+			const unprojected = adapter.unproject(50, 80);
+			expect(getProjectionMock).toHaveBeenCalledTimes(1);
+
+			expect(unprojected.lng).toEqual(testLng);
+			expect(unprojected.lat).toEqual(testLat);
+		});
+	});
+
+	describe("setCursor", () => {
+		it("is no-op for cursor: unset", () => {
+			const map = createMockGoogleMap() as google.maps.Map;
+			const container = {
+				offsetLeft: 0,
+				offsetTop: 0,
+				style: { removeProperty: jest.fn(), cursor: "initial" },
+			} as any;
+
+			map.getDiv = jest.fn(() => container);
+
+			// Create the adapter instance with the mocked map
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map,
+			});
+
+			adapter.setCursor("unset");
+
+			expect(map.getDiv).not.toHaveBeenCalled();
+			expect(container.style.removeProperty).not.toHaveBeenCalledTimes(1);
+		});
+
+		it("sets to pointer", () => {
+			const elId = "map-container";
+			const map = createMockGoogleMap() as google.maps.Map;
+			const container = {
+				...document.createElement("div"),
+				offsetLeft: 0,
+				offsetTop: 0,
+				id: elId,
+			};
+
+			map.getDiv = jest.fn(() => container);
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map,
+			});
+
+			adapter.setCursor("pointer");
+
+			expect(map.getDiv).toHaveBeenCalledTimes(1);
+			const firstSheetAndRule = document.styleSheets[0]
+				.cssRules[0] as CSSStyleRule;
+			expect(
+				firstSheetAndRule.selectorText.startsWith(`#${elId}`),
+			).toBeTruthy();
+			expect(
+				firstSheetAndRule.cssText.includes(`cursor: pointer`),
+			).toBeTruthy();
+		});
+
+		it("exits early when no update to cursor type", () => {
+			const elId = "map-container";
+			const map = createMockGoogleMap() as google.maps.Map;
+			const container = {
+				...document.createElement("div"),
+				offsetLeft: 0,
+				offsetTop: 0,
+				id: elId,
+			};
+
+			map.getDiv = jest.fn(() => container);
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn().mockImplementation(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map,
+			});
+
+			adapter.setCursor("pointer");
+			adapter.setCursor("pointer");
+			adapter.setCursor("pointer");
+
+			expect(map.getDiv).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("render", () => {
+		it("first invocation registers event listeners", () => {
+			const addListenerMock = jest.fn();
+			const addGeoJsonMock = jest.fn();
+			const mockMap = createMockGoogleMap({
+				data: {
+					addListener: addListenerMock,
+					addGeoJson: addGeoJsonMock,
+					setStyle: jest.fn(),
+				} as any,
+			});
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map: mockMap,
+			});
+
+			adapter.render(
+				{ unchanged: [], created: [], deletedIds: [], updated: [] },
+				mockStyleDraw,
+			);
+
+			expect(addListenerMock).toHaveBeenNthCalledWith(
+				1,
+				"click",
+				expect.any(Function),
+			);
+			expect(addListenerMock).toHaveBeenNthCalledWith(
+				2,
+				"mousemove",
+				expect.any(Function),
+			);
+			expect(addGeoJsonMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					features: [],
+				}),
+			);
+		});
+
+		it("rejects updates to invalid features", () => {
+			const p1 = createMockPoint("point-1") as GeoJSONStoreFeatures;
+			const mockMap = createMockGoogleMap({
+				data: {
+					addListener: () => {},
+					addGeoJson: () => {},
+					remove: () => {},
+					getFeatureById: () => {},
+					setStyle: () => {},
+				} as any,
+			});
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: () => {},
+						getProjection: () => {},
+					})),
+				} as any,
+				map: mockMap,
+			});
+
+			adapter.render(
+				{
+					unchanged: [],
+					created: [p1],
+					deletedIds: [],
+					updated: [],
+				},
+				mockStyleDraw,
+			);
+
+			const p2 = createMockPoint("point-2") as GeoJSONStoreFeatures;
+			p2.id = undefined;
+
+			expect(() => {
+				adapter.render(
+					{
+						unchanged: [p1],
+						created: [],
+						deletedIds: [],
+						updated: [p2],
+					},
+					mockStyleDraw,
+				);
+			}).toThrowError();
+		});
+
+		it("rejects updates to unrecognized/out-of-sync features", () => {
+			const p1 = createMockPoint("point-1") as GeoJSONStoreFeatures;
+			Object.assign(p1, { forEachProperty: () => {} });
+			Object.assign(p1, { setProperty: () => {} });
+			Object.assign(p1, { setGeometry: jest.fn() });
+			const getFeatureByIdMock = jest.fn((featureId: string) =>
+				[p1].find((f) => f.id === featureId),
+			);
+			const mockMap = createMockGoogleMap({
+				data: {
+					addListener: jest.fn(),
+					addGeoJson: () => {},
+					remove: () => {},
+					getFeatureById: getFeatureByIdMock,
+					setStyle: () => {},
+				} as any,
+			});
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+					LatLng: jest.fn(),
+					Data: {
+						Point: jest.fn(),
+					},
+				} as any,
+				map: mockMap,
+			});
+
+			adapter.render(
+				{
+					unchanged: [],
+					created: [p1],
+					deletedIds: [],
+					updated: [],
+				},
+				mockStyleDraw,
+			);
+
+			// Not present in map copy of state, will cause to throw
+			const p2 = createMockPoint("point-2") as GeoJSONStoreFeatures;
+
+			expect(() => {
+				adapter.render(
+					{
+						unchanged: [],
+						created: [],
+						deletedIds: [],
+						updated: [p1, p2],
+					},
+					mockStyleDraw,
+				);
+			}).toThrowError();
+
+			expect(getFeatureByIdMock).toHaveBeenCalledTimes(2);
+		});
+
+		describe("Point", () => {
+			it("adds and deletes features", () => {
+				const p1 = createMockPoint("point-1") as GeoJSONStoreFeatures;
+				const p2 = createMockPoint("point-2", 2, 4) as GeoJSONStoreFeatures;
+
+				verifyAddingAndDeletingFeature(p1, p2);
+			});
+
+			it("applies styles to added feature", () => {
+				const feature = createMockPoint("point-1") as GeoJSONStoreFeatures;
+				Object.assign(feature, {
+					getGeometry: jest.fn(() => ({
+						getType: () => "Point",
+					})),
+				});
+
+				const testStyles: TerraDrawAdapterStyling = {
+					pointColor: "#FF0000",
+					pointOutlineWidth: 5,
+					pointOutlineColor: "#FFFFFF",
+				} as unknown as TerraDrawAdapterStyling;
+
+				const setStyleResult = getStyleAppliedToAddedFeature(
+					feature,
+					testStyles,
+				);
+
+				expect(setStyleResult).toHaveProperty("icon");
+				expect(setStyleResult!.icon.strokeColor).toEqual(
+					testStyles.pointOutlineColor,
+				);
+				expect(setStyleResult!.icon.strokeWeight).toEqual(
+					testStyles.pointOutlineWidth,
+				);
+			});
+
+			it("adds features on successive renders", () => {
+				const p1 = createMockPoint("point-1") as GeoJSONStoreFeatures;
+				verifyAddingFeatureSecondRender(p1);
+			});
+
+			it("updates features on successive renders", () => {
+				const p1 = createMockPoint("point-1") as GeoJSONStoreFeatures;
+				verifyUpdatesFeature(p1);
+			});
+		});
+
+		describe("LineString", () => {
+			it("adds and deletes features", () => {
+				const p1 = createMockLineString(
+					"line-string-1",
+				) as GeoJSONStoreFeatures;
+				const p2 = createMockLineString(
+					"line-string-2",
+				) as GeoJSONStoreFeatures;
+
+				verifyAddingAndDeletingFeature(p1, p2);
+			});
+
+			it("applies styles to added feature", () => {
+				const feature = createMockLineString(
+					"line-string-1",
+				) as GeoJSONStoreFeatures;
+				Object.assign(feature, {
+					getGeometry: jest.fn(() => ({
+						getType: () => "LineString",
+					})),
+				});
+
+				const testStyles: TerraDrawAdapterStyling = {
+					lineStringWidth: 5,
+					lineStringColor: "#FFFFFF",
+				} as unknown as TerraDrawAdapterStyling;
+
+				const setStyleResult = getStyleAppliedToAddedFeature(
+					feature,
+					testStyles,
+				);
+
+				expect(setStyleResult!.strokeColor).toEqual(testStyles.lineStringColor);
+				expect(setStyleResult!.strokeWeight).toEqual(
+					testStyles.lineStringWidth,
+				);
+			});
+
+			it("adds features on successive renders", () => {
+				const p1 = createMockLineString(
+					"line-string-1",
+				) as GeoJSONStoreFeatures;
+				verifyAddingFeatureSecondRender(p1);
+			});
+
+			it("updates features on successive renders", () => {
+				const p1 = createMockLineString(
+					"line-string-1",
+				) as GeoJSONStoreFeatures;
+				verifyUpdatesFeature(p1);
+			});
+		});
+
+		describe("Polygon", () => {
+			it("adds and deletes features", () => {
+				const sq1 = createMockPolygonSquare("square-1") as GeoJSONStoreFeatures;
+				const sq2 = createMockPolygonSquare(
+					"square-2",
+					2,
+					4,
+				) as GeoJSONStoreFeatures;
+
+				verifyAddingAndDeletingFeature(sq1, sq2);
+			});
+
+			it("applies styles to added feature", () => {
+				const feature = createMockPolygonSquare(
+					"square-1",
+				) as GeoJSONStoreFeatures;
+				Object.assign(feature, {
+					getGeometry: jest.fn(() => ({
+						getType: () => "Polygon",
+					})),
+				});
+
+				const testStyles: TerraDrawAdapterStyling = {
+					polygonOutlineWidth: 5,
+					polygonOutlineColor: "#FFFFFF",
+				} as unknown as TerraDrawAdapterStyling;
+
+				const setStyleResult = getStyleAppliedToAddedFeature(
+					feature,
+					testStyles,
+				);
+
+				expect(setStyleResult!.strokeColor).toEqual(
+					testStyles.polygonOutlineColor,
+				);
+				expect(setStyleResult!.strokeWeight).toEqual(
+					testStyles.polygonOutlineWidth,
+				);
+			});
+
+			it("adds features on successive renders", () => {
+				const sq1 = createMockPolygonSquare("square-1") as GeoJSONStoreFeatures;
+				verifyAddingFeatureSecondRender(sq1);
+			});
+
+			it("updates features on successive renders", () => {
+				const sq1 = createMockPolygonSquare("square-1") as GeoJSONStoreFeatures;
+				verifyUpdatesFeature(sq1);
+			});
+		});
+	});
+
+	describe("clear", () => {
+		it("is safe to call without features", () => {
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map: createMockGoogleMap(),
+			});
+
+			adapter.clear();
+		});
+	});
 });
+
+const mockStyleDraw = {
+	test: jest.fn(() => ({}) as any),
+};
+
+const verifyAddingAndDeletingFeature = (
+	feature1: GeoJSONStoreFeatures,
+	feature2: GeoJSONStoreFeatures,
+) => {
+	const addGeoJsonMock = jest.fn();
+	const removeMock = jest.fn();
+	const mockMap = createMockGoogleMap({
+		data: {
+			addListener: jest.fn(),
+			addGeoJson: addGeoJsonMock,
+			remove: removeMock,
+			getFeatureById: (featureId: string) =>
+				[feature1, feature2].find((s) => s.id === featureId),
+			setStyle: jest.fn(),
+		} as any,
+	});
+	const adapter = new TerraDrawGoogleMapsAdapter({
+		lib: {
+			OverlayView: jest.fn(() => ({
+				setMap: jest.fn(),
+				getProjection: jest.fn(),
+			})),
+		} as any,
+		map: mockMap,
+	});
+
+	adapter.render(
+		{
+			unchanged: [],
+			created: [feature1, feature2],
+			deletedIds: [],
+			updated: [],
+		},
+		mockStyleDraw,
+	);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [
+				expect.objectContaining({
+					id: feature1.id,
+				}),
+				expect.objectContaining({
+					id: feature2.id,
+				}),
+			],
+		}),
+	);
+
+	adapter.render(
+		{
+			unchanged: [feature1],
+			created: [],
+			deletedIds: [feature2.id!.toString()],
+			updated: [],
+		},
+		mockStyleDraw,
+	);
+
+	expect(removeMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			id: feature2.id,
+		}),
+	);
+};
+
+const getStyleAppliedToAddedFeature = (
+	feature: GeoJSONStoreFeatures,
+	testStyles: TerraDrawAdapterStyling,
+): any => {
+	// looks up mode
+	Object.assign(feature, { getProperty: () => "test" });
+	Object.assign(feature, { forEachProperty: () => {} });
+
+	const addGeoJsonMock = jest.fn();
+	let setStyleResult;
+	const setStyleMock = jest.fn((cb) => {
+		setStyleResult = cb(feature);
+	});
+	const mockMap = createMockGoogleMap({
+		data: {
+			addListener: () => {},
+			addGeoJson: addGeoJsonMock,
+			remove: () => {},
+			getFeatureById: (featureId: string) =>
+				[feature].find((s) => s.id === featureId),
+			setStyle: setStyleMock,
+		} as any,
+	});
+	const adapter = new TerraDrawGoogleMapsAdapter({
+		lib: {
+			OverlayView: jest.fn(() => ({
+				setMap: jest.fn(),
+				getProjection: jest.fn(),
+			})),
+		} as any,
+		map: mockMap,
+	});
+
+	adapter.render(
+		{
+			unchanged: [],
+			created: [feature],
+			deletedIds: [],
+			updated: [],
+		},
+		{
+			test: () => testStyles,
+		},
+	);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [
+				expect.objectContaining({
+					id: feature.id,
+				}),
+			],
+		}),
+	);
+
+	return setStyleResult;
+};
+
+const verifyAddingFeatureSecondRender = (feature: GeoJSONStoreFeatures) => {
+	const addGeoJsonMock = jest.fn();
+	const removeMock = jest.fn();
+	const mockMap = createMockGoogleMap({
+		data: {
+			addListener: jest.fn(),
+			addGeoJson: addGeoJsonMock,
+			remove: removeMock,
+			getFeatureById: jest.fn(),
+			setStyle: jest.fn(),
+		} as any,
+	});
+	const adapter = new TerraDrawGoogleMapsAdapter({
+		lib: {
+			OverlayView: jest.fn(() => ({
+				setMap: jest.fn(),
+				getProjection: jest.fn(),
+			})),
+		} as any,
+		map: mockMap,
+	});
+
+	adapter.render(
+		{ unchanged: [], created: [], deletedIds: [], updated: [] },
+		mockStyleDraw,
+	);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [],
+		}),
+	);
+
+	adapter.render(
+		{
+			unchanged: [],
+			created: [feature],
+			deletedIds: [],
+			updated: [],
+		},
+		mockStyleDraw,
+	);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [expect.objectContaining({ id: feature.id })],
+		}),
+	);
+};
+
+function verifyUpdatesFeature(feature: GeoJSONStoreFeatures) {
+	const addGeoJsonMock = jest.fn();
+	const dummyProp = "dummy";
+	const forEachPropertyMock = jest.fn((cb) => {
+		cb("propValue", dummyProp);
+	});
+	const setPropertyMock = jest.fn();
+	Object.assign(feature, { forEachProperty: forEachPropertyMock });
+	Object.assign(feature, { setProperty: setPropertyMock });
+	Object.assign(feature, { setGeometry: jest.fn() });
+
+	const mockMap = createMockGoogleMap({
+		data: {
+			addListener: jest.fn(),
+			addGeoJson: addGeoJsonMock,
+			remove: () => {},
+			getFeatureById: (featureId: string) =>
+				[feature].find((s) => s.id === featureId),
+			setStyle: jest.fn(),
+		} as any,
+	});
+	const adapter = new TerraDrawGoogleMapsAdapter({
+		lib: {
+			OverlayView: jest.fn(() => ({
+				setMap: jest.fn(),
+				getProjection: jest.fn(),
+			})),
+			LatLng: jest.fn(),
+			Data: {
+				LineString: jest.fn(),
+				Polygon: jest.fn(),
+				Point: jest.fn(),
+			},
+		} as any,
+		map: mockMap,
+	});
+
+	adapter.render(
+		{ unchanged: [], created: [feature], deletedIds: [], updated: [] },
+		mockStyleDraw,
+	);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [expect.objectContaining({ id: feature.id })],
+		}),
+	);
+
+	adapter.render(
+		{
+			unchanged: [],
+			created: [],
+			deletedIds: [],
+			updated: [feature],
+		},
+		mockStyleDraw,
+	);
+
+	expect(setPropertyMock).toHaveBeenCalledWith(dummyProp, undefined);
+
+	expect(addGeoJsonMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			features: [expect.objectContaining({ id: feature.id })],
+		}),
+	);
+}

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -59,12 +59,12 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 
 		const ne = bounds.getNorthEast();
 		const sw = bounds.getSouthWest();
-		const latLngBounds = new google.maps.LatLngBounds(sw, ne);
+		const latLngBounds = new this._lib.LatLngBounds(sw, ne);
 
 		const mapCanvas = this._map.getDiv();
 		const offsetX = event.clientX - mapCanvas.getBoundingClientRect().left;
 		const offsetY = event.clientY - mapCanvas.getBoundingClientRect().top;
-		const screenCoord = new google.maps.Point(offsetX, offsetY);
+		const screenCoord = new this._lib.Point(offsetX, offsetY);
 
 		const projection = this._overlay.getProjection();
 
@@ -108,7 +108,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 		}
 
 		const point = projection.fromLatLngToContainerPixel(
-			new google.maps.LatLng(lat, lng),
+			new this._lib.LatLng(lat, lng),
 		);
 
 		if (point === null) {
@@ -131,7 +131,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 		}
 
 		const latLng = projection.fromContainerPixelToLatLng(
-			new google.maps.Point(x, y),
+			new this._lib.Point(x, y),
 		);
 
 		if (latLng === null) {
@@ -239,8 +239,8 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 							const coordinates = updatedFeature.geometry.coordinates;
 
 							featureToUpdate.setGeometry(
-								new google.maps.Data.Point(
-									new google.maps.LatLng(coordinates[1], coordinates[0]),
+								new this._lib.Data.Point(
+									new this._lib.LatLng(coordinates[1], coordinates[0]),
 								),
 							);
 						}
@@ -252,16 +252,14 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 							const path = [];
 							for (let i = 0; i < coordinates.length; i++) {
 								const coordinate = coordinates[i];
-								const latLng = new google.maps.LatLng(
+								const latLng = new this._lib.LatLng(
 									coordinate[1],
 									coordinate[0],
 								);
 								path.push(latLng);
 							}
 
-							featureToUpdate.setGeometry(
-								new google.maps.Data.LineString(path),
-							);
+							featureToUpdate.setGeometry(new this._lib.Data.LineString(path));
 						}
 						break;
 					case "Polygon":
@@ -272,7 +270,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 							for (let i = 0; i < coordinates.length; i++) {
 								const path = [];
 								for (let j = 0; j < coordinates[i].length; j++) {
-									const latLng = new google.maps.LatLng(
+									const latLng = new this._lib.LatLng(
 										coordinates[i][j][1],
 										coordinates[i][j][0],
 									);
@@ -281,7 +279,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 								paths.push(path);
 							}
 
-							featureToUpdate.setGeometry(new google.maps.Data.Polygon(paths));
+							featureToUpdate.setGeometry(new this._lib.Data.Polygon(paths));
 						}
 
 						break;


### PR DESCRIPTION
# Improve Test coverage of Google Maps Adapter

Add more tests for the Google Maps adapter. With these changes, coverage by statements and by lines are now just over 80% for the Google Maps adapter.

Closes #88 

## Details

Note that these changes add [JSDOM](https://github.com/jsdom/jsdom) to enable DOM emulation for the tests. This was the [simplest](https://github.com/JamesLMilner/terra-draw/issues/88#issuecomment-1745749984) way to get the tests up and running for this adapter. For now I've only enabled the JSDOM environment for the Google Maps adapter (via the `@jest-environment` [directive in the docblock](https://jestjs.io/docs/configuration#testenvironmentoptions-object) ), so the environment remains the same (still [`node`](https://github.com/JamesLMilner/terra-draw/blob/main/jest.config.ts#L14)) for the other modules.

In addition to JSDOM, I also considered [Happy DOM](https://github.com/capricorn86/happy-dom), which worked just fine on a functional level, but wasn't consistently faster during casual testing (no real performance testing done).<sup>1</sup> Nonetheless, it wouldn't be hard to add it later on - just install the `@happy-dom/jest-environment` package, and specify it as the `@jest-environment` at the top of the file) 


## Verification

The changes themselves are either tests, or minor refactorings to make the library code more testable, and all tests are passing.

Beyond that, I set up a Google Maps API key, added it to the local `.env` file, and briefly clicked through the Terra Draw Google Maps instance locally. I was able to add & remove shapes and anotations without errors:   
![image](https://github.com/JamesLMilner/terra-draw/assets/2937540/8f0936f0-1255-40e1-84bd-aa86a76178e8)



<sup>1</sup> - _Casual observation demonstrated similarly large variance with both JSDOM and Happy DOM, likely more tied to the number of background processes that happened to be running on my development machine than anything else._