### PR TITLE
refactor: move Adapter event listener init and small convention improvements

### DIFF
--- a/src/test/mock-callbacks.ts
+++ b/src/test/mock-callbacks.ts
@@ -1,0 +1,16 @@
+import { TerraDrawCallbacks } from "../common";
+
+export const createMockCallbacks = (
+	overrides?: Partial<TerraDrawCallbacks>,
+): TerraDrawCallbacks => ({
+	getState: jest.fn(),
+	onKeyUp: jest.fn(),
+	onKeyDown: jest.fn(),
+	onClick: jest.fn(),
+	onMouseMove: jest.fn(),
+	onDragStart: jest.fn(),
+	onDrag: jest.fn(),
+	onDragEnd: jest.fn(),
+	onClear: jest.fn(),
+	...overrides,
+});


### PR DESCRIPTION
This PR proposes a few smaller changes to internal organization and conventions used in the Google Maps Adapter.

The main changes, which split out set up of the event listeners to their own method, invoked in the constructor, come from [this previous comment](https://github.com/JamesLMilner/terra-draw/pull/98#discussion_r1359947432).

The other two are some small things that occurred to me while writing the tests:
- The internal property for tracking what was rendered was tracking the Feature IDs, but was named `renderedFeatures`. This briefly lead to confusion when comparing it to [`TerraDrawChanges`](https://github.com/JamesLMilner/terra-draw/blob/main/src/common.ts#L117), which uses [`deletedIds`](https://github.com/JamesLMilner/terra-draw/blob/main/src/common.ts#L121) to indicate the deleted features are only referenced by ID.
- `_layers` looked like it was a effectively a calculated property, but was being set manually. I just changed this to be 'automatic'

Caveat: as these changes delete several lines of covered code, coverage by line drops slightly below 80%

The first change is the only one discussed previously, but I thought it would be easiest to demo these and get feedback, also that they were related enough to warrant grouping (minor refactors). Each change is initially provided as a separate commit, which should allow some flexibility in which to accept, or possibly splitting to other PRs, if desired.

## Verification:

Verified that I can add & edit objects to the Google Maps editor. Also that I could register click & mousemove handlers