### PR TITLE
refactor: use Google Maps API methods for draggability cursor styles and settings

### DIFF
--- a/src/adapters/google-maps.adapter.spec.ts
+++ b/src/adapters/google-maps.adapter.spec.ts
@@ -492,21 +492,12 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 			expect(container.style.removeProperty).not.toHaveBeenCalledTimes(1);
 		});
 
-		it("sets to pointer", () => {
-			const elId = "map-container";
+		it("uses API method for setting cursor", () => {
 			const map = createMockGoogleMap() as google.maps.Map;
-			const container = {
-				...document.createElement("div"),
-				offsetLeft: 0,
-				offsetTop: 0,
-				id: elId,
-			};
-
-			map.getDiv = jest.fn(() => container);
 
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
-					OverlayView: jest.fn().mockImplementation(() => ({
+					OverlayView: jest.fn(() => ({
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
@@ -514,41 +505,17 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				map,
 			});
 
-			const mockQuerySelector = jest.spyOn(document, "querySelector");
-
-			mockQuerySelector.mockImplementationOnce(
-				() => ({ ariaLabel: "Map" }) as Element,
-			);
-
 			adapter.setCursor("pointer");
 
-			expect(map.getDiv).toHaveBeenCalledTimes(1);
-
-			const firstSheetAndRule = document.styleSheets[0]
-				.cssRules[0] as CSSStyleRule;
-			expect(
-				firstSheetAndRule.selectorText.startsWith(`#${elId}`),
-			).toBeTruthy();
-			expect(
-				firstSheetAndRule.cssText.includes(`cursor: pointer`),
-			).toBeTruthy();
+			expect(map.setOptions).toHaveBeenCalledTimes(1);
 		});
 
 		it("exits early when no update to cursor type", () => {
-			const elId = "map-container";
 			const map = createMockGoogleMap() as google.maps.Map;
-			const container = {
-				...document.createElement("div"),
-				offsetLeft: 0,
-				offsetTop: 0,
-				id: elId,
-			};
-
-			map.getDiv = jest.fn(() => container);
 
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
-					OverlayView: jest.fn().mockImplementation(() => ({
+					OverlayView: jest.fn(() => ({
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
@@ -560,7 +527,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 			adapter.setCursor("pointer");
 			adapter.setCursor("pointer");
 
-			expect(map.getDiv).toHaveBeenCalledTimes(1);
+			expect(map.setOptions).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -27,7 +27,6 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 	}
 
 	private _cursor: string | undefined;
-	private _cursorStyleSheet: HTMLStyleElement | undefined;
 	private _lib: typeof google.maps;
 	private _map: google.maps.Map;
 	private _overlay: google.maps.OverlayView;
@@ -201,26 +200,11 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 			return;
 		}
 
-		if (this._cursorStyleSheet) {
-			this._cursorStyleSheet.remove();
-			this._cursorStyleSheet = undefined;
-		}
-
-		if (cursor !== "unset") {
-			// TODO: We could cache these individually per cursor
-
-			const div = this.getMapContainer();
-			const mapSelector = `#${div.id} div[aria-label]`;
-			const map = document.querySelector(mapSelector);
-
-			if (map) {
-				const style = document.createElement("style");
-				const selector = `#${div.id} div[aria-label="${map.ariaLabel}"]`;
-				style.innerHTML = `${selector} { cursor: ${cursor} !important; }`;
-				document.getElementsByTagName("head")[0].appendChild(style);
-				this._cursorStyleSheet = style;
-			}
-		}
+		// Restore to the (Google-provided) defaults, when "unset" received
+		this._map.setOptions({
+			draggableCursor: cursor !== "unset" ? cursor : undefined,
+			draggingCursor: cursor !== "unset" ? cursor : undefined,
+		});
 
 		this._cursor = cursor;
 	}
@@ -242,7 +226,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 	 * @param enabled Set to true to enable map dragging, or false to disable it.
 	 */
 	setDraggability(enabled: boolean) {
-		this._map.setOptions({ draggable: enabled });
+		this._map.setOptions({ gestureHandling: enabled ? "auto" : "none" });
 	}
 
 	private renderedFeatureIds: Set<string> = new Set();


### PR DESCRIPTION
A couple changes to use `setOptions`, provided by Google Maps API, for configuring draggability cursor styles and settings.

## Details

The first change is to address #111. After trying to style the element directly (like in the [ArcGIS adapter](https://github.com/JamesLMilner/terra-draw/blob/main/src/adapters/arcgis-maps-sdk.adapter.ts#L119)), I quickly realized that that method doesn't work: While the style attribute is correctly set on the element (it was visible in Dev Tools), it is overridden by the style that Google Maps provides by default. After some digging, I found that there was [a way of doing this](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.draggableCursor) via `setOptions`, which I have implemented here.

Note that the API has its own modality for the cursor styling (_draggable_ and _dragging_). Both have been set to the value provided to the method, as Terra Draw provides its own modes (and the functionality matches what was happening before).

Lastly, replace a [deprecated option](https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.draggable) with its supported equivalent - I happened to realize that this method was deprecated while looking through the documentation for the cursor styling options (they are next to each other in the documentation)

## Verification

I used the dev server to verify that cursor styling is applied, and that the dragging functionality works as expected. That should verify the initial change directly. I'm not sure if there is more that needs to be done to verify the second change? I only found it used in the base adapter.