### PR TITLE
fix: only add sources and layers if they don't exist in existing style for maplibre (mapbox) adapter

### DIFF
--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -50,6 +50,7 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 	}
 
 	private _addGeoJSONSource(id: string, features: Feature[]) {
+		if (this._map.getSource(id)) return;
 		this._map.addSource(id, {
 			type: "geojson",
 			data: {
@@ -135,6 +136,7 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 		featureType: "Point" | "LineString" | "Polygon",
 		beneath?: string,
 	) {
+		if (this._map.getLayer(id)) return;
 		if (featureType === "Point") {
 			this._addPointLayer(id, beneath);
 		}


### PR DESCRIPTION
fixes #116 

I added if statement to check if the source and layer already exist and only add them if they are not in style.