### PR TITLE
fix: add TerraDrawArcGISMapsSDKAdapter to terra-draw exports

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -17,6 +17,7 @@ import {
 	TerraDrawGoogleMapsAdapter,
 	TerraDrawMapLibreGLAdapter,
 	TerraDrawGreatCircleMode,
+	TerraDrawArcGISMapsSDKAdapter,
 } from "../../src/terra-draw";
 import { TerraDrawRenderMode } from "../../src/modes/render/render.mode";
 
@@ -32,7 +33,6 @@ import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
 import { fromLonLat, toLonLat } from "ol/proj";
 import EsriMap from "@arcgis/core/Map";
 import MapView from "@arcgis/core/views/MapView.js";
-import { TerraDrawArcGISMapsSDKAdapter } from "../../src/adapters/arcgis-maps-sdk.adapter";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -3,6 +3,7 @@ import { TerraDrawLeafletAdapter } from "./adapters/leaflet.adapter";
 import { TerraDrawMapboxGLAdapter } from "./adapters/mapbox-gl.adapter";
 import { TerraDrawMapLibreGLAdapter } from "./adapters/maplibre-gl.adapter";
 import { TerraDrawOpenLayersAdapter } from "./adapters/openlayers.adapter";
+import { TerraDrawArcGISMapsSDKAdapter } from "./adapters/arcgis-maps-sdk.adapter";
 import {
 	TerraDrawAdapter,
 	TerraDrawAdapterStyling,
@@ -700,6 +701,7 @@ export {
 	TerraDrawLeafletAdapter,
 	TerraDrawMapLibreGLAdapter,
 	TerraDrawOpenLayersAdapter,
+	TerraDrawArcGISMapsSDKAdapter,
 	TerraDrawExtend,
 
 	// Types that are required for 3rd party developers to extend


### PR DESCRIPTION
The Esri ArcGIS Maps SDK adapter added in #58 is not exported. This PR adds the export and updates the development/ app to import from there.