### PR TITLE
fix: listen for google maps key events on document, not map container

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -351,12 +351,10 @@ export abstract class TerraDrawBaseAdapter {
 					});
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
-					mapElement.addEventListener("keyup", callback);
+					document.addEventListener("keyup", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
-					mapElement.removeEventListener("keyup", callback);
+					document.removeEventListener("keyup", callback);
 				},
 			}),
 			new AdapterListener({
@@ -375,12 +373,10 @@ export abstract class TerraDrawBaseAdapter {
 					});
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
-					mapElement.addEventListener("keydown", callback);
+					document.addEventListener("keydown", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
-					mapElement.removeEventListener("keydown", callback);
+					document.removeEventListener("keydown", callback);
 				},
 			}),
 		];


### PR DESCRIPTION
Proposed fix for #129.

Google Maps was not picking up keyboard events ("keyup"/"keydown"). This change listens for keyboard events on the entire document, instead of the map container.

This means keyboard deletion is now working for Google Maps.

The only unintended consequence that I can think of is if there are multiple Terra Draw instances, both would respond to these events.

For example, in the `development/` app if you have a Feature selected in Google Maps and then switch to another Map and select/delete a feature it will also pick up the keyboard event and delete it from the GM map also.