### PR TITLE
fix: ensure keyboard events are capture for the Google Maps API

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -57,7 +57,9 @@ export abstract class TerraDrawBaseAdapter {
 		"not-dragging";
 	protected _currentModeCallbacks: TerraDrawCallbacks | undefined;
 
-	protected abstract getMapEventElement(): HTMLElement;
+	protected abstract getMapEventElement(
+		type?: "keyboard" | "pointer",
+	): HTMLElement;
 
 	protected getButton(event: PointerEvent | MouseEvent) {
 		if (event.button === -1) {
@@ -351,11 +353,11 @@ export abstract class TerraDrawBaseAdapter {
 					});
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keyboard");
 					mapElement.addEventListener("keyup", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keyboard");
 					mapElement.removeEventListener("keyup", callback);
 				},
 			}),

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -136,7 +136,13 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 	 * Retrieves the HTML element of the Google Map element that handles interaction events
 	 * @returns The HTMLElement representing the map container.
 	 */
-	public getMapEventElement() {
+	public getMapEventElement(type?: "keyboard" | "pointer") {
+		if (type === "keyboard") {
+			// Google Maps for some reason seems to swallow all keyboard events
+			// and sets the focused element to document.body
+			return document.body;
+		}
+
 		// TODO: This is a bit hacky, maybe there is a better solution here
 		const selector = 'div[style*="z-index: 3;"]';
 		return this._map.getDiv().querySelector(selector) as HTMLDivElement;


### PR DESCRIPTION
This PR aims to resolve #129 

It makes getMapEventElement take an argument so we can apply different types of events handlers to different elements if required. 

Here we apply the keyboard handler to the document which seems odd but this does seems to be the default focus when you select the Google Map, so perhaps not so odd.

Should allow keyboard events to work for Google Maps again.