### PR TITLE
Better Typing for TerraDrawModes & Setting coordinatePrecision of modes inside of a TerraDraw to the respective Adapter

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -124,6 +124,15 @@ export abstract class TerraDrawBaseAdapter {
 		});
 	}
 
+	/**
+	 * Gets the coordinate precision.
+	 * @returns {number} The coordinate precision.
+	 * @description The coordinate precision is the number of decimal places. Note that the precision will be overriden by the precision of the TerraDraw Adapter.
+	 */
+	public getCoordinatePrecision() {
+		return this._coordinatePrecision;
+	}
+
 	private getAdapterListeners() {
 		return [
 			new AdapterListener<BasePointerListener>({

--- a/src/common.ts
+++ b/src/common.ts
@@ -136,6 +136,7 @@ export interface TerraDrawAdapter {
 	unregister(): void;
 	render(changes: TerraDrawChanges, styling: TerraDrawStylingFunction): void;
 	clear(): void;
+	getCoordinatePrecision(): number;
 }
 
 export const SELECT_PROPERTIES = {

--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -16,7 +16,7 @@ import {
 } from "../store/store";
 import { isValidStoreFeature } from "../store/store-feature-validation";
 
-type CustomStyling = Record<
+export type CustomStyling = Record<
 	string,
 	| string
 	| number
@@ -30,6 +30,13 @@ export enum ModeTypes {
 	Static = "static",
 	Render = "render",
 }
+
+export type BaseModeOptions<T extends CustomStyling> = {
+	styles?: Partial<T>;
+	pointerDistance?: number;
+	coordinatePrecision?: number;
+};
+
 export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 	protected _state: TerraDrawModeState;
 	get state() {
@@ -63,11 +70,7 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 	protected setCursor!: TerraDrawModeRegisterConfig["setCursor"];
 	protected registerBehaviors(behaviorConfig: BehaviorConfig): void {}
 
-	constructor(options?: {
-		styles?: Partial<T>;
-		pointerDistance?: number;
-		coordinatePrecision?: number;
-	}) {
+	constructor(options?: BaseModeOptions<T>) {
 		this._state = "unregistered";
 		this._styles =
 			options && options.styles ? { ...options.styles } : ({} as Partial<T>);
@@ -195,5 +198,14 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 		} else {
 			return value;
 		}
+	}
+
+	/**
+	 * Sets the coordinate precision for the mode.
+	 *
+	 * @param {number} coordinatePrecision The precision value for the coordinates.
+	 */
+	public setCoordinatePrecision(coordinatePrecision: number) {
+		this.coordinatePrecision = coordinatePrecision;
 	}
 }

--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -11,7 +11,11 @@ import { haversineDistanceKilometers } from "../../geometry/measure/haversine-di
 import { circle } from "../../geometry/shape/create-circle";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { isValidNonIntersectingPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
 
 type TerraDrawCircleModeKeyEvents = {
@@ -30,6 +34,12 @@ interface Cursors {
 	start?: Cursor;
 }
 
+interface TerraDrawCircleModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	keyEvents?: TerraDrawCircleModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyling> {
 	mode = "circle";
 	private center: Position | undefined;
@@ -38,11 +48,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	private keyEvents: TerraDrawCircleModeKeyEvents;
 	private cursors: Required<Cursors>;
 
-	constructor(options?: {
-		styles?: Partial<CirclePolygonStyling>;
-		keyEvents?: TerraDrawCircleModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawCircleModeOptions<CirclePolygonStyling>) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -8,7 +8,11 @@ import {
 } from "../../common";
 import { Polygon } from "geojson";
 
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { getDefaultStyling } from "../../util/styling";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { pixelDistance } from "../../geometry/measure/pixel-distance";
@@ -35,6 +39,14 @@ interface Cursors {
 	close?: Cursor;
 }
 
+interface TerraDrawFreehandModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	minDistance?: number;
+	preventPointsNearClose?: boolean;
+	keyEvents?: TerraDrawFreehandModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygonStyling> {
 	mode = "freehand";
 
@@ -46,13 +58,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	private cursors: Required<Cursors>;
 	private preventPointsNearClose: boolean;
 
-	constructor(options?: {
-		styles?: Partial<FreehandPolygonStyling>;
-		minDistance?: number;
-		preventPointsNearClose?: boolean;
-		keyEvents?: TerraDrawFreehandModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawFreehandModeOptions<FreehandPolygonStyling>) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/greatcircle/great-circle.mode.ts
+++ b/src/modes/greatcircle/great-circle.mode.ts
@@ -7,7 +7,11 @@ import {
 	Cursor,
 } from "../../common";
 import { LineString } from "geojson";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { BehaviorConfig } from "../base.behavior";
 import { getDefaultStyling } from "../../util/styling";
 import { GeoJSONStoreFeatures } from "../../store/store";
@@ -35,6 +39,14 @@ interface Cursors {
 	close?: Cursor;
 }
 
+interface TerraDrawGreatCircleModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	snapping?: boolean;
+	pointerDistance?: number;
+	keyEvents?: TerraDrawGreateCircleModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircleStyling> {
 	mode = "greatcircle";
 
@@ -48,13 +60,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	// Behaviors
 	private snapping!: GreatCircleSnappingBehavior;
 
-	constructor(options?: {
-		snapping?: boolean;
-		pointerDistance?: number;
-		styles?: Partial<GreateCircleStyling>;
-		keyEvents?: TerraDrawGreateCircleModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawGreatCircleModeOptions<GreateCircleStyling>) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -8,7 +8,11 @@ import {
 } from "../../common";
 import { LineString } from "geojson";
 import { selfIntersects } from "../../geometry/boolean/self-intersects";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { pixelDistance } from "../../geometry/measure/pixel-distance";
 import { BehaviorConfig } from "../base.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
@@ -36,6 +40,15 @@ interface Cursors {
 	close?: Cursor;
 }
 
+interface TerraDrawLineStringModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	snapping?: boolean;
+	allowSelfIntersections?: boolean;
+	pointerDistance?: number;
+	keyEvents?: TerraDrawLineStringModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringStyling> {
 	mode = "linestring";
 
@@ -51,14 +64,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	// Behaviors
 	private snapping!: SnappingBehavior;
 
-	constructor(options?: {
-		snapping?: boolean;
-		allowSelfIntersections?: boolean;
-		pointerDistance?: number;
-		styles?: Partial<LineStringStyling>;
-		keyEvents?: TerraDrawLineStringModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawLineStringModeOptions<LineStringStyling>) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/point/point.mode.ts
+++ b/src/modes/point/point.mode.ts
@@ -7,7 +7,11 @@ import {
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { isValidPoint } from "../../geometry/boolean/is-valid-point";
 
 type PointModeStyling = {
@@ -21,15 +25,17 @@ interface Cursors {
 	create?: Cursor;
 }
 
+interface TerraDrawPointModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	cursors?: Cursors;
+}
+
 export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> {
 	mode = "point";
 
 	private cursors: Required<Cursors>;
 
-	constructor(options?: {
-		styles?: Partial<PointModeStyling>;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawPointModeOptions<PointModeStyling>) {
 		super(options);
 		const defaultCursors = {
 			create: "crosshair",

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -8,7 +8,11 @@ import {
 } from "../../common";
 import { Polygon } from "geojson";
 import { selfIntersects } from "../../geometry/boolean/self-intersects";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	TerraDrawBaseDrawMode,
+	BaseModeOptions,
+	CustomStyling,
+} from "../base.mode";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { BehaviorConfig } from "../base.behavior";
@@ -41,6 +45,15 @@ interface Cursors {
 	close?: Cursor;
 }
 
+interface TerraDrawPolygonModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	allowSelfIntersections?: boolean;
+	snapping?: boolean;
+	pointerDistance?: number;
+	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> {
 	mode = "polygon";
 
@@ -57,14 +70,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private cursors: Required<Cursors>;
 	private mouseMove = false;
 
-	constructor(options?: {
-		allowSelfIntersections?: boolean;
-		snapping?: boolean;
-		pointerDistance?: number;
-		styles?: Partial<PolygonStyling>;
-		keyEvents?: TerraDrawPolygonModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawPolygonModeOptions<PolygonStyling>) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -9,7 +9,11 @@ import {
 } from "../../common";
 import { GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
-import { TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { isValidNonIntersectingPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
 
 type TerraDrawRectangleModeKeyEvents = {
@@ -28,6 +32,12 @@ interface Cursors {
 	start?: Cursor;
 }
 
+interface TerraDrawRectangleModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	keyEvents?: TerraDrawRectangleModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
 export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolygonStyling> {
 	mode = "rectangle";
 	private center: Position | undefined;
@@ -36,11 +46,9 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	private keyEvents: TerraDrawRectangleModeKeyEvents;
 	private cursors: Required<Cursors>;
 
-	constructor(options?: {
-		styles?: Partial<RectanglePolygonStyling>;
-		keyEvents?: TerraDrawRectangleModeKeyEvents | null;
-		cursors?: Cursors;
-	}) {
+	constructor(
+		options?: TerraDrawRectangleModeOptions<RectanglePolygonStyling>,
+	) {
 		super(options);
 
 		const defaultCursors = {

--- a/src/modes/render/render.mode.ts
+++ b/src/modes/render/render.mode.ts
@@ -3,7 +3,12 @@ import {
 	NumericStyling,
 	TerraDrawAdapterStyling,
 } from "../../common";
-import { ModeTypes, TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	ModeTypes,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { BehaviorConfig } from "../base.behavior";
 import { getDefaultStyling } from "../../util/styling";
 import { GeoJSONStoreFeatures } from "../../terra-draw";
@@ -25,14 +30,18 @@ type RenderModeStyling = {
 	zIndex: NumericStyling;
 };
 
+interface TerraDrawRenderModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	modeName: string;
+	// styles need to be there else we could fall back to BaseModeOptions
+	styles: Partial<T>;
+}
+
 export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling> {
 	public type = ModeTypes.Render; // The type of the mode
 	public mode = "render"; // This gets changed dynamically
 
-	constructor(options: {
-		modeName: string;
-		styles: Partial<RenderModeStyling>;
-	}) {
+	constructor(options: TerraDrawRenderModeOptions<RenderModeStyling>) {
 		super({ styles: options.styles });
 		this.mode = options.modeName;
 	}

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -8,7 +8,12 @@ import {
 	Cursor,
 } from "../../common";
 import { Point, Position } from "geojson";
-import { ModeTypes, TerraDrawBaseDrawMode } from "../base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	ModeTypes,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
 import { MidPointBehavior } from "./behaviors/midpoint.behavior";
 import { SelectionPointBehavior } from "./behaviors/selection-point.behavior";
 import { FeatureAtPointerEventBehavior } from "./behaviors/feature-at-pointer-event.behavior";
@@ -80,6 +85,15 @@ interface Cursors {
 	insertMidpoint?: Cursor;
 }
 
+interface TerraDrawSelectModeOptions<T extends CustomStyling>
+	extends BaseModeOptions<T> {
+	pointerDistance?: number;
+	flags?: { [mode: string]: ModeFlags };
+	keyEvents?: TerraDrawSelectModeKeyEvents | null;
+	dragEventThrottle?: number;
+	cursors?: Cursors;
+}
+
 export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling> {
 	public type = ModeTypes.Select;
 	public mode = "select";
@@ -103,14 +117,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 	private scaleFeature!: ScaleFeatureBehavior;
 	private cursors: Required<Cursors>;
 
-	constructor(options?: {
-		styles?: Partial<SelectionStyling>;
-		pointerDistance?: number;
-		flags?: { [mode: string]: ModeFlags };
-		keyEvents?: TerraDrawSelectModeKeyEvents | null;
-		dragEventThrottle?: number;
-		cursors?: Cursors;
-	}) {
+	constructor(options?: TerraDrawSelectModeOptions<SelectionStyling>) {
 		super(options);
 
 		this.flags = options && options.flags ? options.flags : {};

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -78,25 +78,29 @@ class TerraDraw {
 		modes: TerraDrawBaseDrawMode<any>[];
 	}) {
 		this._adapter = options.adapter;
-		this._mode = new TerraDrawStaticMode();
+
+		const coordinatePrecision = this._adapter.getCoordinatePrecision();
+
+		this._mode = new TerraDrawStaticMode({
+			coordinatePrecision,
+		});
 
 		// Keep track of if there are duplicate modes
 		const duplicateModeTracker = new Set();
 
 		// Construct a map of the mode name to the mode
-		const modesMap = options.modes.reduce(
-			(modeMap, currentMode) => {
-				if (duplicateModeTracker.has(currentMode.mode)) {
-					throw new Error(
-						`There is already a ${currentMode.mode} mode provided`,
-					);
-				}
-				duplicateModeTracker.add(currentMode.mode);
-				modeMap[currentMode.mode] = currentMode;
-				return modeMap;
-			},
-			{} as { [mode: string]: TerraDrawBaseDrawMode<any> },
-		);
+		const modesMap = options.modes.reduce<{
+			[mode: string]: TerraDrawBaseDrawMode<any>;
+		}>((modeMap, currentMode) => {
+			if (duplicateModeTracker.has(currentMode.mode)) {
+				throw new Error(`There is already a ${currentMode.mode} mode provided`);
+			}
+			duplicateModeTracker.add(currentMode.mode);
+			modeMap[currentMode.mode] = currentMode;
+			// ovveride the coordinate precision of the mode
+			modeMap[currentMode.mode].setCoordinatePrecision(coordinatePrecision);
+			return modeMap;
+		}, {});
 
 		// Construct an array of the mode keys (names)
 		const modeKeys = Object.keys(modesMap);


### PR DESCRIPTION
### Changes
- added typing for the BaseMode constructor params to all other Modes 
- setting coordinatePrecision of all Modes loaded into a TerraDraw instance to its adapters respective coordinatePrecision


Closes #136