### PR TITLE
fix: ensure coordinate precision is set via the config to the adapter

### DIFF
--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -74,7 +74,6 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 		this._styles =
 			options && options.styles ? { ...options.styles } : ({} as Partial<T>);
 		this.pointerDistance = (options && options.pointerDistance) || 40;
-		this.coordinatePrecision = 9;
 	}
 
 	type = ModeTypes.Drawing;
@@ -124,6 +123,7 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 			this.setCursor = config.setCursor;
 			this.onStyleChange = config.onChange;
 			this.onFinish = config.onFinish;
+			this.coordinatePrecision = config.coordinatePrecision;
 
 			this.registerBehaviors({
 				mode: config.mode,
@@ -139,6 +139,10 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 	}
 
 	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
+		if (this._state === "unregistered") {
+			throw new Error("Mode must be registered");
+		}
+
 		return isValidStoreFeature(feature);
 	}
 

--- a/src/modes/circle/circle.spec.ts
+++ b/src/modes/circle/circle.spec.ts
@@ -505,6 +505,7 @@ describe("TerraDrawCircleMode", () => {
 					fillOpacity: 0.5,
 				},
 			});
+			circleMode.register(getMockModeConfig("circle"));
 
 			expect(
 				circleMode.validateFeature({
@@ -532,6 +533,7 @@ describe("TerraDrawCircleMode", () => {
 					fillOpacity: 0.5,
 				},
 			});
+			circleMode.register(getMockModeConfig("circle"));
 
 			expect(
 				circleMode.validateFeature({

--- a/src/modes/freehand/freehand.mode.spec.ts
+++ b/src/modes/freehand/freehand.mode.spec.ts
@@ -546,6 +546,7 @@ describe("TerraDrawFreehandMode", () => {
 					closingPointOutlineColor: "#111111",
 				},
 			});
+			freehandMode.register(getMockModeConfig("freehand"));
 
 			expect(
 				freehandMode.validateFeature({
@@ -573,6 +574,7 @@ describe("TerraDrawFreehandMode", () => {
 					closingPointOutlineColor: "#111111",
 				},
 			});
+			freehandMode.register(getMockModeConfig("freehand"));
 
 			expect(
 				freehandMode.validateFeature({

--- a/src/modes/greatcircle/great-circle.mode.spec.ts
+++ b/src/modes/greatcircle/great-circle.mode.spec.ts
@@ -631,6 +631,7 @@ describe("TerraDrawGreatCircleMode", () => {
 					lineStringColor: "#ffffff",
 				},
 			});
+			greatCircleMode.register(getMockModeConfig("greatcircle"));
 
 			expect(
 				greatCircleMode.validateFeature({
@@ -655,6 +656,7 @@ describe("TerraDrawGreatCircleMode", () => {
 					lineStringColor: "#ffffff",
 				},
 			});
+			greatCircleMode.register(getMockModeConfig("greatcircle"));
 
 			expect(
 				greatCircleMode.validateFeature({

--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -876,6 +876,7 @@ describe("TerraDrawLineStringMode", () => {
 					lineStringColor: "#ffffff",
 				},
 			});
+			lineStringMode.register(getMockModeConfig("linestring"));
 
 			expect(
 				lineStringMode.validateFeature({
@@ -900,6 +901,7 @@ describe("TerraDrawLineStringMode", () => {
 					lineStringColor: "#ffffff",
 				},
 			});
+			lineStringMode.register(getMockModeConfig("linestring"));
 
 			expect(
 				lineStringMode.validateFeature({

--- a/src/modes/point/point.mode.spec.ts
+++ b/src/modes/point/point.mode.spec.ts
@@ -276,6 +276,8 @@ describe("TerraDrawPointMode", () => {
 				},
 			});
 
+			pointMode.register(getMockModeConfig("point"));
+
 			expect(
 				pointMode.validateFeature({
 					id: "ed030248-d7ee-45a2-b8e8-37ad2f622509",
@@ -299,6 +301,8 @@ describe("TerraDrawPointMode", () => {
 					pointColor: "#ffffff",
 				},
 			});
+
+			pointMode.register(getMockModeConfig("point"));
 
 			expect(
 				pointMode.validateFeature({

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -1453,6 +1453,7 @@ describe("validateFeature", () => {
 				fillOpacity: 0.5,
 			},
 		});
+		polygonMode.register(getMockModeConfig("polygon"));
 
 		expect(
 			polygonMode.validateFeature({
@@ -1480,6 +1481,7 @@ describe("validateFeature", () => {
 				fillOpacity: 0.5,
 			},
 		});
+		polygonMode.register(getMockModeConfig("polygon"));
 
 		expect(
 			polygonMode.validateFeature({

--- a/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/src/modes/rectangle/rectangle.mode.spec.ts
@@ -518,6 +518,7 @@ describe("TerraDrawRectangleMode", () => {
 					fillOpacity: 0.5,
 				},
 			});
+			rectangleMode.register(getMockModeConfig("rectangle"));
 
 			expect(
 				rectangleMode.validateFeature({
@@ -545,6 +546,7 @@ describe("TerraDrawRectangleMode", () => {
 					fillOpacity: 0.5,
 				},
 			});
+			rectangleMode.register(getMockModeConfig("rectangle"));
 
 			expect(
 				rectangleMode.validateFeature({

--- a/src/modes/render/render.mode.spec.ts
+++ b/src/modes/render/render.mode.spec.ts
@@ -238,18 +238,21 @@ describe("TerraDrawRenderMode", () => {
 	describe("validateFeature", () => {
 		it("validates points", () => {
 			const renderMode = new TerraDrawRenderMode(options);
+			renderMode.register(getMockModeConfig("arbitary"));
 
 			expect(renderMode.validateFeature(createMockPoint())).toBe(true);
 		});
 
 		it("validates linestrings", () => {
 			const renderMode = new TerraDrawRenderMode(options);
+			renderMode.register(getMockModeConfig("arbitary"));
 
 			expect(renderMode.validateFeature(createMockLineString())).toBe(true);
 		});
 
 		it("validates polygons", () => {
 			const renderMode = new TerraDrawRenderMode(options);
+			renderMode.register(getMockModeConfig("arbitary"));
 
 			expect(renderMode.validateFeature(createMockPolygonSquare())).toBe(true);
 		});


### PR DESCRIPTION
Fixes hard coding of the coordinate precision and then the unit tests to run the register function first before attempting to validate.