### PR TITLE
fix: ensure full commit history is fetched for releasing so changelog is populated correctly

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -11,7 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+        with:
+          fetch-depth: 0
+          
       - uses: actions/setup-node@v3
         with:
           node-version: "18.x"


### PR DESCRIPTION
I think this should resolve the issue of the changelog being populated incorrectly. Let's see!