### PR TITLE
chore: attempt push to main first before pushing tags incase push to main fails

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -53,6 +53,9 @@ jobs:
         run: npm run release:alpha:changelog
 
       - name: Push upstream
+        run: git push origin main
+
+      - name: Push tags upstream
         run: git push origin main --tags
 
       - run: npm publish


### PR DESCRIPTION
Ensures that push can happen before attempting to push the tags. This avoids situation where tags get push but the main push has failed because of credential issues.