### PR TITLE
fix: ensure that base config parameters can be configured for adapters

### DIFF
--- a/src/adapters/arcgis-maps-sdk.adapter.ts
+++ b/src/adapters/arcgis-maps-sdk.adapter.ts
@@ -4,7 +4,7 @@ import {
 	TerraDrawChanges,
 	TerraDrawStylingFunction,
 } from "../common";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 import MapView from "@arcgis/core/views/MapView";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
@@ -44,11 +44,12 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawBaseAdapter {
 	private _dragHandler: undefined | IHandle;
 	private _doubleClickHandler: undefined | IHandle;
 
-	constructor(config: {
-		map: MapView;
-		lib: InjectableArcGISMapsSDK;
-		coordinatePrecision?: number;
-	}) {
+	constructor(
+		config: {
+			map: MapView;
+			lib: InjectableArcGISMapsSDK;
+		} & BaseAdapterConfig,
+	) {
 		super(config);
 
 		this._mapView = config.map;

--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -16,13 +16,15 @@ type BasePointerListener = (event: PointerEvent) => void;
 type BaseKeyboardListener = (event: KeyboardEvent) => void;
 type BaseMouseListener = (event: MouseEvent) => void;
 
+export type BaseAdapterConfig = {
+	coordinatePrecision?: number;
+	minPixelDragDistanceDrawing?: number;
+	minPixelDragDistance?: number;
+	minPixelDragDistanceSelecting?: number;
+};
+
 export abstract class TerraDrawBaseAdapter {
-	constructor(config: {
-		coordinatePrecision?: number;
-		minPixelDragDistanceDrawing?: number;
-		minPixelDragDistance?: number;
-		minPixelDragDistanceSelecting?: number;
-	}) {
+	constructor(config: BaseAdapterConfig) {
 		this._minPixelDragDistance =
 			typeof config.minPixelDragDistance === "number"
 				? config.minPixelDragDistance

--- a/src/adapters/google-maps.adapter.spec.ts
+++ b/src/adapters/google-maps.adapter.spec.ts
@@ -73,6 +73,10 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					})),
 				} as any,
 				map: createMockGoogleMap(),
+				minPixelDragDistance: 1,
+				minPixelDragDistanceSelecting: 8,
+				minPixelDragDistanceDrawing: 8,
+				coordinatePrecision: 9,
 			});
 
 			expect(adapter).toBeDefined();

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -5,14 +5,15 @@ import {
 	TerraDrawCallbacks,
 } from "../common";
 import { GeoJsonObject } from "geojson";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 
 export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
-	constructor(config: {
-		lib: typeof google.maps;
-		map: google.maps.Map;
-		coordinatePrecision?: number;
-	}) {
+	constructor(
+		config: {
+			lib: typeof google.maps;
+			map: google.maps.Map;
+		} & BaseAdapterConfig,
+	) {
 		super(config);
 		this._lib = config.lib;
 		this._map = config.map;

--- a/src/adapters/leaflet.adapter.spec.ts
+++ b/src/adapters/leaflet.adapter.spec.ts
@@ -52,6 +52,10 @@ describe("TerraDrawLeafletAdapter", () => {
 					geoJSON: jest.fn(),
 				} as any,
 				map: createLeafletMap() as L.Map,
+				minPixelDragDistance: 1,
+				minPixelDragDistanceSelecting: 8,
+				minPixelDragDistanceDrawing: 8,
+				coordinatePrecision: 9,
 			});
 
 			expect(adapter).toBeDefined();

--- a/src/adapters/leaflet.adapter.ts
+++ b/src/adapters/leaflet.adapter.ts
@@ -5,15 +5,15 @@ import {
 } from "../common";
 import L from "leaflet";
 import { GeoJSONStoreFeatures } from "../store/store";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 
 export class TerraDrawLeafletAdapter extends TerraDrawBaseAdapter {
-	constructor(config: {
-		lib: typeof L;
-		map: L.Map;
-		coordinatePrecision?: number;
-		minPixelDragDistance?: number;
-	}) {
+	constructor(
+		config: {
+			lib: typeof L;
+			map: L.Map;
+		} & BaseAdapterConfig,
+	) {
 		super(config);
 
 		this._lib = config.lib;

--- a/src/adapters/mapbox-gl.adapter.spec.ts
+++ b/src/adapters/mapbox-gl.adapter.spec.ts
@@ -49,6 +49,10 @@ describe("TerraDrawMapboxGLAdapter", () => {
 		it("instantiates the adapter correctly", () => {
 			const adapter = new TerraDrawMapboxGLAdapter({
 				map: createMapboxGLMap() as mapboxgl.Map,
+				minPixelDragDistance: 1,
+				minPixelDragDistanceSelecting: 8,
+				minPixelDragDistanceDrawing: 8,
+				coordinatePrecision: 9,
 			});
 
 			expect(adapter).toBeDefined();

--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -11,10 +11,10 @@ import mapboxgl, {
 	PointLike,
 } from "mapbox-gl";
 import { GeoJSONStoreFeatures, GeoJSONStoreGeometries } from "../store/store";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 
 export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
-	constructor(config: { map: mapboxgl.Map; coordinatePrecision?: number }) {
+	constructor(config: { map: mapboxgl.Map } & BaseAdapterConfig) {
 		super(config);
 
 		this._map = config.map;

--- a/src/adapters/maplibre-gl.adapter.spec.ts
+++ b/src/adapters/maplibre-gl.adapter.spec.ts
@@ -22,6 +22,10 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 		it("instantiates the adapter correctly", () => {
 			const adapter = new TerraDrawMapLibreGLAdapter({
 				map: createMapLibreGLMap() as maplibregl.Map,
+				minPixelDragDistance: 1,
+				minPixelDragDistanceSelecting: 8,
+				minPixelDragDistanceDrawing: 8,
+				coordinatePrecision: 9,
 			});
 
 			expect(adapter).toBeDefined();

--- a/src/adapters/maplibre-gl.adapter.ts
+++ b/src/adapters/maplibre-gl.adapter.ts
@@ -6,12 +6,12 @@ import {
 } from "../common";
 import { Map } from "maplibre-gl";
 import { TerraDrawMapboxGLAdapter } from "./mapbox-gl.adapter";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 
 export class TerraDrawMapLibreGLAdapter extends TerraDrawBaseAdapter {
 	private mapboxglAdapter: TerraDrawMapboxGLAdapter;
 
-	constructor(config: { map: Map; coordinatePrecision?: number }) {
+	constructor(config: { map: Map } & BaseAdapterConfig) {
 		super(config);
 
 		// At the moment the APIs of MapboxGL and MapLibre are so compatible that

--- a/src/adapters/openlayers.adapter.spec.ts
+++ b/src/adapters/openlayers.adapter.spec.ts
@@ -22,6 +22,10 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
 				} as any,
+				minPixelDragDistance: 1,
+				minPixelDragDistanceSelecting: 8,
+				minPixelDragDistanceDrawing: 8,
+				coordinatePrecision: 9,
 			});
 
 			expect(adapter).toBeDefined();

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -16,7 +16,7 @@ import VectorSource from "ol/source/Vector";
 import VectorLayer from "ol/layer/Vector";
 import { fromLonLat, toLonLat } from "ol/proj";
 import Geometry from "ol/geom/Geometry";
-import { TerraDrawBaseAdapter } from "./common/base.adapter";
+import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 
 type InjectableOL = {
 	Circle: typeof CircleGeom;
@@ -31,11 +31,12 @@ type InjectableOL = {
 };
 
 export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
-	constructor(config: {
-		map: Map;
-		lib: InjectableOL;
-		coordinatePrecision?: number;
-	}) {
+	constructor(
+		config: {
+			map: Map;
+			lib: InjectableOL;
+		} & BaseAdapterConfig,
+	) {
 		super(config);
 
 		this._map = config.map;


### PR DESCRIPTION
## Description of Changes

This PR should allow for the setting of the base adapter settings in extending adapters. Namely ensuring the ability to configure:

```typescript
	coordinatePrecision?: number;
	minPixelDragDistanceDrawing?: number;
	minPixelDragDistance?: number;
	minPixelDragDistanceSelecting?: number;
```

Across all extending adapters (Leaflet, Google Maps, ArcGIS, Mapbox, Maplibre). 

## Link to Issue

#167 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 