### PR TITLE
docs: clarify the requiremnts for google maps and throw error if element id is not set

### DIFF
--- a/guides/3.ADAPTERS.md
+++ b/guides/3.ADAPTERS.md
@@ -192,7 +192,9 @@ draw.setMode("freehand");
 ### Google Maps
 
 > [!IMPORTANT]
-> The Google Maps API requires an `apiKey` property when loading the library.
+> There are some requirements for the Google Map Adapter to work correctly:
+> 1) The Google Maps API requires an `apiKey` property when loading the library.
+> 2) The map element must have a id property set
 
 ```javascript
 // Import Google Maps
@@ -215,13 +217,15 @@ const loader = new Loader({
 });
 
 loader.load().then((google) => {
-  // Create map
-  const map = new google.maps.Map(document.getElementById(id), {
+  // Create map element
+  const mapElement = document.getElementById(id) // The map element must have an id set for the adapter to work!
+
+  // Create the google map itself
+  const map = new google.maps.Map(mapElement, {
     disableDefaultUI: true,
     center: { lat, lng },
     zoom: zoom,
     clickableIcons: false,
-    mapId: id,
   });
 
   // Once the map is loaded

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -17,6 +17,13 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 		super(config);
 		this._lib = config.lib;
 		this._map = config.map;
+
+		// In order for the internals of the adapter to work we require an ID to
+		// allow query selectors  to work
+		if (!this._map.getDiv().id) {
+			throw new Error("Google Map container div requires and id to be set");
+		}
+
 		this._coordinatePrecision =
 			typeof config.coordinatePrecision === "number"
 				? config.coordinatePrecision


### PR DESCRIPTION
## Description of Changes

1. Aims to clarify the around the necessity for and ID to be set on the map passed to the `TerraDrawGoogleMapAdapter` instance
2. Throw an error if the `id` attribute is not set on the map div


## Link to Issue

#176 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 