### PR TITLE
feat: allow custom id strategies

### DIFF
--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -2,6 +2,41 @@
 
 The Store is the heart of the library and is responsible for managing the state of all Features that are added to the map. The Store is created when Terra Draw is instantiated, but is not directly exposed, and instead exposed via a series of API methods on the Terra Draw instance itself. All data in the store is represented using [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON). Currently the store only represents data as Features, using the Point, LineString and Polygon geometry types.
 
+
+### Ids
+
+By default Terra Draw will use [UUID4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) to create Feature ids. This is done because this ids are broadly unique and as such lends themselves well to these IDs where would want our features to be uniquely identifiable, potentially across drawing sessions.
+ 
+It is possible to override this with an approach which aligns with your own requirements. This is done via the `idStrategy`` paramter is passed at the top level when you create a Terra Draw instance. For example say we wanted to be able to define our own integer incrementing id strategy, we could do that like so:
+
+```typescript
+
+const draw = new TerraDraw({
+  adapter,
+  modes,
+  idStrategy: {
+    isValidId: (id) => typeof id === "number" && Number.isInteger(id),
+    getId: (function () {
+      let id = 0;
+      return function () {
+        return ++id;
+      };
+    })() // Returns a function that returns incrementing integer ids
+  },
+});
+```
+
+You can create any strategy you like, although it advisable to start with one and stick with it consistently.
+
+> [!IMPORTANT]
+> You can only have one unique id per feature in each Terra Draw instance. Trying to create or add a feature with an id that already exists will throw an error!
+
+It is also possible to check if a given feature with an id exists if so needed:
+
+```typescript
+  draw.hasFeature('f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8')
+```
+
 ### Retrieving Data
 
 The data contained with the store is exposed via the `getSnapshot` method, which returns an Array of all given Feature geometries in the Store:
@@ -42,7 +77,48 @@ draw.addFeatures([
 ]);
 ```
 
-Here setting the mode property will add the feature to that specific mode, so for example in this instance we added a point to the `TerraDrawPointMode` of this instance of Terra Draw.
+If you want to get an ID for a feature and create that outside Terra Draw to do something with it later, you can use the `getFeatureId` method on the Terra Draw instance, like so:
+
+```javascript
+
+const id = draw.getFeatureId()
+
+// Add a Point to the Store
+draw.addFeatures([
+  {
+    id,
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [-1.825859, 51.178867],
+    },
+    properties: {
+      mode: "point",
+    },
+  },
+]);
+```
+
+Here setting the mode property will add the feature to that specific mode, so for example in this instance we added a point to the `TerraDrawPointMode` of this instance of Terra Draw. 
+
+> [!IMPORTANT]
+> In the above example we do not pass in an id property, as addFeatures will generate one for us using the `idStrategy` provided or the built in one, which defaults to UUID4. You can provide your own id but it must be valid by the `idStrategy` you provide. For more info on ids, see the [Ids section](./2.STORE.md#ids) above.
+
+You can add the `mode` property to the Feature dynamically before adding it to Terra Draw:
+
+```javascript
+// Iterate over the points
+points.forEach((point) => {
+  // Set the `mode` property to "point"
+  point.properties.mode = "point";
+});
+
+draw.addFeatures(points);
+```
+
+> [!NOTE]
+> We have to provide the mode property to the passed feature because otherwise Terra Draw does not know which mode you intended the feature to be added to. Assume a user has two different types of point modes in their application - where would the point be added to? Although it is slightly more verbose, this approach ensures that the features end up in the correct modes they were intended for by the user.
+
 
 We can also get data at a specific event location, using the `getFeaturesAtLngLat` and `getFeaturesAtPointerEvent` methods. Find out more about these in the [events section of the guides](./6.EVENTS.md).
 

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -338,42 +338,9 @@ draw.setMode("freehand");
 > [!TIP]
 > Render Modes are enabled by default and do not need to be enabled using the `setMode` method.
 
-## Loading Features
+## Adding Data to a Mode
 
-It is common pattern to want to load data from an external source (GeoJSON file, API call, etc). This can be achieved with the Terra Draw `addFeatures` method.
-
-The method works out which mode to add the feature based on looking at its `mode` property for that Feature. All modes have a `validateFeature` method that checks if a given feature is valid for the mode.
-
-For example if you wanted to add a series of points to the `TerraDrawPointMode` you could do this by ensuring that the points have a `mode` property set to `point`:
-
-```javascript
-const points = [
-  {
-    type: "Feature",
-    geometry: {
-      type: "Point",
-      coordinates: [-1.825859, 51.178867],
-    },
-    properties: {
-      mode: "point",
-    },
-  },
-
-  // Etc...
-];
-```
-
-You can add the `mode` property to the Feature dynamically before adding it to Terra Draw:
-
-```javascript
-// Iterate over the points
-points.forEach((point) => {
-  // Set the `mode` property to "point"
-  point.properties.mode = "point";
-});
-
-draw.addFeatures(points);
-```
+For guidance around adding pre-existing data to a specific mode, please see the [Store guide on adding features](./2.STORE.md#adding-data).
 
 ## Creating Custom Modes
 

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -6,6 +6,7 @@ import {
 } from "../common";
 import { GeoJsonObject } from "geojson";
 import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
+import { FeatureId } from "../store/store";
 
 export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 	constructor(
@@ -256,7 +257,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 		this._map.setOptions({ draggable: enabled });
 	}
 
-	private renderedFeatureIds: Set<string> = new Set();
+	private renderedFeatureIds: Set<FeatureId> = new Set();
 
 	/**
 	 * Renders GeoJSON features on the map using the provided styling configuration.

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -3,7 +3,7 @@ import {
 	SetCursor,
 	TerraDrawStylingFunction,
 } from "../common";
-import { GeoJSONStoreFeatures } from "../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../store/store";
 import CircleGeom from "ol/geom/Circle";
 import Feature, { FeatureLike } from "ol/Feature";
 import GeoJSON from "ol/format/GeoJSON";
@@ -176,7 +176,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 		}
 	}
 
-	private removeFeature(id: string) {
+	private removeFeature(id: FeatureId) {
 		if (this._vectorSource) {
 			const deleted = this._vectorSource.getFeatureById(id);
 			if (!deleted) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,6 +2,7 @@ import {
 	StoreChangeHandler,
 	GeoJSONStore,
 	GeoJSONStoreFeatures,
+	FeatureId,
 } from "./store/store";
 
 export type HexColor = `#${string}`;
@@ -119,7 +120,7 @@ export interface TerraDrawChanges {
 	created: GeoJSONStoreFeatures[];
 	updated: GeoJSONStoreFeatures[];
 	unchanged: GeoJSONStoreFeatures[];
-	deletedIds: string[];
+	deletedIds: FeatureId[];
 }
 
 export type TerraDrawStylingFunction = {

--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -10,6 +10,7 @@ import {
 	TerraDrawMouseEvent,
 } from "../common";
 import {
+	FeatureId,
 	GeoJSONStore,
 	GeoJSONStoreFeatures,
 	StoreChangeHandler,
@@ -143,7 +144,7 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 			throw new Error("Mode must be registered");
 		}
 
-		return isValidStoreFeature(feature);
+		return isValidStoreFeature(feature, this.store.idStrategy.isValidId);
 	}
 
 	abstract start(): void;
@@ -151,9 +152,9 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 	abstract cleanUp(): void;
 	abstract styleFeature(feature: GeoJSONStoreFeatures): TerraDrawAdapterStyling;
 
-	onFinish(finishedId: string) {}
-	onDeselect(deselectedId: string) {}
-	onSelect(selectedId: string) {}
+	onFinish(finishedId: FeatureId) {}
+	onDeselect(deselectedId: FeatureId) {}
+	onSelect(selectedId: FeatureId) {}
 	onKeyDown(event: TerraDrawKeyboardEvent) {}
 	onKeyUp(event: TerraDrawKeyboardEvent) {}
 	onMouseMove(event: TerraDrawMouseEvent) {}

--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -9,7 +9,7 @@ import {
 } from "../../common";
 import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import { circle } from "../../geometry/shape/create-circle";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
@@ -44,7 +44,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	mode = "circle";
 	private center: Position | undefined;
 	private clickCount = 0;
-	private currentCircleId: string | undefined;
+	private currentCircleId: FeatureId | undefined;
 	private keyEvents: TerraDrawCircleModeKeyEvents;
 	private cursors: Required<Cursors>;
 
@@ -75,7 +75,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	}
 
 	private close() {
-		if (!this.currentCircleId) {
+		if (this.currentCircleId === undefined) {
 			return;
 		}
 
@@ -128,7 +128,11 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 			this.clickCount++;
 			this.setDrawing();
 		} else {
-			if (this.clickCount === 1 && this.center && this.currentCircleId) {
+			if (
+				this.clickCount === 1 &&
+				this.center &&
+				this.currentCircleId !== undefined
+			) {
 				this.createCircle(event);
 			}
 
@@ -166,7 +170,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	/** @internal */
 	cleanUp() {
 		try {
-			if (this.currentCircleId) {
+			if (this.currentCircleId !== undefined) {
 				this.store.delete([this.currentCircleId]);
 			}
 		} catch (error) {}

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -14,7 +14,7 @@ import {
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { getDefaultStyling } from "../../util/styling";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { pixelDistance } from "../../geometry/measure/pixel-distance";
 import { isValidPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
 
@@ -51,8 +51,8 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	mode = "freehand";
 
 	private startingClick = false;
-	private currentId: string | undefined;
-	private closingPointId: string | undefined;
+	private currentId: FeatureId | undefined;
+	private closingPointId: FeatureId | undefined;
 	private minDistance: number;
 	private keyEvents: TerraDrawFreehandModeKeyEvents;
 	private cursors: Required<Cursors>;
@@ -91,7 +91,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	}
 
 	private close() {
-		if (!this.currentId) {
+		if (this.currentId === undefined) {
 			return;
 		}
 
@@ -125,7 +125,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 
 	/** @internal */
 	onMouseMove(event: TerraDrawMouseEvent) {
-		if (!this.currentId || this.startingClick === false) {
+		if (this.currentId === undefined || this.startingClick === false) {
 			return;
 		}
 

--- a/src/modes/great-circle-snapping.behavior.ts
+++ b/src/modes/great-circle-snapping.behavior.ts
@@ -2,7 +2,7 @@ import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
 import { TerraDrawMouseEvent } from "../common";
 import { Feature, Position } from "geojson";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
-import { BBoxPolygon } from "../store/store";
+import { BBoxPolygon, FeatureId } from "../store/store";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
 
 export class GreatCircleSnappingBehavior extends TerraDrawModeBehavior {
@@ -16,7 +16,7 @@ export class GreatCircleSnappingBehavior extends TerraDrawModeBehavior {
 
 	public getSnappableCoordinate = (
 		event: TerraDrawMouseEvent,
-		currentFeatureId?: string,
+		currentFeatureId?: FeatureId,
 	) => {
 		return this.getSnappableEnds(event, (feature) => {
 			return Boolean(

--- a/src/modes/greatcircle/great-circle.mode.ts
+++ b/src/modes/greatcircle/great-circle.mode.ts
@@ -14,7 +14,7 @@ import {
 } from "../base.mode";
 import { BehaviorConfig } from "../base.behavior";
 import { getDefaultStyling } from "../../util/styling";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { greatCircleLine } from "../../geometry/shape/great-circle-line";
 import { GreatCircleSnappingBehavior } from "../great-circle-snapping.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
@@ -51,8 +51,8 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	mode = "greatcircle";
 
 	private currentCoordinate = 0;
-	private currentId: string | undefined;
-	private closingPointId: string | undefined;
+	private currentId: FeatureId | undefined;
+	private closingPointId: FeatureId | undefined;
 	private keyEvents: TerraDrawGreateCircleModeKeyEvents;
 	private snappingEnabled: boolean;
 	private cursors: Required<Cursors>;
@@ -91,7 +91,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	}
 
 	private close() {
-		if (!this.currentId) {
+		if (this.currentId === undefined) {
 			return;
 		}
 
@@ -137,7 +137,7 @@ export class TerraDrawGreatCircleMode extends TerraDrawBaseDrawMode<GreateCircle
 	onMouseMove(event: TerraDrawMouseEvent) {
 		this.setCursor(this.cursors.start);
 
-		if (!this.currentId && this.currentCoordinate === 0) {
+		if (this.currentId === undefined && this.currentCoordinate === 0) {
 			return;
 		} else if (
 			this.currentId &&

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -19,7 +19,7 @@ import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { SnappingBehavior } from "../snapping.behavior";
 import { getDefaultStyling } from "../../util/styling";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 
 type TerraDrawLineStringModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
@@ -53,8 +53,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	mode = "linestring";
 
 	private currentCoordinate = 0;
-	private currentId: string | undefined;
-	private closingPointId: string | undefined;
+	private currentId: FeatureId | undefined;
+	private closingPointId: FeatureId | undefined;
 	private allowSelfIntersections;
 	private keyEvents: TerraDrawLineStringModeKeyEvents;
 	private snappingEnabled: boolean;
@@ -100,7 +100,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	}
 
 	private close() {
-		if (!this.currentId) {
+		if (this.currentId === undefined) {
 			return;
 		}
 
@@ -164,7 +164,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		this.mouseMove = true;
 		this.setCursor(this.cursors.start);
 
-		if (!this.currentId || this.currentCoordinate === 0) {
+		if (this.currentId === undefined || this.currentCoordinate === 0) {
 			return;
 		}
 		const currentLineGeometry = this.store.getGeometryCopy<LineString>(

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -21,7 +21,7 @@ import { SnappingBehavior } from "../snapping.behavior";
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { ClosingPointsBehavior } from "./behaviors/closing-points.behavior";
 import { getDefaultStyling } from "../../util/styling";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { isValidPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
 
 type TerraDrawPolygonModeKeyEvents = {
@@ -58,7 +58,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	mode = "polygon";
 
 	private currentCoordinate = 0;
-	private currentId: string | undefined;
+	private currentId: FeatureId | undefined;
 	private allowSelfIntersections: boolean;
 	private keyEvents: TerraDrawPolygonModeKeyEvents;
 	private snappingEnabled: boolean;
@@ -106,7 +106,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	}
 
 	private close() {
-		if (!this.currentId) {
+		if (this.currentId === undefined) {
 			return;
 		}
 
@@ -179,7 +179,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		this.mouseMove = true;
 		this.setCursor(this.cursors.start);
 
-		if (!this.currentId || this.currentCoordinate === 0) {
+		if (this.currentId === undefined || this.currentCoordinate === 0) {
 			return;
 		}
 

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -7,7 +7,7 @@ import {
 	NumericStyling,
 	Cursor,
 } from "../../common";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
@@ -42,7 +42,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	mode = "rectangle";
 	private center: Position | undefined;
 	private clickCount = 0;
-	private currentRectangleId: string | undefined;
+	private currentRectangleId: FeatureId | undefined;
 	private keyEvents: TerraDrawRectangleModeKeyEvents;
 	private cursors: Required<Cursors>;
 

--- a/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -6,6 +6,7 @@ import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { selfIntersects } from "../../../geometry/boolean/self-intersects";
+import { FeatureId } from "../../../store/store";
 
 export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -17,7 +18,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		super(config);
 	}
 
-	private draggedCoordinate: { id: null | string; index: number } = {
+	private draggedCoordinate: { id: null | FeatureId; index: number } = {
 		id: null,
 		index: -1,
 	};
@@ -72,7 +73,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 
 	public getDraggableIndex(
 		event: TerraDrawMouseEvent,
-		selectedId: string,
+		selectedId: FeatureId,
 	): number {
 		const geometry = this.store.getGeometryCopy(selectedId);
 		const closestCoordinate = this.getClosestCoordinate(event, geometry);
@@ -171,7 +172,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		return this.draggedCoordinate.id !== null;
 	}
 
-	startDragging(id: string, index: number) {
+	startDragging(id: FeatureId, index: number) {
 		this.draggedCoordinate = {
 			id,
 			index,

--- a/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -5,6 +5,7 @@ import { Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
+import { FeatureId } from "../../../store/store";
 
 export class DragFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -16,11 +17,11 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 		super(config);
 	}
 
-	private draggedFeatureId: string | null = null;
+	private draggedFeatureId: FeatureId | null = null;
 
 	private dragPosition: Position | undefined;
 
-	startDragging(event: TerraDrawMouseEvent, id: string) {
+	startDragging(event: TerraDrawMouseEvent, id: FeatureId) {
 		this.draggedFeatureId = id;
 		this.dragPosition = [event.lng, event.lat];
 	}
@@ -34,7 +35,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 		return this.draggedFeatureId !== null;
 	}
 
-	canDrag(event: TerraDrawMouseEvent, selectedId: string) {
+	canDrag(event: TerraDrawMouseEvent, selectedId: FeatureId) {
 		const { clickedFeature } = this.featuresAtMouseEvent.find(event, true);
 
 		// If the cursor is not over the selected

--- a/src/modes/select/behaviors/midpoint.behavior.ts
+++ b/src/modes/select/behaviors/midpoint.behavior.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../geometry/get-midpoints";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { SELECT_PROPERTIES } from "../../../common";
+import { FeatureId } from "../../../store/store";
 
 export class MidPointBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -74,7 +75,7 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 
 	public create(
 		selectedCoords: Position[],
-		featureId: string,
+		featureId: FeatureId,
 		coordinatePrecision: number,
 	) {
 		if (!this.store.has(featureId)) {

--- a/src/modes/select/behaviors/rotate-feature.behavior.ts
+++ b/src/modes/select/behaviors/rotate-feature.behavior.ts
@@ -7,6 +7,7 @@ import { transformRotate } from "../../../geometry/transform/rotate";
 import { centroid } from "../../../geometry/centroid";
 import { rhumbBearing } from "../../../geometry/measure/rhumb-bearing";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
+import { FeatureId } from "../../../store/store";
 
 export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -23,7 +24,7 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 		this.lastBearing = undefined;
 	}
 
-	rotate(event: TerraDrawMouseEvent, selectedId: string) {
+	rotate(event: TerraDrawMouseEvent, selectedId: FeatureId) {
 		const geometry = this.store.getGeometryCopy<LineString | Polygon>(
 			selectedId,
 		);

--- a/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -7,6 +7,7 @@ import { centroid } from "../../../geometry/centroid";
 import { haversineDistanceKilometers } from "../../../geometry/measure/haversine-distance";
 import { transformScale } from "../../../geometry/transform/scale";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
+import { FeatureId } from "../../../store/store";
 
 export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -23,7 +24,7 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 		this.lastDistance = undefined;
 	}
 
-	scale(event: TerraDrawMouseEvent, selectedId: string) {
+	scale(event: TerraDrawMouseEvent, selectedId: FeatureId) {
 		const geometry = this.store.getGeometryCopy<LineString | Polygon>(
 			selectedId,
 		);

--- a/src/modes/select/behaviors/selection-point.behavior.ts
+++ b/src/modes/select/behaviors/selection-point.behavior.ts
@@ -1,24 +1,25 @@
 import { LineString, Point, Polygon, Position } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { getCoordinatesAsPoints } from "../../../geometry/get-coordinates-as-points";
+import { FeatureId } from "../../../store/store";
 
 export class SelectionPointBehavior extends TerraDrawModeBehavior {
 	constructor(config: BehaviorConfig) {
 		super(config);
 	}
 
-	private _selectionPoints: string[] = [];
+	private _selectionPoints: FeatureId[] = [];
 
 	get ids() {
 		return this._selectionPoints.concat();
 	}
 
-	set ids(_: string[]) {}
+	set ids(_: FeatureId[]) {}
 
 	public create(
 		selectedCoords: Position[],
 		type: Polygon["type"] | LineString["type"],
-		featureId: string,
+		featureId: FeatureId,
 	) {
 		this._selectionPoints = this.store.create(
 			getCoordinatesAsPoints(selectedCoords, type, (i) => ({

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -24,7 +24,7 @@ import { DragCoordinateBehavior } from "./behaviors/drag-coordinate.behavior";
 import { BehaviorConfig } from "../base.behavior";
 import { RotateFeatureBehavior } from "./behaviors/rotate-feature.behavior";
 import { ScaleFeatureBehavior } from "./behaviors/scale-feature.behavior";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 
 type TerraDrawSelectModeKeyEvents = {
@@ -251,7 +251,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 
 		let clickedFeatureDistance = Infinity;
 
-		this.selectionPoints.ids.forEach((id: string) => {
+		this.selectionPoints.ids.forEach((id) => {
 			const geometry = this.store.getGeometryCopy<Point>(id);
 			const distance = this.pixelDistance.measure(event, geometry.coordinates);
 
@@ -706,7 +706,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 		let nearbySelectionPoint = false;
 		// TODO: Is there a cleaner way to handle prioritising
 		// dragging selection points?
-		this.selectionPoints.ids.forEach((id: string) => {
+		this.selectionPoints.ids.forEach((id: FeatureId) => {
 			const geometry = this.store.getGeometryCopy<Point>(id);
 			const distance = this.pixelDistance.measure(event, geometry.coordinates);
 			if (distance < this.pointerDistance) {

--- a/src/modes/snapping.behavior.ts
+++ b/src/modes/snapping.behavior.ts
@@ -2,7 +2,7 @@ import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
 import { TerraDrawMouseEvent } from "../common";
 import { Feature, Position } from "geojson";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
-import { BBoxPolygon } from "../store/store";
+import { BBoxPolygon, FeatureId } from "../store/store";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
 
 export class SnappingBehavior extends TerraDrawModeBehavior {
@@ -25,7 +25,7 @@ export class SnappingBehavior extends TerraDrawModeBehavior {
 
 	public getSnappableCoordinate = (
 		event: TerraDrawMouseEvent,
-		currentFeatureId: string,
+		currentFeatureId: FeatureId,
 	) => {
 		return this.getSnappable(event, (feature) => {
 			return Boolean(

--- a/src/store/store-feature-validation.ts
+++ b/src/store/store-feature-validation.ts
@@ -1,11 +1,12 @@
-import { GeoJSONStoreFeatures } from "./store";
+import { FeatureId, GeoJSONStoreFeatures, IdStrategy } from "./store";
 
 export const StoreValidationErrors = {
 	FeatureHasNoId: "Feature has no id",
 	FeatureIsNotObject: "Feature is not object",
 	InvalidTrackedProperties: "updatedAt and createdAt are not valid timestamps",
 	FeatureHasNoMode: "Feature does not have a set mode",
-	FeatureIdIsNotUUID4: `Feature must have UUID4 id`,
+	FeatureIdIsNotValidGeoJSON: `Feature must be string or number as per GeoJSON spec`,
+	FeatureIdIsNotValid: `Feature must match the id strategy (default is UUID4)`,
 	FeatureHasNoGeometry: "Feature has no geometry",
 	FeatureHasNoProperties: "Feature has no properties",
 	FeatureGeometryNotSupported: "Feature is not Point, LineString or Polygon",
@@ -41,14 +42,17 @@ export function isValidTimestamp(timestamp: unknown): boolean {
 
 export function isValidStoreFeature(
 	feature: unknown,
+	isValidId: IdStrategy<FeatureId>["isValidId"],
 ): feature is GeoJSONStoreFeatures {
 	let error;
 	if (!isObject(feature)) {
 		error = StoreValidationErrors.FeatureIsNotObject;
-	} else if (!feature.id) {
+	} else if (feature.id === null || feature.id === undefined) {
 		error = StoreValidationErrors.FeatureHasNoId;
-	} else if (typeof feature.id !== "string" || feature.id.length !== 36) {
-		error = StoreValidationErrors.FeatureIdIsNotUUID4;
+	} else if (typeof feature.id !== "string" && typeof feature.id !== "number") {
+		error = StoreValidationErrors.FeatureIdIsNotValidGeoJSON;
+	} else if (!isValidId(feature.id)) {
+		error = StoreValidationErrors.FeatureIdIsNotValid;
 	} else if (!isObject(feature.geometry)) {
 		error = StoreValidationErrors.FeatureHasNoGeometry;
 	} else if (!isObject(feature.properties)) {

--- a/src/store/store-validation.spec.ts
+++ b/src/store/store-validation.spec.ts
@@ -1,3 +1,4 @@
+import { defaultIdStrategy } from "./store";
 import {
 	StoreValidationErrors,
 	isValidStoreFeature,
@@ -5,99 +6,119 @@ import {
 } from "./store-feature-validation";
 
 describe("isValidStoreFeature", () => {
+	const isValidId = defaultIdStrategy.isValidId;
+
 	it("throws on data with non object feature", () => {
-		expect(() => isValidStoreFeature(undefined)).toThrowError(
+		expect(() => isValidStoreFeature(undefined, isValidId)).toThrowError(
 			StoreValidationErrors.FeatureIsNotObject,
 		);
-		expect(() => isValidStoreFeature(null)).toThrowError(
+		expect(() => isValidStoreFeature(null, isValidId)).toThrowError(
 			StoreValidationErrors.FeatureIsNotObject,
 		);
 	});
 
 	it("throws on data with no id", () => {
-		expect(() => isValidStoreFeature({ id: undefined })).toThrowError(
-			StoreValidationErrors.FeatureHasNoId,
-		);
-		expect(() => isValidStoreFeature({ id: null })).toThrowError(
+		expect(() =>
+			isValidStoreFeature({ id: undefined }, isValidId),
+		).toThrowError(StoreValidationErrors.FeatureHasNoId);
+		expect(() => isValidStoreFeature({ id: null }, isValidId)).toThrowError(
 			StoreValidationErrors.FeatureHasNoId,
 		);
 	});
 
 	it("throws on data with non string id", () => {
-		expect(() => isValidStoreFeature({ id: 1 })).toThrowError(
-			StoreValidationErrors.FeatureIdIsNotUUID4,
+		expect(() => isValidStoreFeature({ id: 1 }, isValidId)).toThrowError(
+			StoreValidationErrors.FeatureIdIsNotValid,
 		);
 	});
 
 	it("throws on data with non uuid4 id", () => {
-		expect(() => isValidStoreFeature({ id: "1" })).toThrowError(
-			StoreValidationErrors.FeatureIdIsNotUUID4,
+		expect(() => isValidStoreFeature({ id: "1" }, isValidId)).toThrowError(
+			StoreValidationErrors.FeatureIdIsNotValid,
 		);
 	});
 
 	it("throws on data with no geometry", () => {
 		expect(() =>
-			isValidStoreFeature({ id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284" }),
+			isValidStoreFeature(
+				{ id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284" },
+				isValidId,
+			),
 		).toThrowError(StoreValidationErrors.FeatureHasNoGeometry);
 	});
 
 	it("throws on data with no properties", () => {
 		expect(() => {
-			isValidStoreFeature({
-				id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
-				geometry: {},
-			} as any);
+			isValidStoreFeature(
+				{
+					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
+					geometry: {},
+				} as any,
+				isValidId,
+			);
 		}).toThrowError(StoreValidationErrors.FeatureHasNoProperties);
 	});
 
 	it("throws on data with non Point, LineString, Polygon geometry type", () => {
 		expect(() => {
-			isValidStoreFeature({
-				id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
-				geometry: {
-					type: "MultiLineString",
-				},
-				properties: {},
-			} as any);
+			isValidStoreFeature(
+				{
+					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
+					geometry: {
+						type: "MultiLineString",
+					},
+					properties: {},
+				} as any,
+				isValidId,
+			);
 		}).toThrowError(StoreValidationErrors.FeatureGeometryNotSupported);
 	});
 
 	it("throws on data with supported geometry with non array coordinate property", () => {
 		expect(() => {
-			isValidStoreFeature({
-				id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
-				geometry: {
-					type: "Point",
-					coordinates: "[]",
+			isValidStoreFeature(
+				{
+					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
+					geometry: {
+						type: "Point",
+						coordinates: "[]",
+					},
+					properties: {},
 				},
-				properties: {},
-			});
+				isValidId,
+			);
 		}).toThrowError(StoreValidationErrors.FeatureCoordinatesNotAnArray);
 	});
 
 	it("throws if mode is not provided as a string", () => {
 		expect(() =>
-			isValidStoreFeature({
-				id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
-				type: "Feature",
-				geometry: { type: "Point", coordinates: [0, 0] },
-				properties: {
-					mode: 1,
+			isValidStoreFeature(
+				{
+					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: 1,
+					},
 				},
-			}),
+				isValidId,
+			),
 		).toThrowError(StoreValidationErrors.InvalidModeProperty);
 	});
 
 	it("does not throw if mode is provide as a string", () => {
 		expect(() =>
-			isValidStoreFeature({
-				id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
-				type: "Feature",
-				geometry: { type: "Point", coordinates: [0, 0] },
-				properties: {
-					mode: "test",
+			isValidStoreFeature(
+				{
+					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: "test",
+					},
 				},
-			}),
+				isValidId,
+			),
 		).not.toThrowError();
 	});
 

--- a/src/store/store.spec.ts
+++ b/src/store/store.spec.ts
@@ -6,7 +6,7 @@ describe("GeoJSONStore", () => {
 		it("Point", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -16,7 +16,7 @@ describe("GeoJSONStore", () => {
 		it("LineString", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{
 					geometry: {
 						type: "LineString",
@@ -35,7 +35,7 @@ describe("GeoJSONStore", () => {
 		it("Polygon", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{
 					geometry: {
 						type: "Polygon",
@@ -66,7 +66,7 @@ describe("GeoJSONStore", () => {
 		it("returns true for existing store feature", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -78,7 +78,7 @@ describe("GeoJSONStore", () => {
 		it("removes geometry from the store", () => {
 			const store = new GeoJSONStore();
 
-			const ids = store.create([
+			const ids = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -107,7 +107,9 @@ describe("GeoJSONStore", () => {
 		it("gets size one after feature added", () => {
 			const store = new GeoJSONStore();
 
-			store.create([{ geometry: { type: "Point", coordinates: [0, 0] } }]);
+			store.create<string>([
+				{ geometry: { type: "Point", coordinates: [0, 0] } },
+			]);
 
 			expect(store.size()).toBe(1);
 		});
@@ -117,7 +119,7 @@ describe("GeoJSONStore", () => {
 		it("removes all data from store", () => {
 			const store = new GeoJSONStore();
 
-			const ids = store.create([
+			const ids = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -135,7 +137,7 @@ describe("GeoJSONStore", () => {
 		it("copy existing geometry", () => {
 			const store = new GeoJSONStore();
 
-			const ids = store.create([
+			const ids = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -158,7 +160,7 @@ describe("GeoJSONStore", () => {
 		it("copy existing properties", () => {
 			const store = new GeoJSONStore();
 
-			const ids = store.create([
+			const ids = store.create<string>([
 				{
 					geometry: { type: "Point", coordinates: [0, 0] },
 					properties: { mode: "test" },
@@ -175,7 +177,7 @@ describe("GeoJSONStore", () => {
 		it("do not expect createdAt and updatedAt in returned properties if flag is disabled", () => {
 			const store = new GeoJSONStore({ tracked: false });
 
-			const ids = store.create([
+			const ids = store.create<string>([
 				{
 					geometry: { type: "Point", coordinates: [0, 0] },
 					properties: { mode: "test" },
@@ -191,7 +193,7 @@ describe("GeoJSONStore", () => {
 			const store = new GeoJSONStore();
 
 			const createdAt = +new Date();
-			const ids = store.create([
+			const ids = store.create<string>([
 				{
 					geometry: { type: "Point", coordinates: [0, 0] },
 					properties: {
@@ -222,7 +224,7 @@ describe("GeoJSONStore", () => {
 		it("updates geometry", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -257,7 +259,7 @@ describe("GeoJSONStore", () => {
 		it("updates geometry", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -288,7 +290,7 @@ describe("GeoJSONStore", () => {
 			const mockCallback = jest.fn();
 			store.registerOnChange(mockCallback);
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 
@@ -308,7 +310,7 @@ describe("GeoJSONStore", () => {
 		it("deletes feature", () => {
 			const store = new GeoJSONStore();
 
-			const [id] = store.create([
+			const [id] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
 			store.delete([id]);
@@ -445,10 +447,10 @@ describe("GeoJSONStore", () => {
 			const mockCallback = jest.fn();
 			store.registerOnChange(mockCallback);
 
-			const [one] = store.create([
+			const [one] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [0, 0] } },
 			]);
-			const [two] = store.create([
+			const [two] = store.create<string>([
 				{ geometry: { type: "Point", coordinates: [1, 1] } },
 			]);
 

--- a/src/terra-draw.spec.ts
+++ b/src/terra-draw.spec.ts
@@ -1,0 +1,261 @@
+import {
+	TerraDraw,
+	TerraDrawGoogleMapsAdapter,
+	TerraDrawPointMode,
+} from "./terra-draw";
+
+// Frustratingly required to keep the tests working and avoiding SyntaxError: Cannot use import statement outside a module
+jest.mock("ol/style/Circle", () => jest.fn());
+jest.mock("ol/style/Fill", () => jest.fn());
+jest.mock("ol/style/Stroke", () => jest.fn());
+jest.mock("ol/style/Style", () => jest.fn());
+jest.mock("ol/proj", () => jest.fn());
+jest.mock("ol/geom/Geometry", () => jest.fn());
+
+describe("Terra Draw", () => {
+	let adapter: TerraDrawGoogleMapsAdapter;
+
+	beforeAll(() => {
+		adapter = new TerraDrawGoogleMapsAdapter({
+			map: {
+				getDiv: () => ({
+					id: "map",
+					querySelector: () => ({ addEventListener: jest.fn() }),
+				}),
+				data: {
+					addListener: jest.fn(),
+					addGeoJson: jest.fn(),
+					setStyle: jest.fn(),
+				},
+			} as any,
+			lib: {
+				LatLng: jest.fn(),
+				OverlayView: jest.fn().mockImplementation(() => ({
+					setMap: jest.fn(),
+				})),
+			} as any,
+			coordinatePrecision: 9,
+		});
+	});
+
+	describe("addFeature", () => {
+		it("respects the default id strategy", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-25.431289673, 34.355907891],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			const snapshot = draw.getSnapshot();
+			expect(typeof snapshot[0].id).toBe("string");
+			expect(snapshot[0].id).toHaveLength(36);
+		});
+
+		it("respects the user defined id strategy", () => {
+			let id = 1;
+
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+				idStrategy: {
+					isValidId: (id) => typeof id === "number" && Number.isInteger(id),
+					getId: () => id++,
+				},
+			});
+
+			draw.start();
+
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-25.431289673, 34.355907891],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			const snapshot = draw.getSnapshot();
+			expect(typeof snapshot[0].id).toBe("number");
+			expect(snapshot[0].id).toBe(1);
+		});
+
+		it("does not allow features with same id to be added twice ", () => {
+			const draw = new TerraDraw({
+				adapter: adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			expect(() => {
+				draw.addFeatures([
+					{
+						id: "e90e54ea-0a63-407e-b433-08717009d9f6",
+						type: "Feature",
+						geometry: {
+							type: "Point",
+							coordinates: [-25.431289673, 34.355907891],
+						},
+						properties: {
+							mode: "point",
+						},
+					},
+					{
+						id: "e90e54ea-0a63-407e-b433-08717009d9f6",
+						type: "Feature",
+						geometry: {
+							type: "Point",
+							coordinates: [-26.431289673, 34.355907891],
+						},
+						properties: {
+							mode: "point",
+						},
+					},
+				]);
+			}).toThrowError();
+		});
+
+		it("does not allow features with incorrect id strategy to be added", () => {
+			const draw = new TerraDraw({
+				adapter: adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			expect(() => {
+				draw.addFeatures([
+					{
+						id: 1,
+						type: "Feature",
+						geometry: {
+							type: "Point",
+							coordinates: [-25.431289673, 34.355907891],
+						},
+						properties: {
+							mode: "point",
+						},
+					},
+					{
+						id: 2,
+						type: "Feature",
+						geometry: {
+							type: "Point",
+							coordinates: [-26.431289673, 34.355907891],
+						},
+						properties: {
+							mode: "point",
+						},
+					},
+				]);
+			}).toThrowError();
+		});
+	});
+
+	describe("getFeatureId", () => {
+		it("respects the default id strategy", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			const featureId = draw.getFeatureId();
+			expect(typeof featureId).toBe("string");
+			expect(featureId).toHaveLength(36);
+
+			const featureId2 = draw.getFeatureId();
+			expect(typeof featureId2).toBe("string");
+			expect(featureId2).toHaveLength(36);
+
+			expect(featureId).not.toBe(featureId2);
+		});
+
+		it("respects the user defined id strategy", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+				idStrategy: {
+					isValidId: (id) => typeof id === "number" && Number.isInteger(id),
+					getId: (function () {
+						let id = 0;
+						return function () {
+							return ++id;
+						};
+					})(),
+				},
+			});
+
+			draw.start();
+
+			const featureId = draw.getFeatureId();
+			expect(typeof featureId).toBe("number");
+			expect(featureId).toBe(1);
+
+			const featureId2 = draw.getFeatureId();
+			expect(typeof featureId2).toBe("number");
+			expect(featureId2).toBe(2);
+
+			expect(featureId).not.toBe(featureId2);
+		});
+	});
+
+	describe("hasFeature", () => {
+		it("returns true if there is a feature with a given id", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-25.431289673, 34.355907891],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			const id = draw.getSnapshot()[0].id as string;
+
+			expect(draw.hasFeature(id)).toBe(true);
+		});
+
+		it("returns false if there is no feature with a given id", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			expect(draw.hasFeature("f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8")).toBe(
+				false,
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Description of Changes

It has historically not been possible to use your own IDs with Terra Draw as they would always be created with UUIDv4. This is generally fine, but there are scenarios were people may want to bring their own id creation strategy along, and not use UUIDv4. This PR allows for that.

## Link to Issue

#179 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 