### PR TITLE
feat: allow maintaining shape when dragging coordinates in select mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,11 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: "18.x"
-    - name: Change to E2E test folder
-      run: cd ./e2e
-
+    - name: Install parent directory
+      run: npm install
     - name: Get installed Playwright version
       id: playwright-version
+      working-directory: ./e2e
       run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
     - name: Cache playwright binaries
       uses: actions/cache@v3
@@ -75,10 +75,14 @@ jobs:
           ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
     - name: Install e2e test
+      working-directory: ./e2e
       run: npm install
     - run: npx playwright install --with-deps
+      working-directory: ./e2e
       if: steps.playwright-cache.outputs.cache-hit != 'true'
     - run: npx playwright install-deps
+      working-directory: ./e2e
       if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: Run Playwright tests
+      working-directory: ./e2e
       run: npm run test

--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -27,7 +27,7 @@ import GeoJSON from "ol/format/GeoJSON";
 import Map from "ol/Map";
 import { TerraDrawOpenLayersAdapter } from "../../src/adapters/openlayers.adapter";
 import View from "ol/View";
-import { Circle as CircleStyle, Fill, Stroke, Style } from "ol/style";
+import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
 import { fromLonLat, toLonLat } from "ol/proj";

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,21 +1,201 @@
 {
-	"name": "terra-draw-development",
+	"name": "terra-draw-e2e",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "terra-draw-development",
+			"name": "terra-draw-e2e",
 			"version": "0.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@playwright/test": "^1.40.1",
+				"@types/jest": "^29.5.12",
 				"@types/node": "^20.10.5",
 				"dotenv-webpack": "^8.0.0",
+				"ts-loader": "^9.5.1",
 				"typescript": "^4.7.4",
 				"webpack": "^5.73.0",
 				"webpack-cli": "^4.10.0",
 				"webpack-dev-server": "^4.11.1"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -25,6 +205,47 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+			"dev": true,
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -105,6 +326,12 @@
 			"engines": {
 				"node": ">=16"
 			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"dev": true
 		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.5",
@@ -209,6 +436,40 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "29.5.12",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+			"integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+			"dev": true,
+			"dependencies": {
+				"expect": "^29.0.0",
+				"pretty-format": "^29.0.0"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -296,6 +557,12 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true
+		},
 		"node_modules/@types/ws": {
 			"version": "8.5.10",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
@@ -304,6 +571,21 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.6",
@@ -609,6 +891,21 @@
 				"ansi-html": "bin/ansi-html"
 			}
 		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -797,6 +1094,34 @@
 				}
 			]
 		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -833,6 +1158,21 @@
 				"node": ">=6.0"
 			}
 		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/clone-deep": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -846,6 +1186,24 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
@@ -1035,6 +1393,15 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"node_modules/diff-sequences": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -1153,6 +1520,15 @@
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"dev": true
 		},
+		"node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1241,6 +1617,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/expect": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/express": {
@@ -1931,6 +2323,82 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/jest-diff": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"diff-sequences": "^29.6.3",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-get-type": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -1944,6 +2412,12 @@
 			"engines": {
 				"node": ">= 10.13.0"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -1995,6 +2469,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/media-typer": {
@@ -2416,6 +2902,32 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2509,6 +3021,12 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/react-is": {
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"dev": true
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
@@ -2683,6 +3201,21 @@
 			"dependencies": {
 				"@types/node-forge": "^1.3.0",
 				"node-forge": "^1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -2888,6 +3421,15 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/sockjs": {
 			"version": "0.3.24",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -2993,6 +3535,18 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
@@ -3134,6 +3688,35 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/ts-loader": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+			"integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"enhanced-resolve": "^5.0.0",
+				"micromatch": "^4.0.0",
+				"semver": "^7.3.4",
+				"source-map": "^0.7.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"typescript": "*",
+				"webpack": "^5.0.0"
+			}
+		},
+		"node_modules/ts-loader/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/type-is": {
@@ -3655,6 +4238,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		}
 	}
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,18 +6,21 @@
 	"scripts": {
 		"build": "webpack",
 		"serve": "webpack serve",
-		"test": "playwright test",
+		"test": "playwright test --workers=1",
+		"test:help": "playwright test --help",
 		"test:ui": "playwright test --ui --headed"
 	},
 	"author": "James Milner",
 	"license": "MIT",
 	"devDependencies": {
+		"@playwright/test": "^1.40.1",
+		"@types/jest": "^29.5.12",
 		"@types/node": "^20.10.5",
 		"dotenv-webpack": "^8.0.0",
+		"ts-loader": "^9.5.1",
 		"typescript": "^4.7.4",
 		"webpack": "^5.73.0",
 		"webpack-cli": "^4.10.0",
-		"webpack-dev-server": "^4.11.1",
-		"@playwright/test": "^1.40.1"
+		"webpack-dev-server": "^4.11.1"
 	}
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: "on-first-retry",
 	},
-
+	timeout: 5 * 1000,
 	/* Configure projects for major browsers */
 	projects: [
 		{

--- a/e2e/public/index.html
+++ b/e2e/public/index.html
@@ -35,7 +35,7 @@
             aria-label="A leaflet map used for testing purposes">
         </div>
     </div>
-    <div class="buttons">
+    <div class="buttons" data-testid="buttons">
         <button id="select">Select</button>
         <button id="point">Point</button>
         <button id="linestring">Linestring</button>

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -46,6 +46,7 @@ const example = {
 			}),
 			modes: [
 				new TerraDrawSelectMode({
+					dragEventThrottle: 0,
 					flags: {
 						arbitary: {
 							feature: {},

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -41,7 +41,8 @@ export const changeMode = async ({
 		| "greatcircle";
 }) => {
 	const modeText = mode.charAt(0).toUpperCase() + mode.slice(1);
-	const button = page.getByText(modeText);
+	const buttons = page.getByTestId("buttons");
+	const button = buttons.getByText(modeText, { exact: true });
 
 	// Click the mode button
 	await button.click();
@@ -63,7 +64,7 @@ export const expectPaths = async ({
 	const selector = "svg > g > path";
 
 	if (count > 0) {
-		page.waitForSelector(selector);
+		await page.waitForSelector(selector);
 		expect(await page.locator(selector).count()).toBe(count);
 	} else {
 		await expect(await page.locator(selector).count()).toBe(0);
@@ -85,4 +86,51 @@ export const expectPathDimensions = async ({
 
 	expect(boundingBox?.width).toBe(width);
 	expect(boundingBox?.height).toBe(height);
+};
+
+export const expectGroupPosition = async ({
+	page,
+	x,
+	y,
+}: {
+	page: Page;
+	x: number;
+	y: number;
+}) => {
+	const selector = "svg > g > path";
+
+	const boundingBox = await page.locator(selector).boundingBox();
+
+	expect(boundingBox?.x).toBe(x);
+	expect(boundingBox?.y).toBe(y);
+};
+
+export const drawRectanglePolygon = async ({
+	mapDiv,
+	page,
+}: {
+	mapDiv: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	page: Page;
+}) => {
+	// Draw a rectangle
+	const sideLength = 100;
+	const halfLength = sideLength / 2;
+	const centerX = mapDiv.width / 2;
+	const centerY = mapDiv.height / 2;
+	const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+	const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+	const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+	const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+	await page.mouse.click(topLeft.x, topLeft.y);
+	await page.mouse.click(topRight.x, topRight.y);
+	await page.mouse.click(bottomRight.x, bottomRight.y);
+	await page.mouse.click(bottomLeft.x, bottomLeft.y);
+	await page.mouse.click(bottomLeft.x, bottomLeft.y); // Closed
+
+	return { topLeft, topRight, bottomRight, bottomLeft };
 };

--- a/e2e/webpack.config.js
+++ b/e2e/webpack.config.js
@@ -26,12 +26,10 @@ module.exports = {
 		static: {
 			directory: path.join(__dirname, "public"),
 		},
-		watchFiles: [
-			"./src",
-			"./*.{js,json,ts,html}",
-			"../src",
-			"../*.{js,json,ts,html}",
-		],
+		liveReload: !process.env.CI,
+		watchFiles: !process.env.CI
+			? ["./src", "./*.{js,json,ts,html}", "../src", "../*.{js,json,ts,html}"]
+			: [],
 		compress: true,
 		port: 3000,
 	},

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -134,6 +134,11 @@ const selectMode = new TerraDrawSelectMode({
           // Can be moved
           draggable: true,
 
+          // [Requires draggable to be true] can be moved but the overall shape of 
+          // the geometry will be maintained. Movementments will be relation to the center,
+          // or opposite corner of the bounding box of the shape.
+          maintainShapeFrom: 'center', // can also be 'opposite'
+
           // Can be deleted
           deletable: true,
         },

--- a/src/geometry/transform/scale.spec.ts
+++ b/src/geometry/transform/scale.spec.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString, Polygon } from "geojson";
 import { transformScale } from "./scale";
+import { centroid } from "../centroid";
 
 describe("scale", () => {
 	it("returns a polygon as is if scale is set to 1", () => {
@@ -19,7 +20,8 @@ describe("scale", () => {
 			},
 			properties: {},
 		} as Feature<Polygon>;
-		const result = transformScale(polygon, 1);
+		const origin = centroid(polygon);
+		const result = transformScale(polygon, 1, origin);
 		expect(result).toStrictEqual(polygon);
 	});
 
@@ -40,7 +42,8 @@ describe("scale", () => {
 			},
 			properties: {},
 		} as Feature<Polygon>;
-		const result = transformScale(polygon, 2);
+		const origin = centroid(polygon);
+		const result = transformScale(polygon, 2, origin);
 		expect(result).toStrictEqual({
 			type: "Feature",
 			geometry: {
@@ -73,7 +76,8 @@ describe("scale", () => {
 			},
 			properties: {},
 		} as Feature<LineString>;
-		const result = transformScale(linestring, 2);
+		const origin = centroid(linestring);
+		const result = transformScale(linestring, 2, origin);
 		expect(result).toStrictEqual({
 			type: "Feature",
 			geometry: {

--- a/src/geometry/transform/scale.ts
+++ b/src/geometry/transform/scale.ts
@@ -1,5 +1,5 @@
 import { Feature, LineString, Polygon, Position } from "geojson";
-import { centroid } from "../centroid";
+// import { centroid } from "../centroid";
 import { rhumbBearing } from "../measure/rhumb-bearing";
 import { rhumbDestination } from "../measure/rhumb-destination";
 import { rhumbDistance } from "../measure/rhumb-distance";
@@ -9,13 +9,12 @@ import { rhumbDistance } from "../measure/rhumb-distance";
 export function transformScale(
 	feature: Feature<Polygon | LineString>,
 	factor: number,
+	origin: Position,
 ) {
 	// Shortcut no-scaling
 	if (factor === 1) {
 		return feature;
 	}
-
-	const origin = centroid(feature);
 
 	const cooordinates =
 		feature.geometry.type === "Polygon"

--- a/src/modes/select/behaviors/drag-maintained-shape.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-maintained-shape.behavior.spec.ts
@@ -1,0 +1,230 @@
+import { Position } from "geojson";
+import {
+	createStorePoint,
+	createStorePolygon,
+} from "../../../test/create-store-features";
+import { mockBehaviorConfig } from "../../../test/mock-behavior-config";
+import { mockDrawEvent } from "../../../test/mock-mouse-event";
+import { BehaviorConfig } from "../../base.behavior";
+import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
+import { DragMaintainedShapeBehavior } from "./drag-maintained-shape.behavior";
+import { MidPointBehavior } from "./midpoint.behavior";
+import { SelectionPointBehavior } from "./selection-point.behavior";
+
+describe("DragMaintainedShapeBehaviour", () => {
+	const createLineString = (
+		config: BehaviorConfig,
+		coordinates: Position[] = [
+			[0, 0],
+			[0, 1],
+		],
+	) => {
+		const [createdId] = config.store.create([
+			{
+				geometry: {
+					type: "LineString",
+					coordinates,
+				},
+				properties: {
+					selected: true,
+				},
+			},
+		]);
+
+		return createdId;
+	};
+
+	describe("constructor", () => {
+		it("constructs", () => {
+			const config = mockBehaviorConfig("test");
+			const selectionPointBehavior = new SelectionPointBehavior(config);
+			new DragMaintainedShapeBehavior(
+				config,
+				new PixelDistanceBehavior(config),
+				selectionPointBehavior,
+				new MidPointBehavior(config, selectionPointBehavior),
+			);
+		});
+	});
+
+	describe("api", () => {
+		let config: BehaviorConfig;
+		let dragMaintainedShapeBehavior: DragMaintainedShapeBehavior;
+
+		beforeEach(() => {
+			config = mockBehaviorConfig("test");
+			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
+			const midpointBehavior = new MidPointBehavior(
+				config,
+				selectionPointBehavior,
+			);
+
+			dragMaintainedShapeBehavior = new DragMaintainedShapeBehavior(
+				config,
+				pixelDistanceBehavior,
+				selectionPointBehavior,
+				midpointBehavior,
+			);
+		});
+
+		describe("getDraggableIndex", () => {
+			it("returns -1 if geometry is a point", () => {
+				const id = createStorePoint(config);
+				jest.spyOn(config.store, "updateGeometry");
+
+				const index = dragMaintainedShapeBehavior.getDraggableIndex(
+					mockDrawEvent(),
+					id,
+				);
+				expect(index).toBe(-1);
+			});
+
+			it("returns -1 if nothing within pointer distance", () => {
+				const id = createStorePolygon(config);
+				jest.spyOn(config.store, "updateGeometry");
+
+				(config.project as jest.Mock)
+					.mockReturnValueOnce({ x: 200, y: 200 })
+					.mockReturnValueOnce({ x: 200, y: 300 })
+					.mockReturnValueOnce({ x: 300, y: 300 })
+					.mockReturnValueOnce({ x: 300, y: 200 })
+					.mockReturnValueOnce({ x: 200, y: 200 });
+
+				const index = dragMaintainedShapeBehavior.getDraggableIndex(
+					mockDrawEvent(),
+					id,
+				);
+				expect(index).toBe(-1);
+			});
+
+			it("can get index for Polygon coordinate if within pointer distance", () => {
+				const id = createStorePolygon(config);
+				jest.spyOn(config.store, "updateGeometry");
+
+				(config.project as jest.Mock)
+					.mockReturnValueOnce({ x: 0, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 0 });
+
+				const index = dragMaintainedShapeBehavior.getDraggableIndex(
+					mockDrawEvent(),
+					id,
+				);
+				expect(index).toBe(0);
+			});
+
+			it("can drag LineString coordinate if within pointer distance", () => {
+				const id = createLineString(config);
+				jest.spyOn(config.store, "updateGeometry");
+
+				(config.project as jest.Mock)
+					.mockReturnValueOnce({ x: 0, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 1 });
+
+				const index = dragMaintainedShapeBehavior.getDraggableIndex(
+					mockDrawEvent(),
+					id,
+				);
+				expect(index).toBe(0);
+			});
+		});
+
+		describe("drag", () => {
+			it("returns early if nothing is being dragged", () => {
+				jest.spyOn(config.store, "updateGeometry");
+
+				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+
+				expect(config.store.updateGeometry).toBeCalledTimes(0);
+			});
+
+			it("returns early if geometry is a point", () => {
+				createStorePoint(config);
+				jest.spyOn(config.store, "updateGeometry");
+
+				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+
+				expect(config.store.updateGeometry).toBeCalledTimes(0);
+			});
+
+			describe("center", () => {
+				it("updates the Polygon coordinate if within pointer distance", () => {
+					const id = createStorePolygon(config);
+
+					dragMaintainedShapeBehavior.startDragging(id, 0);
+
+					jest.spyOn(config.store, "updateGeometry");
+
+					(config.project as jest.Mock)
+						.mockReturnValueOnce({ x: 0, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 1 })
+						.mockReturnValueOnce({ x: 1, y: 1 })
+						.mockReturnValueOnce({ x: 1, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 0 });
+
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+
+					expect(config.store.updateGeometry).toBeCalledTimes(1);
+				});
+
+				it("updates the LineString coordinate if within pointer distance", () => {
+					const id = createLineString(config);
+					jest.spyOn(config.store, "updateGeometry");
+
+					dragMaintainedShapeBehavior.startDragging(id, 0);
+
+					(config.project as jest.Mock)
+						.mockReturnValueOnce({ x: 0, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 1 });
+
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+
+					expect(config.store.updateGeometry).toBeCalledTimes(1);
+				});
+			});
+
+			describe("opposite", () => {
+				it("updates the Polygon coordinate if within pointer distance", () => {
+					const id = createStorePolygon(config);
+
+					dragMaintainedShapeBehavior.startDragging(id, 0);
+
+					jest.spyOn(config.store, "updateGeometry");
+
+					(config.project as jest.Mock)
+						.mockReturnValueOnce({ x: 0, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 1 })
+						.mockReturnValueOnce({ x: 1, y: 1 })
+						.mockReturnValueOnce({ x: 1, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 0 });
+
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+
+					expect(config.store.updateGeometry).toBeCalledTimes(1);
+				});
+
+				it("updates the LineString coordinate if within pointer distance", () => {
+					const id = createLineString(config);
+					jest.spyOn(config.store, "updateGeometry");
+
+					dragMaintainedShapeBehavior.startDragging(id, 0);
+
+					(config.project as jest.Mock)
+						.mockReturnValueOnce({ x: 0, y: 0 })
+						.mockReturnValueOnce({ x: 0, y: 1 });
+
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+
+					expect(config.store.updateGeometry).toBeCalledTimes(1);
+				});
+			});
+		});
+	});
+});

--- a/src/modes/select/behaviors/drag-maintained-shape.behavior.ts
+++ b/src/modes/select/behaviors/drag-maintained-shape.behavior.ts
@@ -1,0 +1,285 @@
+import { TerraDrawMouseEvent } from "../../../common";
+import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
+
+import { LineString, Polygon, Position, Point, Feature } from "geojson";
+import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
+import { MidPointBehavior } from "./midpoint.behavior";
+import { SelectionPointBehavior } from "./selection-point.behavior";
+import { FeatureId } from "../../../store/store";
+import { centroid } from "../../../geometry/centroid";
+import { haversineDistanceKilometers } from "../../../geometry/measure/haversine-distance";
+import { limitPrecision } from "../../../geometry/limit-decimal-precision";
+import { transformScale } from "../../../geometry/transform/scale";
+
+export class DragMaintainedShapeBehavior extends TerraDrawModeBehavior {
+	constructor(
+		readonly config: BehaviorConfig,
+		private readonly pixelDistance: PixelDistanceBehavior,
+		private readonly selectionPoints: SelectionPointBehavior,
+		private readonly midPoints: MidPointBehavior,
+	) {
+		super(config);
+	}
+
+	private draggedCoordinate: { id: null | FeatureId; index: number } = {
+		id: null,
+		index: -1,
+	};
+
+	private getClosestCoordinate(
+		event: TerraDrawMouseEvent,
+		geometry: Polygon | LineString | Point,
+	) {
+		const closestCoordinate = {
+			dist: Infinity,
+			index: -1,
+			isFirstOrLastPolygonCoord: false,
+		};
+
+		let geomCoordinates: Position[] | undefined;
+
+		if (geometry.type === "LineString") {
+			geomCoordinates = geometry.coordinates;
+		} else if (geometry.type === "Polygon") {
+			geomCoordinates = geometry.coordinates[0];
+		} else {
+			// We don't want to handle dragging
+			// points here
+			return closestCoordinate;
+		}
+
+		// Look through the selected features coordinates
+		// and try to find a coordinate that is draggable
+		for (let i = 0; i < geomCoordinates.length; i++) {
+			const coord = geomCoordinates[i];
+			const distance = this.pixelDistance.measure(event, coord);
+
+			if (
+				distance < this.pointerDistance &&
+				distance < closestCoordinate.dist
+			) {
+				// We don't create a point for the final
+				// polygon coord, so we must set it to the first
+				// coordinate instead
+				const isFirstOrLastPolygonCoord =
+					geometry.type === "Polygon" &&
+					(i === geomCoordinates.length - 1 || i === 0);
+
+				closestCoordinate.dist = distance;
+				closestCoordinate.index = isFirstOrLastPolygonCoord ? 0 : i;
+				closestCoordinate.isFirstOrLastPolygonCoord = isFirstOrLastPolygonCoord;
+			}
+		}
+
+		return closestCoordinate;
+	}
+
+	public getDraggableIndex(
+		event: TerraDrawMouseEvent,
+		selectedId: FeatureId,
+	): number {
+		const geometry = this.store.getGeometryCopy(selectedId);
+		const closestCoordinate = this.getClosestCoordinate(event, geometry);
+
+		// No coordinate was within the pointer distance
+		if (closestCoordinate.index === -1) {
+			return -1;
+		}
+		return closestCoordinate.index;
+	}
+
+	private lastDistance: number | undefined;
+
+	public drag(
+		event: TerraDrawMouseEvent,
+		maintainShapeFrom: "center" | "opposite",
+	): boolean {
+		if (!this.draggedCoordinate.id) {
+			return false;
+		}
+		const index = this.draggedCoordinate.index;
+		const geometry = this.store.getGeometryCopy(this.draggedCoordinate.id);
+
+		// Update the geometry of the dragged feature
+		if (geometry.type !== "Polygon" && geometry.type !== "LineString") {
+			return false;
+		}
+
+		const mouseCoord = [event.lng, event.lat];
+
+		// Coordinates are either polygon or linestring at this point
+		const updatedCoords: Position[] =
+			geometry.type === "Polygon"
+				? geometry.coordinates[0]
+				: geometry.coordinates;
+		const selectedCoordinate = updatedCoords[index];
+
+		const feature = { type: "Feature", geometry, properties: {} } as Feature<
+			Polygon | LineString
+		>;
+
+		// Get the origin for the scaling to occur from
+		let origin: Position | undefined;
+		if (maintainShapeFrom === "center") {
+			origin = this.getCenterOrigin(feature);
+		} else if (maintainShapeFrom === "opposite") {
+			origin = this.getOppositeOrigin(feature, selectedCoordinate);
+		}
+
+		const distance = haversineDistanceKilometers(
+			origin as Position,
+			mouseCoord,
+		);
+
+		// We need an original bearing to compare against
+		if (!this.lastDistance) {
+			this.lastDistance = distance;
+			return false;
+		}
+
+		const scale = 1 - (this.lastDistance - distance) / distance;
+
+		transformScale(feature, scale, origin as Position);
+
+		// Ensure that coordinate precision is maintained
+		updatedCoords.forEach((coordinate) => {
+			coordinate[0] = limitPrecision(coordinate[0], this.coordinatePrecision);
+			coordinate[1] = limitPrecision(coordinate[1], this.coordinatePrecision);
+		});
+
+		const updatedMidPoints = this.midPoints.getUpdated(updatedCoords) || [];
+
+		const updatedSelectionPoints =
+			this.selectionPoints.getUpdated(updatedCoords) || [];
+
+		// Issue the update to the selected feature
+		this.store.updateGeometry([
+			{
+				id: this.draggedCoordinate.id,
+				geometry,
+			},
+			...updatedSelectionPoints,
+			...updatedMidPoints,
+		]);
+
+		this.lastDistance = distance;
+
+		return true;
+	}
+
+	private getCenterOrigin(feature: Feature<Polygon | LineString>) {
+		return centroid(feature);
+	}
+
+	private getOppositeOrigin(
+		feature: Feature<Polygon | LineString>,
+		selectedCoordinate: Position,
+	) {
+		const coordinates =
+			feature.geometry.type === "Polygon"
+				? feature.geometry.coordinates[0]
+				: feature.geometry.coordinates;
+
+		const bbox: [number, number, number, number] = [
+			Infinity,
+			Infinity,
+			-Infinity,
+			-Infinity,
+		];
+		coordinates.forEach((coord) => {
+			if (bbox[0] > coord[0]) {
+				bbox[0] = coord[0];
+			}
+			if (bbox[1] > coord[1]) {
+				bbox[1] = coord[1];
+			}
+			if (bbox[2] < coord[0]) {
+				bbox[2] = coord[0];
+			}
+			if (bbox[3] < coord[1]) {
+				bbox[3] = coord[1];
+			}
+		});
+
+		const [west, south, east, north] = bbox;
+
+		//   Bounding box is represnted as follows:
+		//
+		//   0    1    2
+		//   *----*----*
+		// 	 |		   |
+		// 7 *		   *  3
+		//   |		   |
+		//   *----*----*
+		// 	 6    5    4
+		//
+		const topLeft = [west, north];
+		const midTop = [(west + east) / 2, north];
+		const topRight = [east, north];
+		const midRight = [east, (south + north) / 2];
+		const lowRight = [east, south];
+		const midBottom = [(west + east) / 2, south];
+		const lowLeft = [west, south];
+		const midLeft = [west, (south + north) / 2];
+
+		//                  0       1         2        3          4         5         6        7
+		const options = [
+			topLeft,
+			midTop,
+			topRight,
+			midRight,
+			lowRight,
+			midBottom,
+			lowLeft,
+			midLeft,
+		];
+
+		let closest: number | undefined;
+		let closestDistance = Infinity;
+
+		for (let i = 0; i < options.length; i++) {
+			const distance = haversineDistanceKilometers(
+				selectedCoordinate,
+				options[i],
+			);
+			if (distance < closestDistance) {
+				closest = i;
+				closestDistance = distance;
+			}
+		}
+
+		// This map provides the oppsite corner of the bbox
+		// to the index of the coordinate provided
+		const opposite = {
+			0: 4,
+			1: 5,
+			2: 6,
+			3: 7,
+			4: 0,
+			5: 1,
+			6: 2,
+			7: 3,
+		}[closest as number];
+
+		return options[opposite as number];
+	}
+
+	isDragging() {
+		return this.draggedCoordinate.id !== null;
+	}
+
+	startDragging(id: FeatureId, index: number) {
+		this.draggedCoordinate = {
+			id,
+			index,
+		};
+	}
+
+	stopDragging() {
+		this.lastDistance = undefined;
+		this.draggedCoordinate = {
+			id: null,
+			index: -1,
+		};
+	}
+}

--- a/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -1,6 +1,6 @@
 import { TerraDrawMouseEvent } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
-import { LineString, Polygon, Position } from "geojson";
+import { Feature, LineString, Polygon, Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { centroid } from "../../../geometry/centroid";
@@ -49,7 +49,11 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 
 		const scale = 1 - (this.lastDistance - distance) / distance;
 
-		transformScale({ type: "Feature", geometry, properties: {} }, scale);
+		const feature = { type: "Feature", geometry, properties: {} } as Feature<
+			Polygon | LineString
+		>;
+		const origin = centroid(feature);
+		transformScale(feature, scale, origin);
 
 		// Coordinates are either polygon or linestring at this point
 		const updatedCoords: Position[] =

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -2334,6 +2334,259 @@ describe("TerraDrawSelectMode", () => {
 				);
 			});
 		});
+
+		describe("drag maintaining shape", () => {
+			it("does trigger drag events if mode is draggable for linestring", () => {
+				setSelectMode({
+					flags: {
+						linestring: {
+							feature: {
+								coordinates: { draggable: true, maintainShapeFrom: "center" },
+							},
+						},
+					},
+				});
+
+				// We want to account for ignoring points branch
+				addPointToStore([100, 89]);
+				expect(onChange).toBeCalledTimes(1);
+
+				addLineStringToStore([
+					[0, 0],
+					[1, 1],
+				]);
+				expect(onChange).toBeCalledTimes(2);
+
+				mockMouseEventBoundingBox();
+				project
+					.mockReturnValueOnce({
+						x: 100,
+						y: 100,
+					})
+					.mockReturnValue({
+						x: 0,
+						y: 0,
+					});
+
+				selectMode.onClick({
+					lng: 0,
+					lat: 0,
+					containerX: 0,
+					containerY: 0,
+					button: "left",
+					heldKeys: [],
+				});
+
+				expect(onSelect).toBeCalledTimes(1);
+				expect(onChange).toBeCalledTimes(4);
+
+				// Select feature
+				expect(onChange).toHaveBeenNthCalledWith(
+					3,
+					[expect.any(String)],
+					"update",
+				);
+
+				// Create selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[expect.any(String), expect.any(String)],
+					"create",
+				);
+
+				mockMouseEventBoundingBox();
+				project
+					.mockReturnValueOnce({
+						x: 100,
+						y: 100,
+					})
+					.mockReturnValue({
+						x: 0,
+						y: 0,
+					});
+
+				selectMode.onDragStart(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					jest.fn(),
+				);
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					setMapDraggability,
+				);
+
+				selectMode.onDrag(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					setMapDraggability,
+				);
+
+				expect(onChange).toBeCalledTimes(5);
+
+				// Update linestring position and 1 selection points
+				// that gets moved
+				expect(onChange).toHaveBeenNthCalledWith(
+					5,
+					[expect.any(String), expect.any(String), expect.any(String)],
+					"update",
+				);
+			});
+
+			it("does trigger drag events if mode is draggable for polygon", () => {
+				setSelectMode({
+					flags: {
+						polygon: {
+							feature: {
+								coordinates: { draggable: true, maintainShapeFrom: "center" },
+							},
+						},
+					},
+				});
+
+				// We want to account for ignoring points branch
+				addPointToStore([100, 89]);
+
+				expect(onChange).toBeCalledTimes(1);
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				expect(onChange).toBeCalledTimes(2);
+
+				mockMouseEventBoundingBox();
+
+				project
+					.mockReturnValueOnce({
+						x: 100,
+						y: 100,
+					})
+					.mockReturnValue({
+						x: 0,
+						y: 0,
+					});
+
+				selectMode.onClick({
+					lng: 0,
+					lat: 0,
+					containerX: 0,
+					containerY: 0,
+					button: "left",
+					heldKeys: [],
+				});
+
+				expect(onSelect).toBeCalledTimes(1);
+				expect(onChange).toBeCalledTimes(4);
+
+				// Select feature
+				expect(onChange).toHaveBeenNthCalledWith(
+					3,
+					[expect.any(String)],
+					"update",
+				);
+
+				// Create selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+				);
+
+				mockMouseEventBoundingBox();
+				project
+					.mockReturnValueOnce({
+						x: 100,
+						y: 100,
+					})
+					.mockReturnValue({
+						x: 0,
+						y: 0,
+					});
+
+				selectMode.onDragStart(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					jest.fn(),
+				);
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					setMapDraggability,
+				);
+
+				selectMode.onDrag(
+					{
+						lng: 1,
+						lat: 1,
+						containerX: 1,
+						containerY: 1,
+						button: "left",
+						heldKeys: [],
+					},
+					setMapDraggability,
+				);
+
+				expect(onChange).toBeCalledTimes(5);
+
+				// Update polygon position and 1 selection points
+				// that gets moved
+				expect(onChange).toHaveBeenNthCalledWith(
+					5,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"update",
+				);
+			});
+		});
 	});
 
 	describe("onDragEnd", () => {


### PR DESCRIPTION
## Description of Changes

Provides a new option `maintainShapeFrom` in select mode in the `feature` -> `coordinate` property. The possible options are:

* 'center' - the shape is maintained with it's origin at the center
* 'opposite' - the shape is maintained with the origin as the opposite bounding box point 

This is how you use it:

```typescript
		new TerraDrawSelectMode({
			flags: {
				polygon: {
					feature: {
						draggable: true,
						rotateable: true,
						scaleable: true,
						coordinates: {
							midpoints: true,
							draggable: true,
							deletable: true,
							maintainShapeFrom: "center"
						},
					},
				},
```

This PR also fixes the fact that E2E tests were not actually running.

## Link to Issue

#183 #184

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 