### PR TITLE
test: add e2e tests for new maintainShape property in select mode

### DIFF
--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -76,9 +76,22 @@ const example = {
 								},
 							},
 						},
+						rectangle: {
+							feature: {
+								draggable: true,
+								coordinates: {
+									draggable: true,
+									maintainShapeFrom: "opposite",
+								},
+							},
+						},
 						circle: {
 							feature: {
 								draggable: true,
+								coordinates: {
+									draggable: true,
+									maintainShapeFrom: "center",
+								},
 							},
 						},
 						point: {

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -105,7 +105,7 @@ export const expectGroupPosition = async ({
 	expect(boundingBox?.y).toBe(y);
 };
 
-export const drawRectanglePolygon = async ({
+export const drawRectangularPolygon = async ({
 	mapDiv,
 	page,
 }: {
@@ -131,6 +131,34 @@ export const drawRectanglePolygon = async ({
 	await page.mouse.click(bottomRight.x, bottomRight.y);
 	await page.mouse.click(bottomLeft.x, bottomLeft.y);
 	await page.mouse.click(bottomLeft.x, bottomLeft.y); // Closed
+
+	return { topLeft, topRight, bottomRight, bottomLeft };
+};
+
+export const drawTwoClickShape = async ({
+	mapDiv,
+	page,
+}: {
+	mapDiv: {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+	};
+	page: Page;
+}) => {
+	// Draw a rectangle
+	const sideLength = 100;
+	const halfLength = sideLength / 2;
+	const centerX = mapDiv.width / 2;
+	const centerY = mapDiv.height / 2;
+	const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+	const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+	const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+	const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+	await page.mouse.click(topLeft.x, topLeft.y);
+
+	await page.mouse.click(bottomRight.x, bottomRight.y); // Closed
 
 	return { topLeft, topRight, bottomRight, bottomLeft };
 };


### PR DESCRIPTION
## Description of Changes

Adds in two E2E tests for `maintainShape` property introduced in #188. One for `center` option and another for the `opposite` option.

## Link to Issue

#189 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 