### PR TITLE
feat: add cancel api 

### DIFF
--- a/e2e/public/index.html
+++ b/e2e/public/index.html
@@ -44,6 +44,8 @@
         <button id="circle">Circle</button>
         <button id="greatcircle">Greatcircle</button>
         <button id="clear">Clear</button>
+        <button id="cancel">Cancel</button>
+
     </div>
 
 </body>

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -159,6 +159,14 @@ const example = {
 				draw.clear();
 			},
 		);
+		(document.getElementById("cancel") as HTMLButtonElement).addEventListener(
+			"click",
+			() => {
+				if (currentSelected.mode && currentSelected.mode === "select") {
+					draw.cancel();
+				}
+			},
+		);
 	},
 };
 

--- a/src/adapters/arcgis-maps-sdk.adapter.ts
+++ b/src/adapters/arcgis-maps-sdk.adapter.ts
@@ -187,6 +187,17 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawBaseAdapter {
 		this._featureLayer.graphics.removeAll();
 	}
 
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		if (this._currentModeCallbacks) {
+			// Exit edit mode
+			this._currentModeCallbacks.onCancel();
+		}
+	}
+
 	private removeFeatureById(id: string | number | undefined) {
 		const feature = this._featureLayer.graphics.find(
 			(g) => g.attributes[this._featureIdAttributeName] === id,

--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -314,7 +314,6 @@ export abstract class TerraDrawBaseAdapter {
 					}
 
 					const drawEvent = this.getDrawEventFromEvent(event);
-
 					if (!drawEvent) {
 						return;
 					}

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -454,4 +454,15 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 			this.clearLayers();
 		}
 	}
+
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		if (this._currentModeCallbacks) {
+			// Exit edit mode
+			this._currentModeCallbacks.onCancel();
+		}
+	}
 }

--- a/src/adapters/leaflet.adapter.spec.ts
+++ b/src/adapters/leaflet.adapter.spec.ts
@@ -13,6 +13,7 @@ const callbacks = () =>
 		onDrag: jest.fn(),
 		onDragEnd: jest.fn(),
 		onClear: jest.fn(),
+		onCancel: jest.fn(),
 	}) as TerraDrawCallbacks;
 
 const createLeafletMap = () => {

--- a/src/adapters/leaflet.adapter.ts
+++ b/src/adapters/leaflet.adapter.ts
@@ -294,4 +294,15 @@ export class TerraDrawLeafletAdapter extends TerraDrawBaseAdapter {
 			this.clearPanes();
 		}
 	}
+
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		if (this._currentModeCallbacks) {
+			// Exit edit mode
+			this._currentModeCallbacks.onCancel();
+		}
+	}
 }

--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -448,4 +448,15 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 			this.clearLayers();
 		}
 	}
+
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		if (this._currentModeCallbacks) {
+			// Exit edit mode
+			this._currentModeCallbacks.onCancel();
+		}
+	}
 }

--- a/src/adapters/maplibre-gl.adapter.ts
+++ b/src/adapters/maplibre-gl.adapter.ts
@@ -112,4 +112,12 @@ export class TerraDrawMapLibreGLAdapter extends TerraDrawBaseAdapter {
 	public clear() {
 		this.mapboxglAdapter.clear();
 	}
+
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		this.mapboxglAdapter.cancel();
+	}
 }

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -318,4 +318,15 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 			this.clearLayers();
 		}
 	}
+
+	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	public cancel() {
+		if (this._currentModeCallbacks) {
+			// Exit edit mode
+			this._currentModeCallbacks.onCancel();
+		}
+	}
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -114,6 +114,7 @@ export interface TerraDrawCallbacks {
 		setMapDraggability: (enabled: boolean) => void,
 	) => void;
 	onClear: () => void;
+	onCancel: () => void;
 }
 
 export interface TerraDrawChanges {
@@ -138,6 +139,7 @@ export interface TerraDrawAdapter {
 	unregister(): void;
 	render(changes: TerraDrawChanges, styling: TerraDrawStylingFunction): void;
 	clear(): void;
+	cancel(): void;
 	getCoordinatePrecision(): number;
 }
 

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -162,6 +162,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	/** @internal */
 	onMouseMove(event: TerraDrawMouseEvent) {
 		this.mouseMove = true;
+
 		this.setCursor(this.cursors.start);
 
 		if (this.currentId === undefined || this.currentCoordinate === 0) {
@@ -217,6 +218,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		// similar behaviour to mouse based devices so we
 		// trigger a mousemove event before every click
 		// if one has not been trigged to emulate this
+
 		if (this.currentCoordinate > 0 && !this.mouseMove) {
 			this.onMouseMove(event);
 		}

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -255,6 +255,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		// similar behaviour to mouse based devices so we
 		// trigger a mousemove event before every click
 		// if one has not been trigged to emulate this
+
 		if (this.currentCoordinate > 0 && !this.mouseMove) {
 			this.onMouseMove(event);
 		}

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -445,9 +445,6 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 					);
 				}
 			}
-		} else if (this.selected.length) {
-			this.deselect();
-			return;
 		}
 	}
 

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -419,6 +419,15 @@ class TerraDraw {
 	}
 
 	/**
+	 * Cancel the selected state and keep the drawing mode
+	 * @returns void
+	 * */
+	cancel() {
+		this.checkEnabled();
+		console.log(this.checkEnabled());
+		this._adapter.cancel();
+	}
+	/**
 	 * A property used to determine whether the instance is active or not. You
 	 * can use the start method to set this to true, and stop method to set this to false.
 	 * This is a read only property.
@@ -471,6 +480,7 @@ class TerraDraw {
 
 			// Swap the mode to the new mode
 			this._mode = this._modes[mode];
+			console.log(this._mode);
 
 			// Start the new mode
 			this._mode.start();
@@ -574,6 +584,8 @@ class TerraDraw {
 				return this._mode.state;
 			},
 			onClick: (event) => {
+				console.log(event);
+				// debugger
 				this._mode.onClick(event);
 			},
 			onMouseMove: (event) => {
@@ -601,6 +613,10 @@ class TerraDraw {
 
 				// Remove all features from the store
 				this._store.clear();
+			},
+			onCancel: () => {
+				//Cancel the selected state and keep the drawing mode
+				this._mode.cleanUp();
 			},
 		});
 	}

--- a/src/test/mock-callbacks.ts
+++ b/src/test/mock-callbacks.ts
@@ -12,5 +12,6 @@ export const createMockCallbacks = (
 	onDrag: jest.fn(),
 	onDragEnd: jest.fn(),
 	onClear: jest.fn(),
+	onCancel: jest.fn(),
 	...overrides,
 });


### PR DESCRIPTION
## Description of Changes

In the SELECT mode, you can only click the map or switch to other modes. You can exit the selection state.

> It should be noted that the Cability method is not synchronized in the documentation

## Link to Issue

issue: https://github.com/JamesLMilner/terra-draw/issues/186

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 