### PR TITLE
chore: refactor maintainShapeFrom to resizeable in select mode

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -114,9 +114,26 @@ const getModes = () => {
 						},
 					},
 				},
+				rectangle: {
+					feature: {
+						draggable: true,
+						coordinates: {
+							midpoints: false,
+							draggable: true,
+							resizable: "opposite-corner-fixed",
+							deletable: true,
+						},
+					},
+				},
 				circle: {
 					feature: {
 						draggable: true,
+						coordinates: {
+							midpoints: false,
+							draggable: true,
+							resizable: "opposite-corner-fixed",
+							deletable: true,
+						},
 					},
 				},
 				point: {

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -81,7 +81,7 @@ const example = {
 								draggable: true,
 								coordinates: {
 									draggable: true,
-									maintainShapeFrom: "opposite",
+									resizable: "opposite-corner-fixed",
 								},
 							},
 						},
@@ -90,7 +90,7 @@ const example = {
 								draggable: true,
 								coordinates: {
 									draggable: true,
-									maintainShapeFrom: "center",
+									resizable: "center-fixed",
 								},
 							},
 						},

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -134,10 +134,11 @@ const selectMode = new TerraDrawSelectMode({
           // Can be moved
           draggable: true,
 
-          // [Requires draggable to be true] can be moved but the overall shape of 
-          // the geometry will be maintained. Movementments will be relation to the center,
-          // or opposite corner of the bounding box of the shape.
-          maintainShapeFrom: 'center', // can also be 'opposite'
+          // [Requires draggable to be true] allow resizing of the geometry from 
+          // a given origin. Center fixed will allow resizing on fixed aspect ratio from the center
+          // and opposite-corner-fixed allows resizing from the opposite corner of the bounding box 
+          // of the geometry.
+          resizeable: 'center-fixed', // can also be 'opposite-corner-fixed'
 
           // Can be deleted
           deletable: true,

--- a/src/geometry/transform/scale.ts
+++ b/src/geometry/transform/scale.ts
@@ -10,6 +10,7 @@ export function transformScale(
 	feature: Feature<Polygon | LineString>,
 	factor: number,
 	origin: Position,
+	axis: "x" | "y" | "xy" = "xy",
 ) {
 	// Shortcut no-scaling
 	if (factor === 1) {
@@ -26,8 +27,14 @@ export function transformScale(
 		const bearing = rhumbBearing(origin, pointCoords);
 		const newDistance = originalDistance * factor;
 		const newCoord = rhumbDestination(origin, newDistance, bearing);
-		pointCoords[0] = newCoord[0];
-		pointCoords[1] = newCoord[1];
+
+		if (axis === "x" || axis === "xy") {
+			pointCoords[0] = newCoord[0];
+		}
+
+		if (axis === "y" || axis === "xy") {
+			pointCoords[1] = newCoord[1];
+		}
 	});
 
 	return feature;

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -7,11 +7,11 @@ import { mockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { mockDrawEvent } from "../../../test/mock-mouse-event";
 import { BehaviorConfig } from "../../base.behavior";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
-import { DragMaintainedShapeBehavior } from "./drag-maintained-shape.behavior";
+import { DragCoordinateResizeBehavior } from "./drag-coordinate-resize.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 
-describe("DragMaintainedShapeBehaviour", () => {
+describe("DragCoordinateResizeBehavior", () => {
 	const createLineString = (
 		config: BehaviorConfig,
 		coordinates: Position[] = [
@@ -38,7 +38,7 @@ describe("DragMaintainedShapeBehaviour", () => {
 		it("constructs", () => {
 			const config = mockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
-			new DragMaintainedShapeBehavior(
+			new DragCoordinateResizeBehavior(
 				config,
 				new PixelDistanceBehavior(config),
 				selectionPointBehavior,
@@ -49,7 +49,7 @@ describe("DragMaintainedShapeBehaviour", () => {
 
 	describe("api", () => {
 		let config: BehaviorConfig;
-		let dragMaintainedShapeBehavior: DragMaintainedShapeBehavior;
+		let dragMaintainedShapeBehavior: DragCoordinateResizeBehavior;
 
 		beforeEach(() => {
 			config = mockBehaviorConfig("test");
@@ -60,7 +60,7 @@ describe("DragMaintainedShapeBehaviour", () => {
 				selectionPointBehavior,
 			);
 
-			dragMaintainedShapeBehavior = new DragMaintainedShapeBehavior(
+			dragMaintainedShapeBehavior = new DragCoordinateResizeBehavior(
 				config,
 				pixelDistanceBehavior,
 				selectionPointBehavior,
@@ -136,7 +136,7 @@ describe("DragMaintainedShapeBehaviour", () => {
 			it("returns early if nothing is being dragged", () => {
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 				expect(config.store.updateGeometry).toBeCalledTimes(0);
 			});
@@ -145,12 +145,12 @@ describe("DragMaintainedShapeBehaviour", () => {
 				createStorePoint(config);
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+				dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 				expect(config.store.updateGeometry).toBeCalledTimes(0);
 			});
 
-			describe("center", () => {
+			describe("center-fixed", () => {
 				it("updates the Polygon coordinate if within pointer distance", () => {
 					const id = createStorePolygon(config);
 
@@ -165,8 +165,8 @@ describe("DragMaintainedShapeBehaviour", () => {
 						.mockReturnValueOnce({ x: 1, y: 0 })
 						.mockReturnValueOnce({ x: 0, y: 0 });
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
@@ -181,14 +181,14 @@ describe("DragMaintainedShapeBehaviour", () => {
 						.mockReturnValueOnce({ x: 0, y: 0 })
 						.mockReturnValueOnce({ x: 0, y: 1 });
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
+					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
 			});
 
-			describe("opposite", () => {
+			describe("opposite-corner-fixed", () => {
 				it("updates the Polygon coordinate if within pointer distance", () => {
 					const id = createStorePolygon(config);
 
@@ -203,8 +203,14 @@ describe("DragMaintainedShapeBehaviour", () => {
 						.mockReturnValueOnce({ x: 1, y: 0 })
 						.mockReturnValueOnce({ x: 0, y: 0 });
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+					dragMaintainedShapeBehavior.drag(
+						mockDrawEvent(),
+						"opposite-corner-fixed",
+					);
+					dragMaintainedShapeBehavior.drag(
+						mockDrawEvent(),
+						"opposite-corner-fixed",
+					);
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
@@ -219,8 +225,14 @@ describe("DragMaintainedShapeBehaviour", () => {
 						.mockReturnValueOnce({ x: 0, y: 0 })
 						.mockReturnValueOnce({ x: 0, y: 1 });
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
+					dragMaintainedShapeBehavior.drag(
+						mockDrawEvent(),
+						"opposite-corner-fixed",
+					);
+					dragMaintainedShapeBehavior.drag(
+						mockDrawEvent(),
+						"opposite-corner-fixed",
+					);
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -2341,7 +2341,7 @@ describe("TerraDrawSelectMode", () => {
 					flags: {
 						linestring: {
 							feature: {
-								coordinates: { draggable: true, maintainShapeFrom: "center" },
+								coordinates: { draggable: true, resizable: "center-fixed" },
 							},
 						},
 					},
@@ -2458,7 +2458,7 @@ describe("TerraDrawSelectMode", () => {
 					flags: {
 						polygon: {
 							feature: {
-								coordinates: { draggable: true, maintainShapeFrom: "center" },
+								coordinates: { draggable: true, resizable: "center-fixed" },
 							},
 						},
 					},


### PR DESCRIPTION
## Description of Changes

In hindsight, `maintainShapeFrom` was a bad API name and isn't very extensible. Changing it to `resizeable` is cleaner and allows for a host of different arguments to allow changing the aspect ratio of the shape in future. For now `center-fixed` and `opposite-corner-fixed` will be provided, with others to follow eventually

## Link to Issue

Building block for allowing #191 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 