### PR TITLE
feat: allow prevention of deselection on map click with new select mode parameter

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -153,6 +153,9 @@ The following code sample shows the different Selection Mode flags available whe
 
 ```javascript
 new TerraDrawSelectMode({
+  // Allow manual deselection of features
+  allowManualDeselection: true, // this defaults to true - allows users to deselect by clicking on the map
+
   // Enable editing tools by Feature
   flags: {
     // Point

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -461,6 +461,120 @@ describe("TerraDrawSelectMode", () => {
 					expect(onSelect).toBeCalledTimes(1);
 				});
 
+				it("does deselect if feature is clicked then map area is clicked and allowManualDeselection is true", () => {
+					setSelectMode({
+						allowManualDeselection: true,
+						flags: {
+							polygon: { feature: {} },
+						},
+					});
+
+					// Square Polygon
+					addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					mockMouseEventBoundingBox([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+					]);
+
+					selectMode.onClick({
+						lng: 0.5,
+						lat: 0.5,
+						containerX: 0,
+						containerY: 0,
+						button: "left",
+						heldKeys: [],
+					});
+
+					expect(onSelect).toBeCalledTimes(1);
+
+					expect(onDeselect).toBeCalledTimes(0);
+
+					mockMouseEventBoundingBox([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+					]);
+
+					selectMode.onClick({
+						lng: 50.0,
+						lat: 59.0,
+						containerX: 100,
+						containerY: 100,
+						button: "left",
+						heldKeys: [],
+					});
+
+					expect(onSelect).toBeCalledTimes(1);
+					expect(onDeselect).toBeCalledTimes(1);
+				});
+
+				it("does not deselect if feature is clicked then map area is clicked but allowManualDeselection is false", () => {
+					setSelectMode({
+						allowManualDeselection: false,
+						flags: {
+							polygon: { feature: {} },
+						},
+					});
+
+					// Square Polygon
+					addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					mockMouseEventBoundingBox([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+					]);
+
+					selectMode.onClick({
+						lng: 0.5,
+						lat: 0.5,
+						containerX: 0,
+						containerY: 0,
+						button: "left",
+						heldKeys: [],
+					});
+
+					expect(onSelect).toBeCalledTimes(1);
+
+					expect(onDeselect).toBeCalledTimes(0);
+
+					mockMouseEventBoundingBox([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+					]);
+
+					selectMode.onClick({
+						lng: 50.0,
+						lat: 59.0,
+						containerX: 100,
+						containerY: 100,
+						button: "left",
+						heldKeys: [],
+					});
+
+					expect(onSelect).toBeCalledTimes(1);
+					expect(onDeselect).toBeCalledTimes(0);
+				});
+
 				it("does not select if feature is not clicked", () => {
 					// Square Polygon
 					addPolygonToStore([

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -97,12 +97,14 @@ interface TerraDrawSelectModeOptions<T extends CustomStyling>
 	keyEvents?: TerraDrawSelectModeKeyEvents | null;
 	dragEventThrottle?: number;
 	cursors?: Cursors;
+	allowManualDeselection?: boolean;
 }
 
 export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling> {
 	public type = ModeTypes.Select;
 	public mode = "select";
 
+	private allowManualDeselection = true;
 	private dragEventThrottle = 5;
 	private dragEventCount = 0;
 	private selected: string[] = [];
@@ -168,6 +170,8 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 				options.dragEventThrottle !== undefined &&
 				options.dragEventThrottle) ||
 			5;
+
+		this.allowManualDeselection = options?.allowManualDeselection ?? true;
 	}
 
 	setSelecting() {
@@ -367,7 +371,6 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 	private onLeftClick(event: TerraDrawMouseEvent) {
 		const { clickedFeature, clickedMidPoint } = this.featuresAtMouseEvent.find(
 			event,
-
 			this.selected.length > 0,
 		);
 
@@ -448,7 +451,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseDrawMode<SelectionStyling>
 					);
 				}
 			}
-		} else if (this.selected.length) {
+		} else if (this.selected.length && this.allowManualDeselection) {
 			this.deselect();
 			return;
 		}


### PR DESCRIPTION
## Description of Changes

Provides a flag for Select Mode, `allowManualDeselection` which when set to false, will prevent the user from being able to deselect when the click/tap on the map.

## Link to Issue

#186 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 