### PR TITLE
fix: create ready event which can be used by the Google Maps Adapter to avoid async issues

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -383,19 +383,25 @@ const example = {
 			);
 
 			map.addListener("projection_changed", () => {
+				const adapter = new TerraDrawGoogleMapsAdapter({
+					lib: google.maps,
+					map,
+					coordinatePrecision: 9,
+				});
+
 				const draw = new TerraDraw({
-					adapter: new TerraDrawGoogleMapsAdapter({
-						lib: google.maps,
-						map,
-						coordinatePrecision: 9,
-					}),
+					adapter,
 					modes: getModes(),
 				});
+
 				draw.start();
 
-				addModeChangeHandler(draw, currentSelected);
-
-				this.initialised.push("google");
+				draw.on("ready", () => {
+					// If we wanted to do operaations which require project/unproject
+					// we ould ned to do them in here
+					this.initialised.push("google");
+					addModeChangeHandler(draw, currentSelected);
+				});
 			});
 		});
 	},

--- a/guides/3.ADAPTERS.md
+++ b/guides/3.ADAPTERS.md
@@ -191,6 +191,7 @@ draw.setMode("freehand");
 > There are some requirements for the Google Map Adapter to work correctly:
 > 1) The Google Maps API requires an `apiKey` property when loading the library.
 > 2) The map element must have a id property set
+> 3) Because an OverlayView is created, which can only be done asynchronously, you _must_ wait for the 'ready' event on the draw instance
 
 ```javascript
 // Import Google Maps
@@ -238,7 +239,12 @@ loader.load().then((google) => {
 
     // Start drawing
     draw.start();
-    draw.setMode("freehand");
+
+    // Unlike other adapters, the google adapter 'ready' event is required to be listened for
+    // because the adapter creates an OverlayView which is only ready asynchronously
+    draw.on('ready', () => {
+      draw.setMode("freehand");
+    })
   });
 });
 ```

--- a/src/adapters/arcgis-maps-sdk.adapter.ts
+++ b/src/adapters/arcgis-maps-sdk.adapter.ts
@@ -75,6 +75,10 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawBaseAdapter {
 				event.stopPropagation();
 			}
 		});
+
+		this._currentModeCallbacks &&
+			this._currentModeCallbacks.onReady &&
+			this._currentModeCallbacks.onReady();
 	}
 
 	public unregister() {

--- a/src/adapters/leaflet.adapter.ts
+++ b/src/adapters/leaflet.adapter.ts
@@ -2,6 +2,7 @@ import {
 	TerraDrawChanges,
 	SetCursor,
 	TerraDrawStylingFunction,
+	TerraDrawCallbacks,
 } from "../common";
 import L from "leaflet";
 import { GeoJSONStoreFeatures } from "../store/store";
@@ -293,5 +294,13 @@ export class TerraDrawLeafletAdapter extends TerraDrawBaseAdapter {
 			this.clearLayers();
 			this.clearPanes();
 		}
+	}
+
+	public register(callbacks: TerraDrawCallbacks) {
+		super.register(callbacks);
+
+		this._currentModeCallbacks &&
+			this._currentModeCallbacks.onReady &&
+			this._currentModeCallbacks.onReady();
 	}
 }

--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -2,6 +2,7 @@ import {
 	TerraDrawChanges,
 	SetCursor,
 	TerraDrawStylingFunction,
+	TerraDrawCallbacks,
 } from "../common";
 import { Feature, LineString, Point, Polygon } from "geojson";
 import mapboxgl, {
@@ -447,5 +448,12 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 			// Then clean up rendering
 			this.clearLayers();
 		}
+	}
+
+	public register(callbacks: TerraDrawCallbacks) {
+		super.register(callbacks);
+		this._currentModeCallbacks &&
+			this._currentModeCallbacks.onReady &&
+			this._currentModeCallbacks.onReady();
 	}
 }

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -2,6 +2,7 @@ import {
 	TerraDrawChanges,
 	SetCursor,
 	TerraDrawStylingFunction,
+	TerraDrawCallbacks,
 } from "../common";
 import { FeatureId, GeoJSONStoreFeatures } from "../store/store";
 import CircleGeom from "ol/geom/Circle";
@@ -309,7 +310,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	 * Clears the map and store of all rendered data layers
 	 * @returns void
 	 * */
-	clear() {
+	public clear() {
 		if (this._currentModeCallbacks) {
 			// Clean up state first
 			this._currentModeCallbacks.onClear();
@@ -317,5 +318,12 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 			// Then clean up rendering
 			this.clearLayers();
 		}
+	}
+
+	public register(callbacks: TerraDrawCallbacks) {
+		super.register(callbacks);
+		this._currentModeCallbacks &&
+			this._currentModeCallbacks.onReady &&
+			this._currentModeCallbacks.onReady();
 	}
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -114,6 +114,7 @@ export interface TerraDrawCallbacks {
 		setMapDraggability: (enabled: boolean) => void,
 	) => void;
 	onClear: () => void;
+	onReady?(): void;
 }
 
 export interface TerraDrawChanges {

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -51,6 +51,7 @@ type SelectListener = (id: FeatureId) => void;
 type DeselectListener = () => void;
 
 interface TerraDrawEventListeners {
+	ready: () => void;
 	finish: FinishListener;
 	change: ChangeListener;
 	select: SelectListener;
@@ -66,6 +67,7 @@ class TerraDraw {
 	private _enabled = false;
 	private _store: GeoJSONStore;
 	private _eventListeners: {
+		ready: (() => void)[];
 		change: ChangeListener[];
 		finish: FinishListener[];
 		select: SelectListener[];
@@ -121,7 +123,13 @@ class TerraDraw {
 		});
 
 		this._modes = { ...modesMap, static: this._mode };
-		this._eventListeners = { change: [], select: [], deselect: [], finish: [] };
+		this._eventListeners = {
+			change: [],
+			select: [],
+			deselect: [],
+			finish: [],
+			ready: [],
+		};
 		this._store = new GeoJSONStore<FeatureId>({
 			tracked: options.tracked ? true : false,
 			idStrategy: options.idStrategy ? options.idStrategy : undefined,
@@ -570,6 +578,11 @@ class TerraDraw {
 	start() {
 		this._enabled = true;
 		this._adapter.register({
+			onReady: () => {
+				this._eventListeners.ready.forEach((listener) => {
+					listener();
+				});
+			},
 			getState: () => {
 				return this._mode.state;
 			},

--- a/src/test/mock-callbacks.ts
+++ b/src/test/mock-callbacks.ts
@@ -12,5 +12,6 @@ export const createMockCallbacks = (
 	onDrag: jest.fn(),
 	onDragEnd: jest.fn(),
 	onClear: jest.fn(),
+	onReady: jest.fn(),
 	...overrides,
 });


### PR DESCRIPTION
## Description of Changes

Frustratingly Google Maps has an asynchronous aspect to it's setup when we add the OverlayView, we need to wait for it to be ready to get the projection from it, and it in turn it's methods for going from latitude, longitude to pixel space and vice versa.

To account for this a 'ready' event is added to Terra Draw, and Google Maps Adapter must wait for it be called before operating further with the Terra Draw instance.

To an extent the ready event may be generally useful for other adapters to, although the adapters will (in there existing state) _always_ be ready after calling 'start'.

## Link to Issue

#199 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 