### PR TITLE
feat: add planar options, opposite-planar and center-planar for resizeable in select mode

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -137,8 +137,8 @@ const selectMode = new TerraDrawSelectMode({
           // [Requires draggable to be true] allow resizing of the geometry from 
           // a given origin. Center fixed will allow resizing on fixed aspect ratio from the center
           // and opposite-fixed allows resizing from the opposite corner of the bounding box 
-          // of the geometry.
-          resizeable: 'center-fixed', // can also be 'opposite-fixed'
+          // of the geometry. Defaults to geodesic transforms, unless planar options are used.
+          resizeable: 'center-fixed', // can also be 'opposite-fixed', 'opposite-planar', 'center', 'center-planar'
 
           // Can be deleted
           deletable: true,


### PR DESCRIPTION
## Description of Changes

It is noted that resizing uses geodesic transforms under the hood, so two planar options have been added for those not wanting to have visual distortions when resizing. 

## Link to Issue

No issue

## PR Checklist

- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 