### PR TITLE
fix: ensure 'finish' event is called for selected polygons with resizeable option

### DIFF
--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -2984,6 +2984,126 @@ describe("TerraDrawSelectMode", () => {
 			expect(onFinish).toBeCalledTimes(1);
 			expect(onFinish).toBeCalledWith(expect.any(String));
 		});
+
+		it.only("fires onFinish for resizeable if it is currently being dragged", () => {
+			setSelectMode({
+				flags: {
+					polygon: {
+						feature: {
+							coordinates: { draggable: true, resizable: "center-fixed" },
+						},
+					},
+				},
+			});
+			// We want to account for ignoring points branch
+			addPointToStore([100, 89]);
+
+			expect(onChange).toBeCalledTimes(1);
+
+			addPolygonToStore([
+				[0, 0],
+				[0, 1],
+				[1, 1],
+				[1, 0],
+				[0, 0],
+			]);
+
+			expect(onChange).toBeCalledTimes(2);
+
+			mockMouseEventBoundingBox();
+
+			project
+				.mockReturnValueOnce({
+					x: 100,
+					y: 100,
+				})
+				.mockReturnValue({
+					x: 0,
+					y: 0,
+				});
+
+			selectMode.onClick({
+				lng: 0,
+				lat: 0,
+				containerX: 0,
+				containerY: 0,
+				button: "left",
+				heldKeys: [],
+			});
+
+			expect(onSelect).toBeCalledTimes(1);
+			expect(onChange).toBeCalledTimes(4);
+
+			// Select feature
+			expect(onChange).toHaveBeenNthCalledWith(
+				3,
+				[expect.any(String)],
+				"update",
+			);
+
+			// Create selection points
+			expect(onChange).toHaveBeenNthCalledWith(
+				4,
+				[
+					expect.any(String),
+					expect.any(String),
+					expect.any(String),
+					expect.any(String),
+				],
+				"create",
+			);
+
+			mockMouseEventBoundingBox();
+			project
+				.mockReturnValueOnce({
+					x: 100,
+					y: 100,
+				})
+				.mockReturnValue({
+					x: 0,
+					y: 0,
+				});
+
+			selectMode.onDragStart(
+				{
+					lng: 1,
+					lat: 1,
+					containerX: 1,
+					containerY: 1,
+					button: "left",
+					heldKeys: [],
+				},
+				jest.fn(),
+			);
+
+			const setMapDraggability = jest.fn();
+			selectMode.onDrag(
+				{
+					lng: 1,
+					lat: 1,
+					containerX: 1,
+					containerY: 1,
+					button: "left",
+					heldKeys: [],
+				},
+				setMapDraggability,
+			);
+
+			selectMode.onDragEnd(
+				{
+					lng: 1,
+					lat: 1,
+					containerX: 1,
+					containerY: 1,
+					button: "left",
+					heldKeys: [],
+				},
+				setMapDraggability,
+			);
+
+			expect(onFinish).toBeCalledTimes(1);
+			expect(onFinish).toBeCalledWith(expect.any(String));
+		});
 	});
 
 	describe("onMouseMove", () => {

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -594,19 +594,20 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			modeFlags &&
 			modeFlags.feature &&
 			modeFlags.feature.coordinates &&
-			modeFlags.feature.coordinates.draggable &&
+			(modeFlags.feature.coordinates.draggable ||
+				modeFlags.feature.coordinates.resizable) &&
 			draggableCoordinateIndex !== -1
 		) {
 			this.setCursor(this.cursors.dragStart);
 
-			// With Maintained Shape
+			// With resizeable
 			if (modeFlags.feature.coordinates.resizable) {
 				this.dragCoordinateResizeFeature.startDragging(
 					selectedId,
 					draggableCoordinateIndex,
 				);
 			} else {
-				// Without with Maintained Shape
+				// Without with resizable being set
 				this.dragCoordinate.startDragging(selectedId, draggableCoordinateIndex);
 			}
 
@@ -721,6 +722,8 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		if (this.dragCoordinate.isDragging()) {
 			this.onFinish(this.selected[0]);
 		} else if (this.dragFeature.isDragging()) {
+			this.onFinish(this.selected[0]);
+		} else if (this.dragCoordinateResizeFeature.isDragging()) {
 			this.onFinish(this.selected[0]);
 		}
 


### PR DESCRIPTION
## Description of Changes

Triggers 'finish' event on resizeable call

Adds unit test to ensure it works as expected

## Link to Issue

#209 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 