### PR TITLE
fix: make it so resizeable no longer requires draggable to be true to work

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -134,11 +134,13 @@ const selectMode = new TerraDrawSelectMode({
           // Can be moved
           draggable: true,
 
-          // [Requires draggable to be true] allow resizing of the geometry from 
-          // a given origin. Center fixed will allow resizing on fixed aspect ratio from the center
+          // Allow resizing of the geometry from a given origin. 
+          // center-fixed will allow resizing on fixed aspect ratio from the center
           // and opposite-fixed allows resizing from the opposite corner of the bounding box 
-          // of the geometry. Defaults to geodesic transforms, unless planar options are used.
-          resizeable: 'center-fixed', // can also be 'opposite-fixed', 'opposite-planar', 'center', 'center-planar'
+          // of the geometry. Defaults to geodesic transforms, unless planar options are 
+          // used such as center-planar or opposite-planar. Will take priority over draggable
+          // if set to a value.
+          resizeable: 'opposite-planar', // can also be 'opposite-fixed', 'opposite-planar', 'center', 'center-planar'
 
           // Can be deleted
           deletable: true,

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -2985,12 +2985,12 @@ describe("TerraDrawSelectMode", () => {
 			expect(onFinish).toBeCalledWith(expect.any(String));
 		});
 
-		it.only("fires onFinish for resizeable if it is currently being dragged", () => {
+		it("fires onFinish for resizeable if it is currently being dragged", () => {
 			setSelectMode({
 				flags: {
 					polygon: {
 						feature: {
-							coordinates: { draggable: true, resizable: "center-fixed" },
+							coordinates: { resizable: "center-fixed" },
 						},
 					},
 				},

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -575,7 +575,9 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			modeFlags.feature &&
 			(modeFlags.feature.draggable ||
 				(modeFlags.feature.coordinates &&
-					modeFlags.feature.coordinates.draggable));
+					modeFlags.feature.coordinates.draggable) ||
+				(modeFlags.feature.coordinates &&
+					modeFlags.feature.coordinates.resizable));
 
 		if (!draggable) {
 			return;


### PR DESCRIPTION
## Description of Changes

Before, you needed `draggable` to be true for `resizable` to work 

## Link to Issue

No issue

## PR Checklist

- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 