### PR TITLE
fix: ensure that project returns valid lat/lng when using resizable

### DIFF
--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -242,7 +242,14 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 				continue;
 			}
 
-			const bboxPixelCoordinate = this.config.project(bbox[i][0], bbox[i][1]);
+			// Projecting can sometimes cause invalid coordinates
+			let bboxPixelCoordinate;
+			try {
+				bboxPixelCoordinate = this.config.project(bbox[i][0], bbox[i][1]);
+			} catch (_) {
+				return false;
+			}
+
 			const distanceToOtherBboxCoordinate = this.pixelDistance.measure(
 				{
 					containerX: bboxPixelCoordinate.x,


### PR DESCRIPTION
## Description of Changes

Fixes errors when resizing, due to errors thrown by some adapters project methods

## Link to Issue

#215

## PR Checklist

- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 