### PR TITLE
fix: resizeable dragging should now track the cursor much more accurately

### DIFF
--- a/e2e/tests/leaflet.spec.ts
+++ b/e2e/tests/leaflet.spec.ts
@@ -352,7 +352,7 @@ test.describe("select mode", () => {
 		await page.mouse.click(mapDiv.width - 10, mapDiv.height / 2);
 
 		// Dragged the square up and to the left
-		await expectGroupPosition({ page, x: 547, y: 267 });
+		await expectGroupPosition({ page, x: 546, y: 266 });
 	});
 
 	test("selected circle can has it's shape maintained from center origin when coordinates are dragged", async ({
@@ -384,7 +384,7 @@ test.describe("select mode", () => {
 		await page.mouse.click(mapDiv.width - 10, mapDiv.height / 2);
 
 		// Dragged the square up and to the left
-		await expectGroupPosition({ page, x: 392, y: 112 });
+		await expectGroupPosition({ page, x: 430, y: 150 });
 	});
 });
 

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -169,7 +169,6 @@ describe("DragCoordinateResizeBehavior", () => {
 					}
 
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
@@ -188,7 +187,6 @@ describe("DragCoordinateResizeBehavior", () => {
 							.mockReturnValueOnce({ x: 100, y: 100 });
 					}
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "center-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
@@ -211,7 +209,6 @@ describe("DragCoordinateResizeBehavior", () => {
 							.mockReturnValueOnce({ x: 100, y: 100 });
 					}
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite-fixed");
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
@@ -236,7 +233,6 @@ describe("DragCoordinateResizeBehavior", () => {
 					}
 
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite-fixed");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite-fixed");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
@@ -259,7 +255,6 @@ describe("DragCoordinateResizeBehavior", () => {
 					}
 
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);
 				});
@@ -278,7 +273,6 @@ describe("DragCoordinateResizeBehavior", () => {
 							.mockReturnValueOnce({ x: 100, y: 100 });
 					}
 
-					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
 					dragMaintainedShapeBehavior.drag(mockDrawEvent(), "opposite");
 
 					expect(config.store.updateGeometry).toBeCalledTimes(1);


### PR DESCRIPTION
## Description of Changes

Fixes the issue when using `resizeable` that the cursor does not always correctly track the selection point when dragging, especially when done quickly or erratically. 

## Link to Issue

#214

Originally #191 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 