### PR TITLE
fix: ensure that when using resizable you cannot resize after crossing origin axis

### DIFF
--- a/e2e/tests/leaflet.spec.ts
+++ b/e2e/tests/leaflet.spec.ts
@@ -352,7 +352,7 @@ test.describe("select mode", () => {
 		await page.mouse.click(mapDiv.width - 10, mapDiv.height / 2);
 
 		// Dragged the square up and to the left
-		await expectGroupPosition({ page, x: 546, y: 266 });
+		await expectGroupPosition({ page, x: 584, y: 304 });
 	});
 
 	test("selected circle can has it's shape maintained from center origin when coordinates are dragged", async ({

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -168,6 +168,12 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			{ x: originX, y: originY },
 		);
 
+		// This will mean that the cursor is not near the dragged coordinate
+		// and we should not scale
+		if (distanceSelectedToCursor > this.pointerDistance) {
+			return false;
+		}
+
 		const distanceOriginToSelected = pixelDistance(
 			{ x: originX, y: originY },
 			{ x: selectedX, y: selectedY },


### PR DESCRIPTION
## Description of Changes

Prevents issue where you cross the origin axis and can still resize inside planar settings of `resizeable`. 

## Link to Issue

#218 
#191 

## PR Checklist

- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 