### PR TITLE
fix: Resolve issue with center-fixed-web-mercator and center-web-mercator

### DIFF
--- a/src/geometry/web-mercator-center.spec.ts
+++ b/src/geometry/web-mercator-center.spec.ts
@@ -1,0 +1,27 @@
+import { webMercatorCenter } from "./web-mercator-center";
+
+describe("webMercatorCenter", () => {
+	it("returns the web mecator center correctly", () => {
+		const result = webMercatorCenter({
+			type: "Feature",
+			properties: {},
+			geometry: {
+				coordinates: [
+					[
+						[60.15177901043299, 18.599398042438764],
+						[60.15177901043299, 12.900268744312697],
+						[63.75086634124065, 12.900268744312697],
+						[63.75086634124065, 18.599398042438764],
+						[60.15177901043299, 18.599398042438764],
+					],
+				],
+				type: "Polygon",
+			},
+		});
+
+		expect(result).toStrictEqual({
+			x: 6896389.694243937,
+			y: 1778084.1594212404,
+		});
+	});
+});

--- a/src/geometry/web-mercator-center.ts
+++ b/src/geometry/web-mercator-center.ts
@@ -1,0 +1,39 @@
+import { Feature, LineString, Polygon, Position } from "geojson";
+import { lngLatToWebMercatorXY } from "./project/web-mercator";
+
+function bbox(coords: Position[]) {
+	const result = [Infinity, Infinity, -Infinity, -Infinity];
+	for (let i = 0; i < coords.length; i++) {
+		const coord = coords[i];
+		if (result[0] > coord[0]) {
+			result[0] = coord[0];
+		}
+		if (result[1] > coord[1]) {
+			result[1] = coord[1];
+		}
+		if (result[2] < coord[0]) {
+			result[2] = coord[0];
+		}
+		if (result[3] < coord[1]) {
+			result[3] = coord[1];
+		}
+	}
+	return result;
+}
+
+export function webMercatorCenter(feature: Feature<Polygon | LineString>) {
+	const coordinates =
+		feature.geometry.type === "Polygon"
+			? feature.geometry.coordinates[0]
+			: feature.geometry.coordinates;
+
+	const webMercatorCoordinates = coordinates.map((coord) => {
+		const { x, y } = lngLatToWebMercatorXY(coord[0], coord[1]);
+		return [x, y];
+	});
+
+	const ext = bbox(webMercatorCoordinates);
+	const x = (ext[0] + ext[2]) / 2;
+	const y = (ext[1] + ext[3]) / 2;
+	return { x, y };
+}

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -9,7 +9,6 @@ import {
 	GeoJSONStoreFeatures,
 	GeoJSONStoreGeometries,
 } from "../../../store/store";
-import { centroid } from "../../../geometry/centroid";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 import { pixelDistance } from "../../../geometry/measure/pixel-distance";
 import { coordinateIsValid } from "../../../geometry/boolean/is-valid-coordinate";
@@ -17,6 +16,7 @@ import {
 	lngLatToWebMercatorXY,
 	webMercatorXYToLngLat,
 } from "../../../geometry/project/web-mercator";
+import { webMercatorCenter } from "../../../geometry/web-mercator-center";
 
 export type ResizeOptions =
 	| "center-web-mercator"
@@ -207,9 +207,9 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const { feature, boundingBox, updatedCoords, selectedCoordinate } =
 			featureData;
 
-		const center = centroid(feature);
+		const webMercatorOrigin = webMercatorCenter(feature);
 
-		if (!center) {
+		if (!webMercatorOrigin) {
 			return null;
 		}
 
@@ -223,7 +223,6 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorSelected,
 		);
 
-		const webMercatorOrigin = lngLatToWebMercatorXY(center[0], center[1]);
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
 		this.scaleWebMercator({
@@ -245,9 +244,9 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const { feature, boundingBox, updatedCoords, selectedCoordinate } =
 			featureData;
 
-		const center = centroid(feature);
+		const webMercatorOrigin = webMercatorCenter(feature);
 
-		if (!center) {
+		if (!webMercatorOrigin) {
 			return null;
 		}
 
@@ -261,7 +260,6 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorSelected,
 		);
 
-		const webMercatorOrigin = lngLatToWebMercatorXY(center[0], center[1]);
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
 		this.scaleFixedWebMercator({


### PR DESCRIPTION
## Description of Changes

It was not taking into account that the center was the geodesic center and not the web mercator center. This caused movement of the polygon as it was resized.

## Link to Issue

Potentially resolves #243 but hard to say without more feedback.

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 