### PR TITLE
feat: add a context to allow more complex validations when selecting

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -144,7 +144,11 @@ const selectMode = new TerraDrawSelectMode({
           deletable: true,
 
           // Provide a custom validation that will run when we attempt to edit the geometry
-          validation: (feature) => {
+          validation: (feature, context) => {
+
+              // context has the methods project and unproject and be used to go from screen space 
+              // to geographic space and vice versa
+
               // ValidateMinSizeSquareMeters can be imported from Terra Draw
 					    return feature.geometry.type !== "Polygon" && ValidateMinSizeSquareMeters(feature.geometry, 1000);
           }

--- a/src/common.ts
+++ b/src/common.ts
@@ -87,6 +87,15 @@ export interface TerraDrawModeRegisterConfig {
 	coordinatePrecision: number;
 }
 
+type ValidationContext = Pick<
+	TerraDrawModeRegisterConfig,
+	"project" | "unproject" | "coordinatePrecision"
+>;
+export type Validation = (
+	feature: GeoJSONStoreFeatures,
+	context: ValidationContext,
+) => boolean;
+
 export type TerraDrawModeState =
 	| "unregistered"
 	| "registered"

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -156,6 +156,34 @@ describe("DragCoordinateResizeBehavior", () => {
 				expect(config.store.updateGeometry).toBeCalledTimes(0);
 			});
 
+			describe("validation", () => {
+				it("should not update if validation function returns false", () => {
+					const id = createStorePolygon(config);
+
+					dragMaintainedShapeBehavior.startDragging(id, 0);
+
+					jest.spyOn(config.store, "updateGeometry");
+
+					// Mock the projection for the cooridinates of the bounding box
+					// when measuring against them to prevent overlap
+					for (let i = 0; i < 10; i++) {
+						(config.project as jest.Mock)
+							.mockReturnValueOnce({ x: 0, y: 0 })
+							.mockReturnValueOnce({ x: 100, y: 100 });
+					}
+
+					dragMaintainedShapeBehavior.drag(
+						mockDrawEvent(),
+						"center-web-mercator",
+						() => {
+							return false;
+						},
+					);
+
+					expect(config.store.updateGeometry).toBeCalledTimes(0);
+				});
+			});
+
 			describe("center-web-mercator", () => {
 				it("updates the Polygon coordinate if within pointer distance", () => {
 					const id = createStorePolygon(config);

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -1,14 +1,10 @@
-import { TerraDrawMouseEvent } from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { LineString, Polygon, Position, Point, Feature } from "geojson";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
-import {
-	FeatureId,
-	GeoJSONStoreFeatures,
-	GeoJSONStoreGeometries,
-} from "../../../store/store";
+import { FeatureId, GeoJSONStoreGeometries } from "../../../store/store";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 import { pixelDistance } from "../../../geometry/measure/pixel-distance";
 import { coordinateIsValid } from "../../../geometry/boolean/is-valid-coordinate";
@@ -671,7 +667,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	public drag(
 		event: TerraDrawMouseEvent,
 		resizeOption: ResizeOptions,
-		validateFeature?: (feature: GeoJSONStoreFeatures) => boolean,
+		validateFeature?: Validation,
 	): boolean {
 		if (!this.draggedCoordinate.id) {
 			return false;
@@ -722,12 +718,19 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		} as GeoJSONStoreGeometries;
 
 		if (validateFeature) {
-			const valid = validateFeature({
-				id: this.draggedCoordinate.id,
-				type: "Feature",
-				geometry: updatedGeometry,
-				properties: {},
-			});
+			const valid = validateFeature(
+				{
+					id: this.draggedCoordinate.id,
+					type: "Feature",
+					geometry: updatedGeometry,
+					properties: {},
+				},
+				{
+					project: this.config.project,
+					unproject: this.config.unproject,
+					coordinatePrecision: this.config.coordinatePrecision,
+				},
+			);
 			if (!valid) {
 				return false;
 			}

--- a/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -151,6 +151,44 @@ describe("DragCoordinateBehavior", () => {
 				expect(config.store.updateGeometry).toBeCalledTimes(0);
 			});
 
+			it("validation returning false means updates are not called", () => {
+				const id = createStorePolygon(config);
+
+				dragCoordinateBehavior.startDragging(id, 0);
+
+				jest.spyOn(config.store, "updateGeometry");
+
+				(config.project as jest.Mock)
+					.mockReturnValueOnce({ x: 0, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 0 });
+
+				dragCoordinateBehavior.drag(mockDrawEvent(), true, () => false);
+
+				expect(config.store.updateGeometry).toBeCalledTimes(0);
+			});
+
+			it("validation returning false means updates are not called", () => {
+				const id = createStorePolygon(config);
+
+				dragCoordinateBehavior.startDragging(id, 0);
+
+				jest.spyOn(config.store, "updateGeometry");
+
+				(config.project as jest.Mock)
+					.mockReturnValueOnce({ x: 0, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 1 })
+					.mockReturnValueOnce({ x: 1, y: 0 })
+					.mockReturnValueOnce({ x: 0, y: 0 });
+
+				dragCoordinateBehavior.drag(mockDrawEvent(), true, () => true);
+
+				expect(config.store.updateGeometry).toBeCalledTimes(1);
+			});
+
 			it("updates the Polygon coordinate if within pointer distance", () => {
 				const id = createStorePolygon(config);
 

--- a/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent } from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 
 import { LineString, Polygon, Position, Point, Feature } from "geojson";
@@ -6,7 +6,7 @@ import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { selfIntersects } from "../../../geometry/boolean/self-intersects";
-import { FeatureId, GeoJSONStoreFeatures } from "../../../store/store";
+import { FeatureId } from "../../../store/store";
 
 export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -88,7 +88,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 	public drag(
 		event: TerraDrawMouseEvent,
 		allowSelfIntersection: boolean,
-		validateFeature?: (feature: GeoJSONStoreFeatures) => boolean,
+		validateFeature?: Validation,
 	): boolean {
 		if (!this.draggedCoordinate.id) {
 			return false;
@@ -155,12 +155,20 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		}
 
 		if (validateFeature) {
-			const valid = validateFeature({
-				type: "Feature",
-				id: this.draggedCoordinate.id,
-				geometry,
-				properties: {},
-			});
+			const valid = validateFeature(
+				{
+					type: "Feature",
+					id: this.draggedCoordinate.id,
+					geometry,
+					properties: {},
+				},
+				{
+					project: this.config.project,
+					unproject: this.config.unproject,
+					coordinatePrecision: this.config.coordinatePrecision,
+				},
+			);
+
 			if (!valid) {
 				return false;
 			}

--- a/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -138,6 +138,54 @@ describe("DragFeatureBehavior", () => {
 				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
 				expect(config.store.updateGeometry).toBeCalledTimes(1);
 			});
+
+			it("validation returning false does not update the polygon to the dragged position", () => {
+				const id = createStorePolygon(config);
+				const event = mockDrawEvent({ lat: 0.5, lng: 0.5 });
+
+				dragFeatureBehavior.startDragging(event, id);
+
+				jest.spyOn(config.store, "updateGeometry");
+				jest.spyOn(config.store, "getGeometryCopy");
+
+				// Mock the unproject to return a valid set
+				// of bbox coordinates
+				(config.unproject as jest.Mock)
+					.mockImplementationOnce(() => ({ lng: 0, lat: 1 }))
+					.mockImplementationOnce(() => ({ lng: 1, lat: 1 }))
+					.mockImplementationOnce(() => ({ lng: 1, lat: 0 }))
+					.mockImplementationOnce(() => ({ lng: 0, lat: 0 }))
+					.mockImplementationOnce(() => ({ lng: 0, lat: 1 }));
+
+				dragFeatureBehavior.drag(mockDrawEvent(), () => false);
+
+				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toBeCalledTimes(0);
+			});
+
+			it("validation returning true does update the polygon to the dragged position", () => {
+				const id = createStorePolygon(config);
+				const event = mockDrawEvent({ lat: 0.5, lng: 0.5 });
+
+				dragFeatureBehavior.startDragging(event, id);
+
+				jest.spyOn(config.store, "updateGeometry");
+				jest.spyOn(config.store, "getGeometryCopy");
+
+				// Mock the unproject to return a valid set
+				// of bbox coordinates
+				(config.unproject as jest.Mock)
+					.mockImplementationOnce(() => ({ lng: 0, lat: 1 }))
+					.mockImplementationOnce(() => ({ lng: 1, lat: 1 }))
+					.mockImplementationOnce(() => ({ lng: 1, lat: 0 }))
+					.mockImplementationOnce(() => ({ lng: 0, lat: 0 }))
+					.mockImplementationOnce(() => ({ lng: 0, lat: 1 }));
+
+				dragFeatureBehavior.drag(mockDrawEvent(), () => true);
+
+				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toBeCalledTimes(1);
+			});
 		});
 	});
 });

--- a/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -1,11 +1,11 @@
-import { TerraDrawMouseEvent } from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
-import { FeatureId, GeoJSONStoreFeatures } from "../../../store/store";
+import { FeatureId } from "../../../store/store";
 
 export class DragFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -47,10 +47,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 		return true;
 	}
 
-	drag(
-		event: TerraDrawMouseEvent,
-		validateFeature?: (feature: GeoJSONStoreFeatures) => boolean,
-	) {
+	drag(event: TerraDrawMouseEvent, validateFeature?: Validation) {
 		if (!this.draggedFeatureId) {
 			return;
 		}
@@ -124,12 +121,20 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 			const updatedMidPoints = this.midPoints.getUpdated(updatedCoords) || [];
 
 			if (validateFeature) {
-				const valid = validateFeature({
-					type: "Feature",
-					id: this.draggedFeatureId,
-					geometry,
-					properties: {},
-				});
+				const valid = validateFeature(
+					{
+						type: "Feature",
+						id: this.draggedFeatureId,
+						geometry,
+						properties: {},
+					},
+					{
+						project: this.config.project,
+						unproject: this.config.unproject,
+						coordinatePrecision: this.config.coordinatePrecision,
+					},
+				);
+
 				if (!valid) {
 					return false;
 				}

--- a/src/modes/select/behaviors/rotate-feature.behavior.ts
+++ b/src/modes/select/behaviors/rotate-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent } from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { LineString, Polygon, Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -7,7 +7,7 @@ import { transformRotate } from "../../../geometry/transform/rotate";
 import { centroid } from "../../../geometry/centroid";
 import { rhumbBearing } from "../../../geometry/measure/rhumb-bearing";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
-import { FeatureId, GeoJSONStoreFeatures } from "../../../store/store";
+import { FeatureId } from "../../../store/store";
 
 export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -27,7 +27,7 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 	rotate(
 		event: TerraDrawMouseEvent,
 		selectedId: FeatureId,
-		validateFeature?: (feature: GeoJSONStoreFeatures) => boolean,
+		validateFeature?: Validation,
 	) {
 		const geometry = this.store.getGeometryCopy<LineString | Polygon>(
 			selectedId,
@@ -74,12 +74,19 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 
 		if (validateFeature) {
 			if (
-				!validateFeature({
-					id: selectedId,
-					type: "Feature",
-					geometry,
-					properties: {},
-				})
+				!validateFeature(
+					{
+						id: selectedId,
+						type: "Feature",
+						geometry,
+						properties: {},
+					},
+					{
+						project: this.config.project,
+						unproject: this.config.unproject,
+						coordinatePrecision: this.config.coordinatePrecision,
+					},
+				)
 			) {
 				return false;
 			}

--- a/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent } from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { Feature, LineString, Polygon, Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -7,7 +7,7 @@ import { centroid } from "../../../geometry/centroid";
 import { haversineDistanceKilometers } from "../../../geometry/measure/haversine-distance";
 import { transformScale } from "../../../geometry/transform/scale";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
-import { FeatureId, GeoJSONStoreFeatures } from "../../../store/store";
+import { FeatureId } from "../../../store/store";
 
 export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -27,7 +27,7 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 	scale(
 		event: TerraDrawMouseEvent,
 		selectedId: FeatureId,
-		validateFeature?: (feature: GeoJSONStoreFeatures) => boolean,
+		validateFeature?: Validation,
 	) {
 		const geometry = this.store.getGeometryCopy<LineString | Polygon>(
 			selectedId,
@@ -78,12 +78,19 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 
 		if (validateFeature) {
 			if (
-				!validateFeature({
-					id: selectedId,
-					type: "Feature",
-					geometry,
-					properties: {},
-				})
+				!validateFeature(
+					{
+						id: selectedId,
+						type: "Feature",
+						geometry,
+						properties: {},
+					},
+					{
+						project: this.config.project,
+						unproject: this.config.unproject,
+						coordinatePrecision: this.config.coordinatePrecision,
+					},
+				)
 			) {
 				return false;
 			}

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -6,6 +6,7 @@ import {
 	HexColorStyling,
 	NumericStyling,
 	Cursor,
+	Validation,
 } from "../../common";
 import { Point, Position } from "geojson";
 import {
@@ -39,7 +40,7 @@ type TerraDrawSelectModeKeyEvents = {
 
 type ModeFlags = {
 	feature?: {
-		validation?: (geometry: GeoJSONStoreFeatures) => boolean;
+		validation?: Validation;
 		draggable?: boolean;
 		rotateable?: boolean;
 		scaleable?: boolean;


### PR DESCRIPTION
## Description of Changes

Aims to provide a context object as the second parameter of the callback for the `validation` flag. This allows users to more easily project/unproject if they need to do things in pixel space.

Also creates a Validation type that can be reused when we move towards adding this for other built in modes too.

## Link to Issue

No issue

## PR Checklist

- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 