### PR TITLE
fix: attempt to fix tsc build issues with implemented abstract methods

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -43,9 +43,6 @@ import SimpleFillSymbol from "@arcgis/core/symbols/SimpleFillSymbol";
 import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
 import Color from "@arcgis/core/Color";
 import SimpleMarkerSymbol from "@arcgis/core/symbols/SimpleMarkerSymbol";
-import { centroid } from "../../src/geometry/centroid";
-import { distance } from "ol/coordinate";
-import { haversineDistanceKilometers } from "../../src/geometry/measure/haversine-distance";
 
 const addModeChangeHandler = (
 	draw: TerraDraw,

--- a/src/adapters/arcgis-maps-sdk.adapter.ts
+++ b/src/adapters/arcgis-maps-sdk.adapter.ts
@@ -93,6 +93,11 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawBaseAdapter {
 		}
 	}
 
+	public getCoordinatePrecision(): number {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.getCoordinatePrecision();
+	}
+
 	/**
 	 * Returns the longitude and latitude coordinates from a given PointerEvent on the map.
 	 * @param event The PointerEvent or MouseEvent  containing the screen coordinates of the pointer.

--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -7,6 +7,7 @@ import {
 	SetCursor,
 	TerraDrawStylingFunction,
 	GetLngLatFromEvent,
+	TerraDrawAdapter,
 } from "../../common";
 import { limitPrecision } from "../../geometry/limit-decimal-precision";
 import { pixelDistance } from "../../geometry/measure/pixel-distance";
@@ -23,7 +24,7 @@ export type BaseAdapterConfig = {
 	minPixelDragDistanceSelecting?: number;
 };
 
-export abstract class TerraDrawBaseAdapter {
+export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 	constructor(config: BaseAdapterConfig) {
 		this._minPixelDragDistance =
 			typeof config.minPixelDragDistance === "number"
@@ -59,7 +60,7 @@ export abstract class TerraDrawBaseAdapter {
 		"not-dragging";
 	protected _currentModeCallbacks: TerraDrawCallbacks | undefined;
 
-	protected abstract getMapEventElement(): HTMLElement;
+	public abstract getMapEventElement(): HTMLElement;
 
 	protected getButton(event: PointerEvent | MouseEvent) {
 		if (event.button === -1) {

--- a/src/adapters/google-maps.adapter.ts
+++ b/src/adapters/google-maps.adapter.ts
@@ -479,4 +479,9 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawBaseAdapter {
 			this.clearLayers();
 		}
 	}
+
+	public getCoordinatePrecision(): number {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.getCoordinatePrecision();
+	}
 }

--- a/src/adapters/leaflet.adapter.ts
+++ b/src/adapters/leaflet.adapter.ts
@@ -303,4 +303,14 @@ export class TerraDrawLeafletAdapter extends TerraDrawBaseAdapter {
 			this._currentModeCallbacks.onReady &&
 			this._currentModeCallbacks.onReady();
 	}
+
+	public getCoordinatePrecision(): number {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.getCoordinatePrecision();
+	}
+
+	public unregister(): void {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.unregister();
+	}
 }

--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -456,6 +456,15 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 		}
 	}
 
+	public getCoordinatePrecision(): number {
+		return super.getCoordinatePrecision();
+	}
+
+	public unregister(): void {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.unregister();
+	}
+
 	public register(callbacks: TerraDrawCallbacks) {
 		super.register(callbacks);
 		this._currentModeCallbacks &&

--- a/src/adapters/maplibre-gl.adapter.ts
+++ b/src/adapters/maplibre-gl.adapter.ts
@@ -35,6 +35,10 @@ export class TerraDrawMapLibreGLAdapter extends TerraDrawBaseAdapter {
 		this.mapboxglAdapter.unregister();
 	}
 
+	public getCoordinatePrecision(): number {
+		return this.mapboxglAdapter.getCoordinatePrecision();
+	}
+
 	/**
 	 * Returns the longitude and latitude coordinates from a given PointerEvent on the map.
 	 * @param event The PointerEvent or MouseEvent  containing the screen coordinates of the pointer.

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -326,4 +326,13 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 			this._currentModeCallbacks.onReady &&
 			this._currentModeCallbacks.onReady();
 	}
+
+	public getCoordinatePrecision(): number {
+		return super.getCoordinatePrecision();
+	}
+
+	public unregister(): void {
+		// TODO: It seems this shouldn't be necessary as extends BaseAdapter which as this method
+		return super.unregister();
+	}
 }


### PR DESCRIPTION
## Description of Changes

In #248 it was reported barebones tsc compilation when using the MapLibre Terra Draw Adapter was failing due to type errors. This is odd, as the offending method getCoordinatePrecision is implemented in the underlying abstract class for which the adapter extends. 

This PR attempts to fix this by explicitly declaring the methods in the extending adapters. This should mean they are always present, even if they are just a proxy for the underlying methods.

It would be great to understand why this as happened, as it seems as if it should be uncessary.

## Link to Issue

#248

## PR Checklist

- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 