### PR TITLE
fix: remove trigger of onClick from contextmenu handler

### DIFF
--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -272,22 +272,6 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 
 					// We do not want the context menu to open
 					event.preventDefault();
-
-					if (
-						this._dragState === "not-dragging" ||
-						this._dragState === "pre-dragging"
-					) {
-						const drawEvent = this.getDrawEventFromEvent(event);
-						if (!drawEvent) {
-							return;
-						}
-
-						// On mobile devices there is no real 'right click'
-						// so we want to make sure the event is genuine in this case
-						if (drawEvent.button !== "neither") {
-							this._currentModeCallbacks.onClick(drawEvent);
-						}
-					}
 				},
 				register: (callback) => {
 					const mapElement = this.getMapEventElement();


### PR DESCRIPTION
## Description of Changes

The `contextmenu` event is triggering the adapter onClick, but right clicking already triggers a `pointerup` event. This leads to a 'double click' effect where both the `contextmenu` event and the `pointerup` event trigger onClick. 

The knock on consequence of this is #250 where two points are deleted. This PR should fix this - I don't think there should be any knock on consequences having manually tested it and examined the codepaths. 

## Link to Issue

<!--- Please provide a link to the issue for reference. If you have not created an issue, please do so before raising a PR so that it is possible to discuss the changes in advance -->

## PR Checklist

- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 