### PR TITLE
chore: actively exclude folders from tsc to keep IDEs happy

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,13 @@
 		"exclude": ["src/geometry/**/*.ts", "src/test/**/*.ts", "src/util/**/*.ts"],
 		"out": "docs",
 		"skipErrorChecking": true
-	}
+	},
+	"exclude": [
+		"node_modules/",
+		"guides/",
+		"docs/",
+		"dist/",
+		"development/dist",
+		"development/node_modules"
+	]
 }


### PR DESCRIPTION
## Description of Changes

Adds folders to the excludes property of `tsconfig.json` as VSCode complained it was having to traverse too many files

## Link to Issue

No issue

## PR Checklist

- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 