### PR TITLE
feat: add validate to all built in modes

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -18,9 +18,10 @@ import {
 	TerraDrawMapLibreGLAdapter,
 	TerraDrawGreatCircleMode,
 	TerraDrawArcGISMapsSDKAdapter,
-	ValidateMinSizeSquareMeters,
+	ValidateMinAreaSquareMeters,
 } from "../../src/terra-draw";
 import { TerraDrawRenderMode } from "../../src/modes/render/render.mode";
+import { ValidateNotSelfIntersecting } from "../../src/validations/not-self-intersecting.validation";
 
 import Circle from "ol/geom/Circle";
 import Feature from "ol/Feature";
@@ -37,7 +38,7 @@ import MapView from "@arcgis/core/views/MapView.js";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
-import Polygon from "@arcgis/core/geometry/Polygon";
+import ArcGISPolygon from "@arcgis/core/geometry/Polygon";
 import Graphic from "@arcgis/core/Graphic";
 import SimpleFillSymbol from "@arcgis/core/symbols/SimpleFillSymbol";
 import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
@@ -134,7 +135,7 @@ const getModes = () => {
 								return false;
 							}
 
-							return ValidateMinSizeSquareMeters(feature.geometry, 1000);
+							return ValidateMinAreaSquareMeters(feature, 1000);
 						},
 						draggable: true,
 						coordinates: {
@@ -155,14 +156,26 @@ const getModes = () => {
 		new TerraDrawPointMode(),
 		new TerraDrawLineStringMode({
 			snapping: true,
-			allowSelfIntersections: false,
+			validate: (feature) => {
+				return ValidateNotSelfIntersecting(feature);
+			},
 		}),
 		new TerraDrawGreatCircleMode({ snapping: true }),
 		new TerraDrawPolygonMode({
 			snapping: true,
-			allowSelfIntersections: false,
+			validate: (feature, { updateType }) => {
+				if (updateType === "finish" || updateType === "commit") {
+					return ValidateNotSelfIntersecting(feature);
+				}
+				return true;
+			},
 		}),
-		new TerraDrawRectangleMode(),
+		new TerraDrawRectangleMode({
+			validate: (feature) => {
+				console.log(feature);
+				return true;
+			},
+		}),
 		new TerraDrawCircleMode(),
 		new TerraDrawFreehandMode(),
 		new TerraDrawRenderMode({
@@ -176,13 +189,14 @@ const getModes = () => {
 	];
 };
 
-let currentSelected: { button: undefined | HTMLButtonElement; mode: string } = {
-	button: undefined,
-	mode: "static",
-};
+const currentSelected: { button: undefined | HTMLButtonElement; mode: string } =
+	{
+		button: undefined,
+		mode: "static",
+	};
 
 // Used by both Mapbox and MapLibre
-let OSMStyle: Object = {
+const OSMStyle = {
 	version: 8,
 	sources: {
 		"osm-tiles": {
@@ -439,7 +453,7 @@ const example = {
 					GraphicsLayer,
 					Point,
 					Polyline,
-					Polygon,
+					Polygon: ArcGISPolygon,
 					Graphic,
 					SimpleLineSymbol,
 					SimpleFillSymbol,

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -19,11 +19,6 @@ const example = {
 	zoom: 12,
 	initialised: [],
 	initLeaflet() {
-		const currentSelected: {
-			mode: undefined | string;
-			button: HTMLButtonElement | undefined;
-		} = { mode: undefined, button: undefined };
-
 		const { lng, lat, zoom } = this;
 
 		const map = L.map("map", {
@@ -38,6 +33,10 @@ const example = {
 				'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		}).addTo(map);
 
+		return map;
+	},
+
+	initDraw(map: L.Map) {
 		const draw = new TerraDraw({
 			adapter: new TerraDrawLeafletAdapter({
 				lib: L,
@@ -102,15 +101,9 @@ const example = {
 					},
 				}),
 				new TerraDrawPointMode(),
-				new TerraDrawLineStringMode({
-					snapping: true,
-					allowSelfIntersections: false,
-				}),
-				new TerraDrawGreatCircleMode({ snapping: true }),
-				new TerraDrawPolygonMode({
-					snapping: true,
-					allowSelfIntersections: false,
-				}),
+				new TerraDrawLineStringMode(),
+				new TerraDrawGreatCircleMode(),
+				new TerraDrawPolygonMode(),
 				new TerraDrawRectangleMode(),
 				new TerraDrawCircleMode(),
 				new TerraDrawFreehandMode(),
@@ -126,6 +119,11 @@ const example = {
 		});
 
 		draw.start();
+
+		const currentSelected: {
+			mode: undefined | string;
+			button: HTMLButtonElement | undefined;
+		} = { mode: undefined, button: undefined };
 
 		[
 			"select",
@@ -162,4 +160,5 @@ const example = {
 	},
 };
 
-example.initLeaflet();
+const map = example.initLeaflet();
+example.initDraw(map);

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -106,6 +106,38 @@ Terra Draw comes with the following built-in Drawing Modes out of the box:
 | Polygon      | [TerraDrawPolygonMode](https://jameslmilner.github.io/terra-draw/classes/TerraDrawPolygonMode.html)         | `polygon`     |
 | Rectangle    | [TerraDrawRectangleMode](https://jameslmilner.github.io/terra-draw/classes/TerraDrawRectangleMode.html)     | `rectangle`   |
 
+#### Validation in Drawing Modes
+
+All built in drawing modes have a base level of validation that runs when a feature is added programmatically i.e. addFeatures (see the [store guide](./2.STORE.md) for more details).  This attempts to prohibit adding corrupt or invalid data to the mode. Terra Draw works on the assumption that features created on the mode are correct to the validation built in standard. As an end developer we can also take this a step further, by using the `validate` property available on all built in modes. `validate` simply takes a function that returns `true` if the Feature is valid or `false` if it is not. You can write any logic you require to validate the geometry. For example, let's say we wanted to ensure all drawn polygons did not self intersect, we could something like this:
+
+```typescript
+polygonMode = new TerraDrawPolygonMode({
+  validate: (feature, { updateType }) => {
+    if (updateType === "finish" || updateType === "commit") {
+      return ValidateNotSelfIntersecting(feature);
+    }
+    return true
+  }
+});
+```
+
+This would stop the user from being able to create a polygon that is self intersecting. Here we use `ValidateNotSelfIntersecting` which is exposed as a Validation from Terra Draw. At the moment Terra Draw exposes 3 built in validations:
+
+- `ValidateMinAreaSquareMeters` - Ensures that a draw Polygon is a minimum size in square meters
+- `ValidateMaxAreaSquareMeters` - Ensures that a draw Polygon is a maximum size in square meters
+- `ValidateNotSelfIntersecting` - Ensures that a draw Polygon or LineString is does not self intersect
+
+You can combine these validations if you so wish. 
+
+You'll notice there are two arguments to the validate function, the first being the feature, the second being the context object. This has useful properties which can help with peforming the validation. One of the most useful properties is the `updateType` property which tells you what type of update the feature is receiving, where the options are `finish`, `commit` or `provisional`.
+
+- `finish` - when the drawing of the feature is being finished
+- `commit` - when a coordinate has been added or removed from the feature
+- `provisonal` - when the geometry has been update, but the coordinate has not been fully committed to the geometry
+
+Using these can help you write more customised behaviours, for example you may only want to run the validation when the update is a `finish` or `commit` type, ensuring that validation is not prematurely preventing user interactions to update the feature.
+
+
 ### Selection Mode
 
 The Selection Mode is used to select Features that have been drawn on the map.
@@ -149,8 +181,8 @@ const selectMode = new TerraDrawSelectMode({
               // context has the methods project and unproject and be used to go from screen space 
               // to geographic space and vice versa
 
-              // ValidateMinSizeSquareMeters can be imported from Terra Draw
-					    return feature.geometry.type !== "Polygon" && ValidateMinSizeSquareMeters(feature.geometry, 1000);
+              // ValidateMinAreaSquareMeters can be imported from Terra Draw
+					    return feature.geometry.type !== "Polygon" && ValidateMinAreaSquareMeters(feature.geometry, 1000);
           }
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3657,54 +3657,16 @@
 			"integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg==",
 			"dev": true
 		},
-		"node_modules/@pkgr/utils": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+		"node_modules/@pkgr/core": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
 			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"fast-glob": "^3.3.0",
-				"is-glob": "^4.0.3",
-				"open": "^9.1.0",
-				"picocolors": "^1.0.0",
-				"tslib": "^2.6.0"
-			},
 			"engines": {
 				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
-			}
-		},
-		"node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@pkgr/utils/node_modules/open": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-			"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-			"dev": true,
-			"dependencies": {
-				"default-browser": "^4.0.0",
-				"define-lazy-prop": "^3.0.0",
-				"is-inside-container": "^1.0.0",
-				"is-wsl": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@popperjs/core": {
@@ -4584,6 +4546,58 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
+			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "7.5.0",
+				"@typescript-eslint/utils": "7.5.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
+			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "7.5.0",
+				"@typescript-eslint/types": "7.5.0",
+				"@typescript-eslint/typescript-estree": "7.5.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4675,56 +4689,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
-			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
@@ -4812,31 +4776,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dev": true,
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "7.5.0",
@@ -5597,15 +5536,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"node_modules/big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5749,18 +5679,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/bplist-parser": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-			"dev": true,
-			"dependencies": {
-				"big-integer": "^1.6.44"
-			},
-			"engines": {
-				"node": ">= 5.10.0"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5861,21 +5779,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/bundle-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-			"dev": true,
-			"dependencies": {
-				"run-applescript": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7119,150 +7022,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/default-browser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-			"dev": true,
-			"dependencies": {
-				"bundle-name": "^3.0.0",
-				"default-browser-id": "^3.0.0",
-				"execa": "^7.1.1",
-				"titleize": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser-id": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-			"integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-			"dev": true,
-			"dependencies": {
-				"bplist-parser": "^0.2.0",
-				"untildify": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/execa": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.1",
-				"human-signals": "^4.3.0",
-				"is-stream": "^3.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^5.1.0",
-				"onetime": "^6.0.0",
-				"signal-exit": "^3.0.7",
-				"strip-final-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/default-browser/node_modules/human-signals": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.18.0"
-			}
-		},
-		"node_modules/default-browser/node_modules/is-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/mimic-fn": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/npm-run-path": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/onetime": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/default-browser/node_modules/strip-final-newline": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -7786,9 +7545,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-			"integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -7798,23 +7557,24 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-			"integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+			"integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
 			"dev": true,
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.8.5"
+				"synckit": "^0.8.6"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/prettier"
+				"url": "https://opencollective.com/eslint-plugin-prettier"
 			},
 			"peerDependencies": {
 				"@types/eslint": ">=8.0.0",
 				"eslint": ">=8.0.0",
+				"eslint-config-prettier": "*",
 				"prettier": ">=3.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -9507,39 +9267,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-inside-container": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-			"dev": true,
-			"dependencies": {
-				"is-docker": "^3.0.0"
-			},
-			"bin": {
-				"is-inside-container": "cli.js"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-inside-container/node_modules/is-docker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-			"dev": true,
-			"bin": {
-				"is-docker": "cli.js"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-module": {
@@ -13408,21 +13135,6 @@
 			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
 			"dev": true
 		},
-		"node_modules/run-applescript": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-			"dev": true,
-			"dependencies": {
-				"execa": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -14390,13 +14102,13 @@
 			"dev": true
 		},
 		"node_modules/synckit": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-			"integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+			"integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
 			"dev": true,
 			"dependencies": {
-				"@pkgr/utils": "^2.3.1",
-				"tslib": "^2.5.0"
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -14532,18 +14244,6 @@
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
 			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
 			"dev": true
-		},
-		"node_modules/titleize": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
@@ -14977,15 +14677,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/untildify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -18086,39 +17777,11 @@
 			"integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg==",
 			"dev": true
 		},
-		"@pkgr/utils": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.3",
-				"fast-glob": "^3.3.0",
-				"is-glob": "^4.0.3",
-				"open": "^9.1.0",
-				"picocolors": "^1.0.0",
-				"tslib": "^2.6.0"
-			},
-			"dependencies": {
-				"define-lazy-prop": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-					"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-					"dev": true
-				},
-				"open": {
-					"version": "9.1.0",
-					"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-					"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-					"dev": true,
-					"requires": {
-						"default-browser": "^4.0.0",
-						"define-lazy-prop": "^3.0.0",
-						"is-inside-container": "^1.0.0",
-						"is-wsl": "^2.2.0"
-					}
-				}
-			}
+		"@pkgr/core": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+			"dev": true
 		},
 		"@popperjs/core": {
 			"version": "2.11.8",
@@ -18802,6 +18465,33 @@
 				"ts-api-utils": "^1.0.1"
 			},
 			"dependencies": {
+				"@typescript-eslint/type-utils": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
+					"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/typescript-estree": "7.5.0",
+						"@typescript-eslint/utils": "7.5.0",
+						"debug": "^4.3.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				},
+				"@typescript-eslint/utils": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
+					"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
+					"dev": true,
+					"requires": {
+						"@eslint-community/eslint-utils": "^4.4.0",
+						"@types/json-schema": "^7.0.12",
+						"@types/semver": "^7.5.0",
+						"@typescript-eslint/scope-manager": "7.5.0",
+						"@typescript-eslint/types": "7.5.0",
+						"@typescript-eslint/typescript-estree": "7.5.0",
+						"semver": "^7.5.4"
+					}
+				},
 				"debug": {
 					"version": "4.3.4",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -18859,35 +18549,6 @@
 				"@typescript-eslint/visitor-keys": "7.5.0"
 			}
 		},
-		"@typescript-eslint/type-utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
-			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
 		"@typescript-eslint/types": {
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
@@ -18943,21 +18604,6 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
-			}
-		},
-		"@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dev": true,
-			"requires": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
@@ -19572,12 +19218,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
-		"big-integer": {
-			"version": "1.6.51",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-			"dev": true
-		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -19669,15 +19309,6 @@
 				}
 			}
 		},
-		"bplist-parser": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-			"dev": true,
-			"requires": {
-				"big-integer": "^1.6.44"
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -19747,15 +19378,6 @@
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
-		},
-		"bundle-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-			"dev": true,
-			"requires": {
-				"run-applescript": "^5.0.0"
-			}
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -20715,95 +20337,6 @@
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
-		"default-browser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-			"dev": true,
-			"requires": {
-				"bundle-name": "^3.0.0",
-				"default-browser-id": "^3.0.0",
-				"execa": "^7.1.1",
-				"titleize": "^3.0.0"
-			},
-			"dependencies": {
-				"execa": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-					"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.3",
-						"get-stream": "^6.0.1",
-						"human-signals": "^4.3.0",
-						"is-stream": "^3.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^5.1.0",
-						"onetime": "^6.0.0",
-						"signal-exit": "^3.0.7",
-						"strip-final-newline": "^3.0.0"
-					}
-				},
-				"human-signals": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-					"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-					"dev": true
-				},
-				"is-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-					"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-					"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-					"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-					"dev": true,
-					"requires": {
-						"path-key": "^4.0.0"
-					}
-				},
-				"onetime": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-					"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^4.0.0"
-					}
-				},
-				"path-key": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-					"dev": true
-				},
-				"strip-final-newline": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-					"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-					"dev": true
-				}
-			}
-		},
-		"default-browser-id": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-			"integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-			"dev": true,
-			"requires": {
-				"bplist-parser": "^0.2.0",
-				"untildify": "^4.0.0"
-			}
-		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -21298,20 +20831,20 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
-			"integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"requires": {}
 		},
 		"eslint-plugin-prettier": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
-			"integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+			"integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.8.5"
+				"synckit": "^0.8.6"
 			}
 		},
 		"eslint-scope": {
@@ -22462,23 +21995,6 @@
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
-			}
-		},
-		"is-inside-container": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-			"dev": true,
-			"requires": {
-				"is-docker": "^3.0.0"
-			},
-			"dependencies": {
-				"is-docker": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-					"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-					"dev": true
-				}
 			}
 		},
 		"is-module": {
@@ -25344,15 +24860,6 @@
 				}
 			}
 		},
-		"run-applescript": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-			"dev": true,
-			"requires": {
-				"execa": "^5.0.0"
-			}
-		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -26101,13 +25608,13 @@
 			"dev": true
 		},
 		"synckit": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-			"integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+			"integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
 			"dev": true,
 			"requires": {
-				"@pkgr/utils": "^2.3.1",
-				"tslib": "^2.5.0"
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
 			}
 		},
 		"tabbable": {
@@ -26200,12 +25707,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
 			"integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-			"dev": true
-		},
-		"titleize": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
 			"dev": true
 		},
 		"tmpl": {
@@ -26497,12 +25998,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"untildify": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
 			"dev": true
 		},
 		"update-browserslist-db": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -87,10 +87,19 @@ export interface TerraDrawModeRegisterConfig {
 	coordinatePrecision: number;
 }
 
+export enum UpdateTypes {
+	Commit = "commit",
+	Provisional = "provisional",
+	Finish = "finish",
+}
+
 type ValidationContext = Pick<
 	TerraDrawModeRegisterConfig,
 	"project" | "unproject" | "coordinatePrecision"
->;
+> & {
+	updateType: UpdateTypes;
+};
+
 export type Validation = (
 	feature: GeoJSONStoreFeatures,
 	context: ValidationContext,

--- a/src/modes/circle/circle.mode.spec.ts
+++ b/src/modes/circle/circle.mode.spec.ts
@@ -35,9 +35,9 @@ describe("TerraDrawCircleMode", () => {
 			});
 		});
 
-		it("constructs minimumRadiusKilometers", () => {
+		it("constructs startingRadiusKilometers", () => {
 			new TerraDrawCircleMode({
-				minimumRadiusKilometers: 0.00001,
+				startingRadiusKilometers: 0.00001,
 			});
 		});
 	});
@@ -137,7 +137,7 @@ describe("TerraDrawCircleMode", () => {
 		});
 
 		describe("registered", () => {
-			describe("default minimumRadiusKilometers", () => {
+			describe("default startingRadiusKilometers", () => {
 				beforeEach(() => {
 					const mockConfig = getMockModeConfig(circleMode.mode);
 
@@ -195,10 +195,10 @@ describe("TerraDrawCircleMode", () => {
 				});
 			});
 
-			describe("set minimumRadiusKilometers", () => {
+			describe("set startingRadiusKilometers", () => {
 				beforeEach(() => {
 					circleMode = new TerraDrawCircleMode({
-						minimumRadiusKilometers: 1000,
+						startingRadiusKilometers: 1000,
 					});
 					const mockConfig = getMockModeConfig(circleMode.mode);
 
@@ -226,8 +226,61 @@ describe("TerraDrawCircleMode", () => {
 						1000,
 					);
 				});
+			});
 
-				it("finishes drawing circle on second click using the minimum radius", () => {
+			describe("validate", () => {
+				let valid = false;
+
+				beforeEach(() => {
+					circleMode = new TerraDrawCircleMode({
+						validate: () => valid,
+					});
+					const mockConfig = getMockModeConfig(circleMode.mode);
+
+					store = mockConfig.store;
+					onChange = mockConfig.onChange;
+					onFinish = mockConfig.onFinish;
+
+					circleMode.register(mockConfig);
+					circleMode.start();
+				});
+
+				it("does not finish drawing circle on second click if validation returns false", () => {
+					valid = false;
+
+					circleMode.onClick({
+						lng: 0,
+						lat: 0,
+						containerX: 0,
+						containerY: 0,
+						button: "left",
+						heldKeys: [],
+					});
+
+					let features = store.copyAll();
+					expect(features.length).toBe(1);
+
+					circleMode.onClick({
+						lng: 0,
+						lat: 0,
+						containerX: 0,
+						containerY: 0,
+						button: "left",
+						heldKeys: [],
+					});
+
+					features = store.copyAll();
+					expect(features.length).toBe(1);
+
+					expect(onChange).toBeCalledTimes(1);
+					expect(onChange).toBeCalledWith([expect.any(String)], "create");
+
+					expect(onFinish).toBeCalledTimes(0);
+				});
+
+				it("does finish drawing circle on second click if validation returns true", () => {
+					valid = true;
+
 					circleMode.onClick({
 						lng: 0,
 						lat: 0,
@@ -254,11 +307,6 @@ describe("TerraDrawCircleMode", () => {
 
 					expect(onChange).toBeCalledTimes(3);
 					expect(onChange).toBeCalledWith([expect.any(String)], "create");
-
-					expect(store.copyAll()[0].properties.radiusKilometers).toStrictEqual(
-						1000,
-					);
-
 					expect(onFinish).toBeCalledTimes(1);
 				});
 			});
@@ -695,6 +743,105 @@ describe("TerraDrawCircleMode", () => {
 					},
 				}),
 			).toBe(true);
+		});
+
+		it("returns false for valid circle feature but with validation that returns false", () => {
+			const circleMode = new TerraDrawCircleMode({
+				validate: () => {
+					return false;
+				},
+				styles: {
+					fillColor: "#ffffff",
+					outlineColor: "#ffffff",
+					outlineWidth: 2,
+					fillOpacity: 0.5,
+				},
+			});
+			circleMode.register(getMockModeConfig("circle"));
+
+			expect(
+				circleMode.validateFeature({
+					id: "29da86c2-92e2-4095-a1b3-22103535ebfa",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[-0.494384766, 52.581606375],
+								[-0.506010566, 52.581258762],
+								[-0.517523856, 52.580219286],
+								[-0.528813228, 52.578498007],
+								[-0.539769474, 52.576111581],
+								[-0.550286655, 52.573083097],
+								[-0.560263136, 52.56944185],
+								[-0.56960258, 52.565223055],
+								[-0.578214884, 52.560467503],
+								[-0.586017056, 52.555221157],
+								[-0.592934012, 52.54953471],
+								[-0.598899299, 52.543463084],
+								[-0.603855731, 52.537064901],
+								[-0.607755924, 52.530401907],
+								[-0.610562743, 52.523538376],
+								[-0.612249642, 52.516540485],
+								[-0.612800901, 52.509475676],
+								[-0.612211758, 52.502412002],
+								[-0.61048843, 52.495417474],
+								[-0.607648039, 52.488559404],
+								[-0.60371842, 52.481903758],
+								[-0.598737838, 52.47551453],
+								[-0.592754606, 52.469453122],
+								[-0.5858266, 52.46377776],
+								[-0.578020696, 52.458542943],
+								[-0.569412123, 52.453798919],
+								[-0.56008373, 52.44959121],
+								[-0.550125193, 52.44596018],
+								[-0.539632162, 52.44294065],
+								[-0.528705342, 52.440561574],
+								[-0.517449543, 52.438845755],
+								[-0.505972682, 52.437809642],
+								[-0.494384766, 52.437463165],
+								[-0.48279685, 52.437809642],
+								[-0.471319989, 52.438845755],
+								[-0.46006419, 52.440561574],
+								[-0.44913737, 52.44294065],
+								[-0.438644339, 52.44596018],
+								[-0.428685802, 52.44959121],
+								[-0.419357409, 52.453798919],
+								[-0.410748836, 52.458542943],
+								[-0.402942932, 52.46377776],
+								[-0.396014926, 52.469453122],
+								[-0.390031694, 52.47551453],
+								[-0.385051112, 52.481903758],
+								[-0.381121493, 52.488559404],
+								[-0.378281102, 52.495417474],
+								[-0.376557774, 52.502412002],
+								[-0.375968631, 52.509475676],
+								[-0.37651989, 52.516540485],
+								[-0.378206789, 52.523538376],
+								[-0.381013608, 52.530401907],
+								[-0.384913801, 52.537064901],
+								[-0.389870233, 52.543463084],
+								[-0.39583552, 52.54953471],
+								[-0.402752476, 52.555221157],
+								[-0.410554648, 52.560467503],
+								[-0.419166952, 52.565223055],
+								[-0.428506396, 52.56944185],
+								[-0.438482877, 52.573083097],
+								[-0.449000058, 52.576111581],
+								[-0.459956304, 52.578498007],
+								[-0.471245676, 52.580219286],
+								[-0.482758966, 52.581258762],
+								[-0.494384766, 52.581606375],
+							],
+						],
+					},
+					properties: {
+						mode: "circle",
+						createdAt: 1685568434891,
+						updatedAt: 1685568435434,
+					},
+				}),
+			).toBe(false);
 		});
 	});
 });

--- a/src/modes/greatcircle/great-circle.mode.spec.ts
+++ b/src/modes/greatcircle/great-circle.mode.spec.ts
@@ -225,7 +225,7 @@ describe("TerraDrawGreatCircleMode", () => {
 			expect(features[1].geometry.coordinates).toStrictEqual([0, 0]);
 		});
 
-		it("creates line on second click", () => {
+		it("creates great circle line on second click", () => {
 			project.mockReturnValueOnce({ x: 0, y: 0 });
 			project.mockReturnValueOnce({ x: 0, y: 0 });
 			project.mockReturnValueOnce({ x: 50, y: 50 });
@@ -274,6 +274,119 @@ describe("TerraDrawGreatCircleMode", () => {
 			features[0].geometry.coordinates.forEach((coordinate) => {
 				expect(typeof (coordinate as Position)[0]).toBe("number");
 				expect(typeof (coordinate as Position)[1]).toBe("number");
+			});
+		});
+
+		describe("validate", () => {
+			let valid = true;
+			beforeEach(() => {
+				greatCircleMode = new TerraDrawGreatCircleMode({
+					validate: () => valid,
+				});
+				const mockConfig = getMockModeConfig(greatCircleMode.mode);
+				onChange = mockConfig.onChange;
+				store = mockConfig.store;
+				project = mockConfig.project;
+				greatCircleMode.register(mockConfig);
+				greatCircleMode.start();
+			});
+
+			it("does not create great circle line on second click because validate returns false", () => {
+				valid = false;
+				project.mockReturnValueOnce({ x: 0, y: 0 });
+				project.mockReturnValueOnce({ x: 0, y: 0 });
+				project.mockReturnValueOnce({ x: 50, y: 50 });
+				project.mockReturnValueOnce({ x: 50, y: 50 });
+
+				greatCircleMode.onClick({
+					lng: 1,
+					lat: 1,
+					containerX: 0,
+					containerY: 0,
+					button: "left",
+					heldKeys: [],
+				});
+
+				let features = store.copyAll();
+				expect(features.length).toBe(2);
+
+				greatCircleMode.onMouseMove({
+					lng: 20,
+					lat: 20,
+					containerX: 100,
+					containerY: 100,
+					button: "left",
+					heldKeys: [],
+				});
+
+				features = store.copyAll();
+
+				greatCircleMode.onClick({
+					lng: 20,
+					lat: 20,
+					containerX: 100,
+					containerY: 100,
+					button: "left",
+					heldKeys: [],
+				});
+
+				expect(onChange).toBeCalledTimes(2);
+				features = store.copyAll();
+
+				expect(features.length).toBe(2);
+			});
+
+			it("does create great circle line on second click because validate returns true", () => {
+				valid = true;
+				project.mockReturnValueOnce({ x: 0, y: 0 });
+				project.mockReturnValueOnce({ x: 0, y: 0 });
+				project.mockReturnValueOnce({ x: 50, y: 50 });
+				project.mockReturnValueOnce({ x: 50, y: 50 });
+
+				greatCircleMode.onClick({
+					lng: 1,
+					lat: 1,
+					containerX: 0,
+					containerY: 0,
+					button: "left",
+					heldKeys: [],
+				});
+
+				let features = store.copyAll();
+				expect(features.length).toBe(2);
+
+				greatCircleMode.onMouseMove({
+					lng: 20,
+					lat: 20,
+					containerX: 100,
+					containerY: 100,
+					button: "left",
+					heldKeys: [],
+				});
+
+				features = store.copyAll();
+				expect(features.length).toBe(2);
+
+				expect(features[0].geometry.coordinates.length).toBe(100);
+
+				greatCircleMode.onClick({
+					lng: 20,
+					lat: 20,
+					containerX: 100,
+					containerY: 100,
+					button: "left",
+					heldKeys: [],
+				});
+
+				expect(onChange).toBeCalledTimes(5);
+				features = store.copyAll();
+
+				expect(features.length).toBe(1);
+				expect(features[0].geometry.coordinates.length).toBe(100);
+				features[0].geometry.coordinates.forEach((coordinate) => {
+					expect(typeof (coordinate as Position)[0]).toBe("number");
+					expect(typeof (coordinate as Position)[1]).toBe("number");
+				});
 			});
 		});
 	});
@@ -774,6 +887,135 @@ describe("TerraDrawGreatCircleMode", () => {
 					},
 				}),
 			).toBe(true);
+		});
+
+		it("returns false for valid great circle feature but validate function returns false", () => {
+			const greatCircleMode = new TerraDrawGreatCircleMode({
+				validate: () => {
+					return false;
+				},
+				styles: {
+					lineStringColor: "#ffffff",
+				},
+			});
+			greatCircleMode.register(getMockModeConfig("greatcircle"));
+
+			expect(
+				greatCircleMode.validateFeature({
+					id: "8375c1e1-79af-4870-8cbc-57bcf323f2e0",
+					type: "Feature",
+					geometry: {
+						type: "LineString",
+						coordinates: [
+							[-2.559814453, 52.536273041],
+							[-2.519973128, 52.545235198],
+							[-2.480115543, 52.554183976],
+							[-2.440241709, 52.563119364],
+							[-2.400351638, 52.572041353],
+							[-2.360445344, 52.580949932],
+							[-2.32052284, 52.589845092],
+							[-2.280584137, 52.598726824],
+							[-2.240629248, 52.607595117],
+							[-2.200658186, 52.616449962],
+							[-2.160670965, 52.625291349],
+							[-2.120667597, 52.634119268],
+							[-2.080648094, 52.642933709],
+							[-2.040612471, 52.651734663],
+							[-2.000560739, 52.660522121],
+							[-1.960492913, 52.669296071],
+							[-1.920409005, 52.678056506],
+							[-1.880309029, 52.686803414],
+							[-1.840192997, 52.695536786],
+							[-1.800060924, 52.704256613],
+							[-1.759912823, 52.712962884],
+							[-1.719748708, 52.721655591],
+							[-1.679568591, 52.730334723],
+							[-1.639372486, 52.739000271],
+							[-1.599160408, 52.747652225],
+							[-1.55893237, 52.756290575],
+							[-1.518688386, 52.764915312],
+							[-1.478428469, 52.773526426],
+							[-1.438152634, 52.782123908],
+							[-1.397860895, 52.790707748],
+							[-1.357553265, 52.799277935],
+							[-1.317229759, 52.807834462],
+							[-1.276890391, 52.816377317],
+							[-1.236535175, 52.824906492],
+							[-1.196164125, 52.833421976],
+							[-1.155777257, 52.841923761],
+							[-1.115374584, 52.850411836],
+							[-1.07495612, 52.858886192],
+							[-1.034521881, 52.867346819],
+							[-0.99407188, 52.875793709],
+							[-0.953606134, 52.88422685],
+							[-0.913124655, 52.892646235],
+							[-0.87262746, 52.901051852],
+							[-0.832114563, 52.909443694],
+							[-0.791585978, 52.917821749],
+							[-0.751041722, 52.926186009],
+							[-0.710481808, 52.934536464],
+							[-0.669906252, 52.942873104],
+							[-0.62931507, 52.951195921],
+							[-0.588708276, 52.959504904],
+							[-0.548085885, 52.967800044],
+							[-0.507447914, 52.976081332],
+							[-0.466794377, 52.984348757],
+							[-0.42612529, 52.992602312],
+							[-0.385440668, 53.000841985],
+							[-0.344740527, 53.009067768],
+							[-0.304024883, 53.017279652],
+							[-0.263293752, 53.025477626],
+							[-0.222547148, 53.033661682],
+							[-0.181785089, 53.041831809],
+							[-0.141007589, 53.049988],
+							[-0.100214666, 53.058130243],
+							[-0.059406334, 53.06625853],
+							[-0.01858261, 53.074372851],
+							[0.022256489, 53.082473198],
+							[0.063110948, 53.09055956],
+							[0.103980751, 53.098631928],
+							[0.14486588, 53.106690293],
+							[0.18576632, 53.114734645],
+							[0.226682054, 53.122764976],
+							[0.267613066, 53.130781276],
+							[0.308559339, 53.138783535],
+							[0.349520856, 53.146771744],
+							[0.390497601, 53.154745894],
+							[0.431489557, 53.162705976],
+							[0.472496707, 53.17065198],
+							[0.513519033, 53.178583897],
+							[0.554556521, 53.186501717],
+							[0.595609151, 53.194405432],
+							[0.636676907, 53.202295033],
+							[0.677759773, 53.210170509],
+							[0.718857729, 53.218031852],
+							[0.759970761, 53.225879052],
+							[0.801098849, 53.233712101],
+							[0.842241978, 53.241530988],
+							[0.883400128, 53.249335706],
+							[0.924573283, 53.257126244],
+							[0.965761426, 53.264902593],
+							[1.006964537, 53.272664745],
+							[1.048182601, 53.28041269],
+							[1.089415598, 53.288146419],
+							[1.130663512, 53.295865922],
+							[1.171926324, 53.303571191],
+							[1.213204016, 53.311262217],
+							[1.25449657, 53.31893899],
+							[1.295803969, 53.326601501],
+							[1.337126194, 53.334249741],
+							[1.378463226, 53.341883702],
+							[1.419815048, 53.349503373],
+							[1.461181641, 53.357108746],
+						],
+					},
+					properties: {
+						mode: "greatcircle",
+						createdAt: 1685654356961,
+						updatedAt: 1685654358553,
+					},
+				}),
+			).toBe(false);
 		});
 	});
 });

--- a/src/modes/point/point.mode.spec.ts
+++ b/src/modes/point/point.mode.spec.ts
@@ -1,3 +1,4 @@
+import { Point } from "geojson";
 import { TerraDrawMouseEvent } from "../../common";
 import { getMockModeConfig } from "../../test/mock-config";
 import { TerraDrawPointMode } from "./point.mode";
@@ -123,6 +124,58 @@ describe("TerraDrawPointMode", () => {
 				[expect.any(String)],
 				"create",
 			);
+		});
+
+		describe("validate", () => {
+			it("does not create the point if validation returns false", () => {
+				const pointMode = new TerraDrawPointMode({
+					validate: (feature) => {
+						return (feature.geometry as Point).coordinates[0] > 45;
+					},
+				});
+
+				const mockConfig = getMockModeConfig(pointMode.mode);
+
+				pointMode.register(mockConfig);
+
+				pointMode.onClick({
+					lng: 30,
+					lat: 0,
+					containerX: 0,
+					containerY: 0,
+				} as TerraDrawMouseEvent);
+
+				expect(mockConfig.onChange).toBeCalledTimes(0);
+				expect(mockConfig.onChange).not.toBeCalledWith(
+					[expect.any(String)],
+					"create",
+				);
+			});
+
+			it("does create the point if validation returns true", () => {
+				const pointMode = new TerraDrawPointMode({
+					validate: (feature) => {
+						return (feature.geometry as Point).coordinates[0] > 45;
+					},
+				});
+
+				const mockConfig = getMockModeConfig(pointMode.mode);
+
+				pointMode.register(mockConfig);
+
+				pointMode.onClick({
+					lng: 50,
+					lat: 0,
+					containerX: 0,
+					containerY: 0,
+				} as TerraDrawMouseEvent);
+
+				expect(mockConfig.onChange).toBeCalledTimes(1);
+				expect(mockConfig.onChange).toBeCalledWith(
+					[expect.any(String)],
+					"create",
+				);
+			});
 		});
 	});
 
@@ -319,6 +372,33 @@ describe("TerraDrawPointMode", () => {
 					},
 				}),
 			).toBe(true);
+		});
+
+		it("returns false for valid point feature but validate function returns false", () => {
+			const pointMode = new TerraDrawPointMode({
+				validate: () => false,
+				styles: {
+					pointColor: "#ffffff",
+				},
+			});
+
+			pointMode.register(getMockModeConfig("point"));
+
+			expect(
+				pointMode.validateFeature({
+					id: "ed030248-d7ee-45a2-b8e8-37ad2f622509",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-2.329101563, 51.392350875],
+					},
+					properties: {
+						mode: "point",
+						createdAt: 1685654949450,
+						updatedAt: 1685654950609,
+					},
+				}),
+			).toBe(false);
 		});
 	});
 });

--- a/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/src/modes/rectangle/rectangle.mode.spec.ts
@@ -571,5 +571,69 @@ describe("TerraDrawRectangleMode", () => {
 				}),
 			).toBe(false);
 		});
+
+		it("returns true for valid rectangle feature with validation that returns true", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				validate: () => {
+					return true;
+				},
+			});
+			rectangleMode.register(getMockModeConfig("rectangle"));
+
+			expect(
+				rectangleMode.validateFeature({
+					id: "5c582a42-c3a7-4bfc-b686-6036f311df3c",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[-0.127976611, 51.514237243],
+								[-0.106284245, 51.514237243],
+								[-0.106284245, 51.504807832],
+								[-0.127976611, 51.504807832],
+								[-0.127976611, 51.514237243],
+							],
+						],
+					},
+					properties: {
+						mode: "rectangle",
+						createdAt: 1685655516297,
+						updatedAt: 1685655518118,
+					},
+				}),
+			).toBe(true);
+		});
+
+		it("returns false for valid rectangle feature but with validation that returns false", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				validate: () => {
+					return false;
+				},
+			});
+			rectangleMode.register(getMockModeConfig("rectangle"));
+
+			expect(
+				rectangleMode.validateFeature({
+					id: "5c582a42-c3a7-4bfc-b686-6036f311df3c",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[-0.127976611, 51.514237243],
+								[-0.106284245, 51.514237243],
+								[-0.106284245, 51.504807832],
+								[-0.127976611, 51.504807832],
+								[-0.127976611, 51.514237243],
+							],
+						],
+					},
+					properties: {
+						mode: "rectangle",
+						createdAt: 1685655516297,
+						updatedAt: 1685655518118,
+					},
+				}),
+			).toBe(false);
+		});
 	});
 });

--- a/src/modes/render/render.mode.ts
+++ b/src/modes/render/render.mode.ts
@@ -12,9 +12,9 @@ import {
 import { BehaviorConfig } from "../base.behavior";
 import { getDefaultStyling } from "../../util/styling";
 import { GeoJSONStoreFeatures } from "../../terra-draw";
-import { isValidPoint } from "../../geometry/boolean/is-valid-point";
-import { isValidPolygonFeature } from "../../geometry/boolean/is-valid-polygon-feature";
-import { isValidLineStringFeature } from "../../geometry/boolean/is-valid-linestring-feature";
+import { ValidatePointFeature } from "../../validations/point.validation";
+import { ValidatePolygonFeature } from "../../validations/polygon.validation";
+import { ValidateLineStringFeature } from "../../validations/linestring.validation";
 
 type RenderModeStyling = {
 	pointColor: HexColorStyling;
@@ -155,9 +155,9 @@ export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling
 	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
 		return (
 			super.validateFeature(feature) &&
-			(isValidPoint(feature, this.coordinatePrecision) ||
-				isValidPolygonFeature(feature, this.coordinatePrecision) ||
-				isValidLineStringFeature(feature, this.coordinatePrecision))
+			(ValidatePointFeature(feature, this.coordinatePrecision) ||
+				ValidatePolygonFeature(feature, this.coordinatePrecision) ||
+				ValidateLineStringFeature(feature, this.coordinatePrecision))
 		);
 	}
 }

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { LineString, Polygon, Position, Point, Feature } from "geojson";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
@@ -729,6 +729,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 					project: this.config.project,
 					unproject: this.config.unproject,
 					coordinatePrecision: this.config.coordinatePrecision,
+					updateType: UpdateTypes.Provisional,
 				},
 			);
 			if (!valid) {

--- a/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 
 import { LineString, Polygon, Position, Point, Feature } from "geojson";
@@ -166,6 +166,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 					project: this.config.project,
 					unproject: this.config.unproject,
 					coordinatePrecision: this.config.coordinatePrecision,
+					updateType: UpdateTypes.Provisional,
 				},
 			);
 

--- a/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { Position } from "geojson";
@@ -132,6 +132,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 						project: this.config.project,
 						unproject: this.config.unproject,
 						coordinatePrecision: this.config.coordinatePrecision,
+						updateType: UpdateTypes.Provisional,
 					},
 				);
 

--- a/src/modes/select/behaviors/rotate-feature.behavior.ts
+++ b/src/modes/select/behaviors/rotate-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { LineString, Polygon, Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -85,6 +85,7 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 						project: this.config.project,
 						unproject: this.config.unproject,
 						coordinatePrecision: this.config.coordinatePrecision,
+						updateType: UpdateTypes.Provisional,
 					},
 				)
 			) {

--- a/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { Feature, LineString, Polygon, Position } from "geojson";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -89,6 +89,7 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 						project: this.config.project,
 						unproject: this.config.unproject,
 						coordinatePrecision: this.config.coordinatePrecision,
+						updateType: UpdateTypes.Provisional,
 					},
 				)
 			) {

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -7,6 +7,7 @@ import {
 	NumericStyling,
 	Cursor,
 	Validation,
+	UpdateTypes,
 } from "../../common";
 import { Point, Position } from "geojson";
 import {
@@ -124,9 +125,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 	private scaleFeature!: ScaleFeatureBehavior;
 	private dragCoordinateResizeFeature!: DragCoordinateResizeBehavior;
 	private cursors: Required<Cursors>;
-	private validations: {
-		[mode: string]: (feature: GeoJSONStoreFeatures) => boolean;
-	} = {};
+	private validations: Record<string, Validation> = {};
 
 	constructor(options?: TerraDrawSelectModeOptions<SelectionStyling>) {
 		super(options);
@@ -370,12 +369,20 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 		// Validate the new geometry
 		if (validation) {
-			const valid = validation({
-				id: featureId,
-				type: "Feature",
-				geometry,
-				properties,
-			});
+			const valid = validation(
+				{
+					id: featureId,
+					type: "Feature",
+					geometry,
+					properties,
+				},
+				{
+					project: this.project,
+					unproject: this.unproject,
+					coordinatePrecision: this.coordinatePrecision,
+					updateType: UpdateTypes.Commit,
+				},
+			);
 			if (!valid) {
 				return;
 			}

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -48,8 +48,9 @@ import { pixelDistanceToLine } from "./geometry/measure/pixel-distance-to-line";
 import { Position } from "geojson";
 import { pointInPolygon } from "./geometry/boolean/point-in-polygon";
 import { createBBoxFromPoint } from "./geometry/shape/create-bbox";
-import { ValidateMinSizeSquareMeters } from "./validations/min-size.validation";
-import { ValidateMaxSizeSquareMeters } from "./validations/max-size.validation";
+import { ValidateMinAreaSquareMeters } from "./validations/min-size.validation";
+import { ValidateMaxAreaSquareMeters } from "./validations/max-size.validation";
+import { ValidateNotSelfIntersecting } from "./validations/not-self-intersecting.validation";
 
 type FinishListener = (ids: FeatureId) => void;
 type ChangeListener = (ids: FeatureId[], type: string) => void;
@@ -818,6 +819,7 @@ export {
 	GetLngLatFromEvent,
 
 	// Validations
-	ValidateMinSizeSquareMeters,
-	ValidateMaxSizeSquareMeters,
+	ValidateMinAreaSquareMeters,
+	ValidateMaxAreaSquareMeters,
+	ValidateNotSelfIntersecting,
 };

--- a/src/validations/linestring.validation.spec.ts
+++ b/src/validations/linestring.validation.spec.ts
@@ -1,7 +1,7 @@
 import { Feature, LineString } from "geojson";
-import { isValidLineStringFeature } from "./is-valid-linestring-feature";
+import { ValidateLineStringFeature } from "./linestring.validation";
 
-describe("isValidLineStringFeature", () => {
+describe("ValidateLineStringFeature", () => {
 	it("returns true for a valid LineString feature with correct coordinate precision", () => {
 		const validFeature = {
 			type: "Feature",
@@ -14,7 +14,7 @@ describe("isValidLineStringFeature", () => {
 				],
 			},
 		} as Feature<LineString, Record<string, any>>;
-		expect(isValidLineStringFeature(validFeature, 9)).toBe(true);
+		expect(ValidateLineStringFeature(validFeature, 9)).toBe(true);
 	});
 
 	it("returns false for a non-LineString feature", () => {
@@ -30,7 +30,7 @@ describe("isValidLineStringFeature", () => {
 				],
 			},
 		} as any;
-		expect(isValidLineStringFeature(nonLineStringFeature, 9)).toBe(false);
+		expect(ValidateLineStringFeature(nonLineStringFeature, 9)).toBe(false);
 	});
 
 	it("returns false for a LineString feature with less than 2 coordinates", () => {
@@ -42,7 +42,7 @@ describe("isValidLineStringFeature", () => {
 				coordinates: [[45, 90]],
 			},
 		} as Feature<LineString, Record<string, any>>;
-		expect(isValidLineStringFeature(lessCoordinatesFeature, 9)).toBe(false);
+		expect(ValidateLineStringFeature(lessCoordinatesFeature, 9)).toBe(false);
 	});
 
 	it("returns false for a LineString feature with incorrect coordinate precision", () => {
@@ -57,6 +57,6 @@ describe("isValidLineStringFeature", () => {
 				],
 			},
 		} as Feature<LineString, Record<string, any>>;
-		expect(isValidLineStringFeature(validFeature, 2)).toBe(false);
+		expect(ValidateLineStringFeature(validFeature, 2)).toBe(false);
 	});
 });

--- a/src/validations/linestring.validation.ts
+++ b/src/validations/linestring.validation.ts
@@ -1,7 +1,7 @@
-import { GeoJSONStoreFeatures } from "../../terra-draw";
-import { coordinateIsValid } from "./is-valid-coordinate";
+import { GeoJSONStoreFeatures } from "../terra-draw";
+import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 
-export function isValidLineStringFeature(
+export function ValidateLineStringFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
 ): boolean {

--- a/src/validations/max-size.validation.spec.ts
+++ b/src/validations/max-size.validation.spec.ts
@@ -1,25 +1,29 @@
-import { Polygon } from "geojson";
-import { ValidateMaxSizeSquareMeters } from "./max-size.validation";
+import { ValidateMaxAreaSquareMeters } from "./max-size.validation";
+import { GeoJSONStoreFeatures } from "../terra-draw";
 
-describe("ValidateMaxSizeSquareMeters", () => {
+describe("ValidateMaxAreaSquareMeters", () => {
 	it("should return true if the polygon area is less than the max size", () => {
 		// Arrange
 		const polygon = {
-			type: "Polygon",
-			coordinates: [
-				[
-					[0, 0],
-					[0, 1],
-					[1, 1],
-					[1, 0],
-					[0, 0],
+			type: "Feature",
+			properties: {},
+			geometry: {
+				type: "Polygon",
+				coordinates: [
+					[
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					],
 				],
-			],
-		} as Polygon;
+			},
+		} as GeoJSONStoreFeatures;
 
 		const maxSize = 100000000000;
 		// Act
-		const result = ValidateMaxSizeSquareMeters(polygon, maxSize);
+		const result = ValidateMaxAreaSquareMeters(polygon, maxSize);
 		// Assert
 		expect(result).toBe(true);
 	});

--- a/src/validations/max-size.validation.ts
+++ b/src/validations/max-size.validation.ts
@@ -1,9 +1,13 @@
-import { Polygon } from "geojson";
 import { polygonAreaSquareMeters } from "../geometry/measure/area";
+import { GeoJSONStoreFeatures } from "../terra-draw";
 
-export const ValidateMaxSizeSquareMeters = (
-	polygon: Polygon,
+export const ValidateMaxAreaSquareMeters = (
+	feature: GeoJSONStoreFeatures,
 	minSize: number,
 ): boolean => {
-	return polygonAreaSquareMeters(polygon) < minSize;
+	if (feature.geometry.type !== "Polygon") {
+		return false;
+	}
+
+	return polygonAreaSquareMeters(feature.geometry) < minSize;
 };

--- a/src/validations/min-size.validation.spec.ts
+++ b/src/validations/min-size.validation.spec.ts
@@ -1,25 +1,29 @@
 import { Polygon } from "geojson";
-import { ValidateMinSizeSquareMeters } from "./min-size.validation";
+import { ValidateMinAreaSquareMeters } from "./min-size.validation";
+import { GeoJSONStoreFeatures } from "../terra-draw";
 
-describe("ValidateMinSizeSquareMeters", () => {
+describe("ValidateMinAreaSquareMeters", () => {
 	it("it should return true if less than the min size provided", () => {
 		// Arrange
-		const polygon = {
-			type: "Polygon",
-			coordinates: [
-				[
-					[0, 0],
-					[0, 1],
-					[1, 1],
-					[1, 0],
-					[0, 0],
+		const feature = {
+			type: "Feature",
+			geometry: {
+				type: "Polygon",
+				coordinates: [
+					[
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					],
 				],
-			],
-		} as Polygon;
+			} as Polygon,
+		} as GeoJSONStoreFeatures;
 
 		const minSize = 10000;
 		// Act
-		const result = ValidateMinSizeSquareMeters(polygon, minSize);
+		const result = ValidateMinAreaSquareMeters(feature, minSize);
 		// Assert
 		expect(result).toBe(true);
 	});

--- a/src/validations/min-size.validation.ts
+++ b/src/validations/min-size.validation.ts
@@ -1,9 +1,13 @@
-import { Polygon } from "geojson";
 import { polygonAreaSquareMeters } from "../geometry/measure/area";
+import { GeoJSONStoreFeatures } from "../terra-draw";
 
-export const ValidateMinSizeSquareMeters = (
-	polygon: Polygon,
+export const ValidateMinAreaSquareMeters = (
+	feature: GeoJSONStoreFeatures,
 	minSize: number,
 ): boolean => {
-	return polygonAreaSquareMeters(polygon) > minSize;
+	if (feature.geometry.type !== "Polygon") {
+		return false;
+	}
+
+	return polygonAreaSquareMeters(feature.geometry) > minSize;
 };

--- a/src/validations/not-self-intersecting.validation.spec.ts
+++ b/src/validations/not-self-intersecting.validation.spec.ts
@@ -1,0 +1,52 @@
+import { Polygon } from "geojson";
+import { ValidateNotSelfIntersecting } from "./not-self-intersecting.validation";
+import { GeoJSONStoreFeatures } from "../terra-draw";
+
+describe("ValidateNotSelfIntersecting", () => {
+	it("it should return false polygon self intersects", () => {
+		const feature = {
+			type: "Feature",
+			properties: {},
+			geometry: {
+				coordinates: [
+					[
+						[34.22041933638323, 16.155508656132255],
+						[14.634103624858, 1.9928911643832947],
+						[44.85353434697225, -10.538516452804046],
+						[15.981035610620069, 13.843769534036511],
+						[34.22041933638323, 16.155508656132255],
+					],
+				],
+				type: "Polygon",
+			},
+		} as GeoJSONStoreFeatures;
+
+		// Act
+		const result = ValidateNotSelfIntersecting(feature);
+		// Assert
+		expect(result).toBe(false);
+	});
+
+	it("it should return true if polygon does not self intersects", () => {
+		const feature = {
+			type: "Feature",
+			geometry: {
+				coordinates: [
+					[
+						[22.115939239949142, 17.061864550222168],
+						[10.555809858425931, 17.061864550222168],
+						[10.555809858425931, 4.004764588790522],
+						[22.115939239949142, 4.004764588790522],
+						[22.115939239949142, 17.061864550222168],
+					],
+				],
+				type: "Polygon",
+			} as Polygon,
+		} as GeoJSONStoreFeatures;
+
+		// Act
+		const result = ValidateNotSelfIntersecting(feature);
+		// Assert
+		expect(result).toBe(true);
+	});
+});

--- a/src/validations/not-self-intersecting.validation.ts
+++ b/src/validations/not-self-intersecting.validation.ts
@@ -1,0 +1,20 @@
+import { Feature, LineString, Polygon } from "geojson";
+import { selfIntersects } from "../geometry/boolean/self-intersects";
+import { GeoJSONStoreFeatures } from "../terra-draw";
+
+export const ValidateNotSelfIntersecting = (
+	feature: GeoJSONStoreFeatures,
+): boolean => {
+	if (
+		feature.geometry.type !== "Polygon" &&
+		feature.geometry.type !== "LineString"
+	) {
+		return false;
+	}
+
+	const hasSelfIntersections = selfIntersects(
+		feature as Feature<LineString> | Feature<Polygon>,
+	);
+
+	return !hasSelfIntersections;
+};

--- a/src/validations/point.validation.spec.ts
+++ b/src/validations/point.validation.spec.ts
@@ -1,5 +1,5 @@
 import { Feature, Point } from "geojson";
-import { isValidPoint } from "./is-valid-point";
+import { ValidatePointFeature } from "./point.validation";
 
 describe("isValidPoint", () => {
 	it("returns true for a valid Point with correct coordinate precision", () => {
@@ -11,7 +11,7 @@ describe("isValidPoint", () => {
 				coordinates: [45, 90],
 			},
 		} as Feature<Point, Record<string, any>>;
-		expect(isValidPoint(validPoint, 2)).toBe(true);
+		expect(ValidatePointFeature(validPoint, 2)).toBe(true);
 	});
 
 	it("returns false for a non-Point feature", () => {
@@ -26,7 +26,7 @@ describe("isValidPoint", () => {
 				],
 			},
 		} as any;
-		expect(isValidPoint(nonPointFeature, 2)).toBe(false);
+		expect(ValidatePointFeature(nonPointFeature, 2)).toBe(false);
 	});
 
 	it("returns false for a Point with incorrect coordinate precision", () => {
@@ -38,6 +38,6 @@ describe("isValidPoint", () => {
 				coordinates: [45.123, 90.123],
 			},
 		} as Feature<Point, Record<string, any>>;
-		expect(isValidPoint(invalidPoint, 2)).toBe(false);
+		expect(ValidatePointFeature(invalidPoint, 2)).toBe(false);
 	});
 });

--- a/src/validations/point.validation.ts
+++ b/src/validations/point.validation.ts
@@ -1,7 +1,7 @@
-import { GeoJSONStoreFeatures } from "../../terra-draw";
-import { coordinateIsValid } from "./is-valid-coordinate";
+import { GeoJSONStoreFeatures } from "../terra-draw";
+import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 
-export function isValidPoint(
+export function ValidatePointFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
 ): boolean {

--- a/src/validations/polygon.validation.spec.ts
+++ b/src/validations/polygon.validation.spec.ts
@@ -1,8 +1,8 @@
 import { Feature, Polygon } from "geojson";
 import {
-	isValidNonIntersectingPolygonFeature,
-	isValidPolygonFeature,
-} from "./is-valid-polygon-feature";
+	ValidateNonIntersectingPolygonFeature,
+	ValidatePolygonFeature,
+} from "./polygon.validation";
 
 describe("isValidPolygonFeature", () => {
 	it("returns true for a valid Polygon feature", () => {
@@ -21,7 +21,7 @@ describe("isValidPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidPolygonFeature(validFeature, 9)).toBe(true);
+		expect(ValidatePolygonFeature(validFeature, 9)).toBe(true);
 	});
 
 	it("returns false for non-Polygon feature", () => {
@@ -33,7 +33,7 @@ describe("isValidPolygonFeature", () => {
 				coordinates: [[45, 90]],
 			},
 		} as any;
-		expect(isValidPolygonFeature(nonPolygonFeature, 9)).toBe(false);
+		expect(ValidatePolygonFeature(nonPolygonFeature, 9)).toBe(false);
 	});
 
 	it("returns false for Polygon feature with more than one coordinates array", () => {
@@ -58,7 +58,7 @@ describe("isValidPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidPolygonFeature(multiCoordinatesFeature, 9)).toBe(false);
+		expect(ValidatePolygonFeature(multiCoordinatesFeature, 9)).toBe(false);
 	});
 
 	it("returns false for Polygon feature with less than 4 coordinates in array", () => {
@@ -76,7 +76,7 @@ describe("isValidPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidPolygonFeature(lessCoordinatesFeature, 9)).toBe(false);
+		expect(ValidatePolygonFeature(lessCoordinatesFeature, 9)).toBe(false);
 	});
 
 	it("returns false for Polygon feature where first and last coordinates do not match", () => {
@@ -95,7 +95,9 @@ describe("isValidPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidPolygonFeature(nonMatchingCoordinatesFeature, 9)).toBe(false);
+		expect(ValidatePolygonFeature(nonMatchingCoordinatesFeature, 9)).toBe(
+			false,
+		);
 	});
 
 	it("returns false Polygon with excessive coordinate precision", () => {
@@ -114,7 +116,7 @@ describe("isValidPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidPolygonFeature(validFeature, 9)).toBe(false);
+		expect(ValidatePolygonFeature(validFeature, 9)).toBe(false);
 	});
 });
 
@@ -135,7 +137,7 @@ describe("isValidNonIntersectingPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidNonIntersectingPolygonFeature(validFeature, 9)).toBe(true);
+		expect(ValidateNonIntersectingPolygonFeature(validFeature, 9)).toBe(true);
 	});
 
 	it("returns false for a self intersecting Polygon feature", () => {
@@ -156,6 +158,6 @@ describe("isValidNonIntersectingPolygonFeature", () => {
 				],
 			},
 		} as Feature<Polygon, Record<string, any>>;
-		expect(isValidNonIntersectingPolygonFeature(validFeature, 9)).toBe(false);
+		expect(ValidateNonIntersectingPolygonFeature(validFeature, 9)).toBe(false);
 	});
 });

--- a/src/validations/polygon.validation.ts
+++ b/src/validations/polygon.validation.ts
@@ -1,7 +1,7 @@
 import { Feature, Polygon, Position } from "geojson";
-import { GeoJSONStoreFeatures } from "../../terra-draw";
-import { selfIntersects } from "./self-intersects";
-import { coordinateIsValid } from "./is-valid-coordinate";
+import { GeoJSONStoreFeatures } from "../terra-draw";
+import { selfIntersects } from "../geometry/boolean/self-intersects";
+import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 
 function coordinatesMatch(coordinateOne: Position, coordinateTwo: Position) {
 	return (
@@ -10,7 +10,7 @@ function coordinatesMatch(coordinateOne: Position, coordinateTwo: Position) {
 	);
 }
 
-export function isValidPolygonFeature(
+export function ValidatePolygonFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
 ): boolean {
@@ -30,12 +30,12 @@ export function isValidPolygonFeature(
 	);
 }
 
-export function isValidNonIntersectingPolygonFeature(
+export function ValidateNonIntersectingPolygonFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
 ): boolean {
 	return (
-		isValidPolygonFeature(feature, coordinatePrecision) &&
+		ValidatePolygonFeature(feature, coordinatePrecision) &&
 		!selfIntersects(feature as Feature<Polygon>)
 	);
 }


### PR DESCRIPTION
## Description of Changes

The main premise here is to provide a more generalised way to validate drawn features. This allows developers using Terra Draw to define their own custom logic for validating drawn features. 

It also aligns the `validateFeature` function with this new `validate` option for all built in modes. We centralise around the idea of `Validations` which are essentially predicate functions. `validateFeature` will now also run the `validate` function passed as part of any call to it (i.e. via `addFeatures`). 

It attempts to add comprehensive tests and docs to accommodate for the changes.

## Link to Issue

#256 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 