### PR TITLE
chore: bump to Typescript 5.5

### DIFF
--- a/development/package-lock.json
+++ b/development/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"dotenv-webpack": "8.0.0",
-				"typescript": "5.4.4",
+				"typescript": "5.5.2",
 				"webpack": "5.73.0",
 				"webpack-cli": "4.10.0",
 				"webpack-dev-server": "4.11.1"
@@ -2938,9 +2938,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5743,9 +5743,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"dev": true
 		},
 		"unpipe": {

--- a/development/package.json
+++ b/development/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"dotenv-webpack": "8.0.0",
-		"typescript": "5.4.4",
+		"typescript": "5.5.2",
 		"webpack": "5.73.0",
 		"webpack-cli": "4.10.0",
 		"webpack-dev-server": "4.11.1"

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -14,7 +14,7 @@
 				"@types/node": "20.10.5",
 				"dotenv-webpack": "8.0.0",
 				"ts-loader": "9.5.1",
-				"typescript": "5.4.4",
+				"typescript": "5.5.2",
 				"webpack": "5.73.0",
 				"webpack-cli": "4.10.0",
 				"webpack-dev-server": "4.11.1"
@@ -947,13 +947,13 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"dev": true,
 			"dependencies": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -961,7 +961,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -1002,12 +1002,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1061,14 +1061,19 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.1",
-				"set-function-length": "^1.1.1"
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1290,9 +1295,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -1346,17 +1351,20 @@
 			}
 		},
 		"node_modules/define-data-property": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.1",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/define-lazy-prop": {
@@ -1499,6 +1507,27 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
@@ -1636,17 +1665,17 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
+				"body-parser": "1.20.2",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
+				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -1717,9 +1746,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -1769,9 +1798,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.3",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-			"integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1842,15 +1871,19 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
 			"dev": true,
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
 				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1940,21 +1973,21 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.2"
+				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -2659,10 +2692,13 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+			"integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
 			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2989,9 +3025,9 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"dev": true,
 			"dependencies": {
 				"bytes": "3.1.2",
@@ -3329,15 +3365,17 @@
 			}
 		},
 		"node_modules/set-function-length": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dev": true,
 			"dependencies": {
-				"define-data-property": "^1.1.1",
-				"get-intrinsic": "^1.2.1",
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.0"
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3383,14 +3421,18 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"get-intrinsic": "^1.0.2",
-				"object-inspect": "^1.9.0"
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3714,9 +3756,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3939,9 +3981,9 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-			"integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
 			"dev": true,
 			"dependencies": {
 				"colorette": "^2.0.10",
@@ -4202,9 +4244,9 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.15.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-			"integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,7 +18,7 @@
 		"@types/node": "20.10.5",
 		"dotenv-webpack": "8.0.0",
 		"ts-loader": "9.5.1",
-		"typescript": "5.4.4",
+		"typescript": "5.5.2",
 		"webpack": "5.73.0",
 		"webpack-cli": "4.10.0",
 		"webpack-dev-server": "4.11.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"ts-loader": "9.5.1",
 				"tsx": "4.7.2",
 				"typedoc": "0.25.12",
-				"typescript": "5.4.4"
+				"typescript": "5.5.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -14565,9 +14565,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -25926,9 +25926,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"dev": true
 		},
 		"typewise": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
 				"@types/leaflet": "1.7.11",
 				"@types/mapbox-gl": "2.7.3",
 				"@types/rbush": "3.0.0",
-				"@typescript-eslint/eslint-plugin": "7.5.0",
-				"@typescript-eslint/parser": "7.5.0",
+				"@typescript-eslint/eslint-plugin": "7.14.1",
+				"@typescript-eslint/parser": "7.14.1",
 				"eslint": "8.57.0",
 				"eslint-config-prettier": "9.0.0",
 				"eslint-plugin-prettier": "5.0.0",
@@ -38,7 +38,7 @@
 				"ts-jest": "29.1.2",
 				"ts-loader": "9.5.1",
 				"tsx": "4.7.2",
-				"typedoc": "0.25.12",
+				"typedoc": "^0.26.2",
 				"typescript": "5.5.2"
 			}
 		},
@@ -2837,9 +2837,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-			"integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -3799,6 +3799,12 @@
 			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
 			"dev": true
 		},
+		"node_modules/@shikijs/core": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.9.1.tgz",
+			"integrity": "sha512-EmUful2MQtY8KgCF1OkBtOuMcvaZEvmdubhW0UHCGXi21O9dRLeADVCj+k6ZS+de7Mz9d2qixOXJ+GLhcK3pXg==",
+			"dev": true
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4396,7 +4402,8 @@
 			"version": "7.0.13",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
 			"integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/leaflet": {
 			"version": "1.7.11",
@@ -4478,12 +4485,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/semver": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-			"dev": true
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -4512,22 +4513,20 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.5.0.tgz",
-			"integrity": "sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.14.1.tgz",
+			"integrity": "sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/type-utils": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/type-utils": "7.14.1",
+				"@typescript-eslint/utils": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
+				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4546,91 +4545,16 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
-			"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-			"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-			"dev": true,
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
-			"integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
+			"integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/typescript-estree": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4673,13 +4597,13 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
+			"integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4689,10 +4613,60 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.14.1.tgz",
+			"integrity": "sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "7.14.1",
+				"@typescript-eslint/utils": "7.14.1",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
+			"integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4703,19 +4677,19 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
+			"integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4740,9 +4714,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -4757,9 +4731,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -4777,14 +4751,48 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.14.1.tgz",
+			"integrity": "sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/typescript-estree": "7.14.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.56.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
+			"integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.14.1",
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -5161,12 +5169,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/ansi-sequence-parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-			"dev": true
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
@@ -7951,9 +7953,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -9002,9 +9004,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -10526,6 +10528,15 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10845,16 +10856,39 @@
 				"kdbush": "^4.0.2"
 			}
 		},
-		"node_modules/marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
 			"dev": true,
-			"bin": {
-				"marked": "bin/marked.js"
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/markdown-it/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
 			"engines": {
-				"node": ">= 12"
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/maxmin": {
@@ -10955,6 +10989,12 @@
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
 			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+			"dev": true
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"dev": true
 		},
 		"node_modules/meow": {
@@ -12442,6 +12482,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/pure-rand": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -13402,15 +13451,12 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.9.1.tgz",
+			"integrity": "sha512-8PDkgb5ja3nfujTjvC4VytL6wGOGCtFAClUb2r3QROevYXxcq+/shVJK5s6gy0HZnjaJgFxd6BpPqpRfqne5rA==",
 			"dev": true,
 			"dependencies": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
+				"@shikijs/core": "1.9.1"
 			}
 		},
 		"node_modules/side-channel": {
@@ -14520,24 +14566,25 @@
 			"dev": true
 		},
 		"node_modules/typedoc": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
-			"integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.2.tgz",
+			"integrity": "sha512-q/t+M+PZqhN9gPWLBZ3CCvP+KT8O1tyYkSzEYbcQ6mo89avdIrMlBEl3vfo5BgSzwC6Lbmq0W64E8RkY+eVsLA==",
 			"dev": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
-				"marked": "^4.3.0",
-				"minimatch": "^9.0.3",
-				"shiki": "^0.14.7"
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.4",
+				"shiki": "^1.9.0",
+				"yaml": "^2.4.5"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
 			}
 		},
 		"node_modules/typedoc/node_modules/brace-expansion": {
@@ -14550,9 +14597,9 @@
 			}
 		},
 		"node_modules/typedoc/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -14562,6 +14609,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typedoc/node_modules/yaml": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+			"integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+			"dev": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/typescript": {
@@ -14590,6 +14649,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
 			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+			"dev": true
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
 			"dev": true
 		},
 		"node_modules/uglify-js": {
@@ -14787,18 +14852,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"node_modules/vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-			"dev": true
 		},
 		"node_modules/vt-pbf": {
 			"version": "3.1.3",
@@ -17128,9 +17181,9 @@
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-			"integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
@@ -17876,6 +17929,12 @@
 				}
 			}
 		},
+		"@shikijs/core": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.9.1.tgz",
+			"integrity": "sha512-EmUful2MQtY8KgCF1OkBtOuMcvaZEvmdubhW0UHCGXi21O9dRLeADVCj+k6ZS+de7Mz9d2qixOXJ+GLhcK3pXg==",
+			"dev": true
+		},
 		"@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -18336,7 +18395,8 @@
 			"version": "7.0.13",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
 			"integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@types/leaflet": {
 			"version": "1.7.11",
@@ -18418,12 +18478,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/semver": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-			"dev": true
-		},
 		"@types/stack-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -18452,78 +18506,32 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.5.0.tgz",
-			"integrity": "sha512-HpqNTH8Du34nLxbKgVMGljZMG0rJd2O9ecvr2QLYp+7512ty1j42KnsFwspPXg1Vh8an9YImf6CokUBltisZFQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.14.1.tgz",
+			"integrity": "sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/type-utils": "7.5.0",
-				"@typescript-eslint/utils": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
-				"debug": "^4.3.4",
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/type-utils": "7.14.1",
+				"@typescript-eslint/utils": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
+				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"@typescript-eslint/type-utils": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.5.0.tgz",
-					"integrity": "sha512-A021Rj33+G8mx2Dqh0nMO9GyjjIBK3MqgVgZ2qlKf6CJy51wY/lkkFqq3TqqnH34XyAHUkq27IjlUkWlQRpLHw==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/typescript-estree": "7.5.0",
-						"@typescript-eslint/utils": "7.5.0",
-						"debug": "^4.3.4",
-						"ts-api-utils": "^1.0.1"
-					}
-				},
-				"@typescript-eslint/utils": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
-					"integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
-					"dev": true,
-					"requires": {
-						"@eslint-community/eslint-utils": "^4.4.0",
-						"@types/json-schema": "^7.0.12",
-						"@types/semver": "^7.5.0",
-						"@typescript-eslint/scope-manager": "7.5.0",
-						"@typescript-eslint/types": "7.5.0",
-						"@typescript-eslint/typescript-estree": "7.5.0",
-						"semver": "^7.5.4"
-					}
-				},
-				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
+				"ts-api-utils": "^1.3.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.5.0.tgz",
-			"integrity": "sha512-cj+XGhNujfD2/wzR1tabNsidnYRaFfEkcULdcIyVBYcXjBvBKOes+mpMBP7hMpOyk+gBcfXsrg4NBGAStQyxjQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
+			"integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "7.5.0",
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/typescript-estree": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/typescript-estree": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"debug": "^4.3.4"
 			},
 			"dependencies": {
@@ -18545,35 +18553,64 @@
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
-			"integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
+			"integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0"
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1"
+			}
+		},
+		"@typescript-eslint/type-utils": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.14.1.tgz",
+			"integrity": "sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/typescript-estree": "7.14.1",
+				"@typescript-eslint/utils": "7.14.1",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+					"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
-			"integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
+			"integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
-			"integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
+			"integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "7.5.0",
-				"@typescript-eslint/visitor-keys": "7.5.0",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/visitor-keys": "7.14.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -18586,18 +18623,18 @@
 					}
 				},
 				"debug": {
-					"version": "4.3.4",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"version": "4.3.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+					"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
 				},
 				"minimatch": {
-					"version": "9.0.3",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"version": "9.0.5",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+					"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^2.0.1"
@@ -18608,17 +18645,35 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
-			"integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
+		"@typescript-eslint/utils": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.14.1.tgz",
+			"integrity": "sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "7.5.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "7.14.1",
+				"@typescript-eslint/types": "7.14.1",
+				"@typescript-eslint/typescript-estree": "7.14.1"
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
+			"integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "7.14.1",
+				"eslint-visitor-keys": "^3.4.3"
 			}
 		},
 		"@ungap/structured-clone": {
@@ -18943,12 +18998,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true
-		},
-		"ansi-sequence-parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -21010,9 +21059,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -21818,9 +21867,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true
 		},
 		"import-cwd": {
@@ -22952,6 +23001,15 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
+		"linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"requires": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -23230,11 +23288,33 @@
 				}
 			}
 		},
-		"marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-			"dev": true
+		"markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"entities": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+					"dev": true
+				}
+			}
 		},
 		"maxmin": {
 			"version": "2.1.0",
@@ -23312,6 +23392,12 @@
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
 			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+			"dev": true
+		},
+		"mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"dev": true
 		},
 		"meow": {
@@ -24331,6 +24417,12 @@
 			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true
 		},
+		"punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true
+		},
 		"pure-rand": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -25059,15 +25151,12 @@
 			"dev": true
 		},
 		"shiki": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.9.1.tgz",
+			"integrity": "sha512-8PDkgb5ja3nfujTjvC4VytL6wGOGCtFAClUb2r3QROevYXxcq+/shVJK5s6gy0HZnjaJgFxd6BpPqpRfqne5rA==",
 			"dev": true,
 			"requires": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
+				"@shikijs/core": "1.9.1"
 			}
 		},
 		"side-channel": {
@@ -25894,15 +25983,16 @@
 			"dev": true
 		},
 		"typedoc": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
-			"integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.2.tgz",
+			"integrity": "sha512-q/t+M+PZqhN9gPWLBZ3CCvP+KT8O1tyYkSzEYbcQ6mo89avdIrMlBEl3vfo5BgSzwC6Lbmq0W64E8RkY+eVsLA==",
 			"dev": true,
 			"requires": {
 				"lunr": "^2.3.9",
-				"marked": "^4.3.0",
-				"minimatch": "^9.0.3",
-				"shiki": "^0.14.7"
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.4",
+				"shiki": "^1.9.0",
+				"yaml": "^2.4.5"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -25915,13 +26005,19 @@
 					}
 				},
 				"minimatch": {
-					"version": "9.0.3",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"version": "9.0.5",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+					"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^2.0.1"
 					}
+				},
+				"yaml": {
+					"version": "2.4.5",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+					"integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+					"dev": true
 				}
 			}
 		},
@@ -25944,6 +26040,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
 			"integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+			"dev": true
+		},
+		"uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
 			"dev": true
 		},
 		"uglify-js": {
@@ -26087,18 +26189,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"dev": true
-		},
-		"vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
 			"dev": true
 		},
 		"vt-pbf": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
 		"@types/leaflet": "1.7.11",
 		"@types/mapbox-gl": "2.7.3",
 		"@types/rbush": "3.0.0",
-		"@typescript-eslint/eslint-plugin": "7.5.0",
-		"@typescript-eslint/parser": "7.5.0",
+		"@typescript-eslint/eslint-plugin": "7.14.1",
+		"@typescript-eslint/parser": "7.14.1",
 		"eslint": "8.57.0",
 		"eslint-config-prettier": "9.0.0",
 		"eslint-plugin-prettier": "5.0.0",
@@ -80,7 +80,7 @@
 		"ts-jest": "29.1.2",
 		"ts-loader": "9.5.1",
 		"tsx": "4.7.2",
-		"typedoc": "0.25.12",
+		"typedoc": "^0.26.2",
 		"typescript": "5.5.2"
 	},
 	"commitlint": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"ts-loader": "9.5.1",
 		"tsx": "4.7.2",
 		"typedoc": "0.25.12",
-		"typescript": "5.4.4"
+		"typescript": "5.5.2"
 	},
 	"commitlint": {
 		"extends": [


### PR DESCRIPTION
## Description of Changes

Updates TypeScript across the codebase to version 5.5. Also bumps relating eslint packages to latest versions.

## Link to Issue

<!--- Please provide a link to the issue for reference. If you have not created an issue, please do so before raising a PR so that it is possible to discuss the changes in advance -->

## PR Checklist

- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 