### PR TITLE
chore: move all deprecated jest toBeCalled -> toHaveBeenCalled

### DIFF
--- a/src/adapters/arcgis-maps-sdk.adapter.spec.ts
+++ b/src/adapters/arcgis-maps-sdk.adapter.spec.ts
@@ -120,8 +120,8 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 
 			adapter.register(createMockCallbacks());
 			adapter.unregister();
-			expect(removeAll).toBeCalledTimes(1);
-			expect(remove).toBeCalledTimes(2);
+			expect(removeAll).toHaveBeenCalledTimes(1);
+			expect(remove).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -200,12 +200,12 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			});
 
 			adapter.project(0, 0);
-			expect(mockPointImplementation).toBeCalledWith({
+			expect(mockPointImplementation).toHaveBeenCalledWith({
 				latitude: 0,
 				longitude: 0,
 			});
 			expect(map.toScreen).toHaveBeenCalledTimes(1);
-			expect(map.toScreen).toBeCalledWith({ x: 0, y: 0 });
+			expect(map.toScreen).toHaveBeenCalledWith({ x: 0, y: 0 });
 		});
 
 		it("unproject", () => {
@@ -221,7 +221,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			// Test enabling dragging
 			adapter.unproject(0, 0);
 			expect(map.toMap).toHaveBeenCalledTimes(1);
-			expect(map.toMap).toBeCalledWith({ x: 0, y: 0 });
+			expect(map.toMap).toHaveBeenCalledWith({ x: 0, y: 0 });
 		});
 	});
 
@@ -341,9 +341,9 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 				},
 			);
 
-			expect(graphicsMock.add).toBeCalledTimes(1);
+			expect(graphicsMock.add).toHaveBeenCalledTimes(1);
 			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall);
-			expect(removeMock).not.toBeCalled();
+			expect(removeMock).not.toHaveBeenCalled();
 		});
 
 		it("handles updated ids", () => {
@@ -374,7 +374,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			expect(graphicsMock.find).toHaveBeenCalledTimes(1);
 			expect(removeMock).toHaveBeenCalledTimes(1);
 			expect(removeMock).toHaveBeenLastCalledWith(mockedFeature);
-			expect(graphicsMock.add).toBeCalledTimes(1);
+			expect(graphicsMock.add).toHaveBeenCalledTimes(1);
 			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall);
 		});
 
@@ -394,7 +394,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			expect(graphicsMock.find).toHaveBeenCalledTimes(1);
 			expect(removeMock).toHaveBeenCalledTimes(1);
 			expect(removeMock).toHaveBeenCalledWith(mockedFeature);
-			expect(graphicsMock.add).not.toBeCalled();
+			expect(graphicsMock.add).not.toHaveBeenCalled();
 		});
 
 		describe("point", () => {

--- a/src/adapters/common/adapter-listener.spec.ts
+++ b/src/adapters/common/adapter-listener.spec.ts
@@ -26,7 +26,7 @@ describe("AdapterListener", () => {
 			});
 			listener.callback();
 
-			expect(callback).toBeCalledTimes(1);
+			expect(callback).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -43,8 +43,8 @@ describe("AdapterListener", () => {
 
 			listener.register();
 
-			expect(register).toBeCalledTimes(1);
-			expect(register).toBeCalledWith(callback);
+			expect(register).toHaveBeenCalledTimes(1);
+			expect(register).toHaveBeenCalledWith(callback);
 		});
 	});
 
@@ -61,7 +61,7 @@ describe("AdapterListener", () => {
 
 			listener.unregister(callback);
 
-			expect(unregister).toBeCalledWith(callback);
+			expect(unregister).toHaveBeenCalledWith(callback);
 		});
 	});
 });

--- a/src/adapters/leaflet.adapter.spec.ts
+++ b/src/adapters/leaflet.adapter.spec.ts
@@ -129,7 +129,7 @@ describe("TerraDrawLeafletAdapter", () => {
 		// Test enabling dragging
 		adapter.project(0, 0);
 		expect(map.latLngToContainerPoint).toHaveBeenCalledTimes(1);
-		expect(map.latLngToContainerPoint).toBeCalledWith({ lat: 0, lng: 0 });
+		expect(map.latLngToContainerPoint).toHaveBeenCalledWith({ lat: 0, lng: 0 });
 	});
 
 	it("unproject", () => {
@@ -145,7 +145,7 @@ describe("TerraDrawLeafletAdapter", () => {
 		// Test enabling dragging
 		adapter.unproject(0, 0);
 		expect(map.containerPointToLatLng).toHaveBeenCalledTimes(1);
-		expect(map.containerPointToLatLng).toBeCalledWith({ x: 0, y: 0 });
+		expect(map.containerPointToLatLng).toHaveBeenCalledWith({ x: 0, y: 0 });
 	});
 
 	it("setCursor", () => {
@@ -276,9 +276,9 @@ describe("TerraDrawLeafletAdapter", () => {
 				},
 			);
 
-			expect(lib.geoJSON).toBeCalledTimes(2);
-			expect(map.addLayer).toBeCalledTimes(2); // 1 for created 1 for updated
-			expect(map.removeLayer).toBeCalledTimes(2); // 1 for update 1 for delete
+			expect(lib.geoJSON).toHaveBeenCalledTimes(2);
+			expect(map.addLayer).toHaveBeenCalledTimes(2); // 1 for created 1 for updated
+			expect(map.removeLayer).toHaveBeenCalledTimes(2); // 1 for update 1 for delete
 		});
 	});
 
@@ -325,6 +325,6 @@ describe("TerraDrawLeafletAdapter", () => {
 
 		adapter.clear();
 
-		expect(map.removeLayer).toBeCalledTimes(1);
+		expect(map.removeLayer).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/adapters/mapbox-gl.adapter.spec.ts
+++ b/src/adapters/mapbox-gl.adapter.spec.ts
@@ -118,7 +118,7 @@ describe("TerraDrawMapboxGLAdapter", () => {
 		// Test enabling dragging
 		adapter.project(0, 0);
 		expect(map.project).toHaveBeenCalledTimes(1);
-		expect(map.project).toBeCalledWith({ lat: 0, lng: 0 });
+		expect(map.project).toHaveBeenCalledWith({ lat: 0, lng: 0 });
 	});
 
 	it("unproject", () => {
@@ -130,7 +130,7 @@ describe("TerraDrawMapboxGLAdapter", () => {
 		// Test enabling dragging
 		adapter.unproject(0, 0);
 		expect(map.unproject).toHaveBeenCalledTimes(1);
-		expect(map.unproject).toBeCalledWith({ x: 0, y: 0 });
+		expect(map.unproject).toHaveBeenCalledWith({ x: 0, y: 0 });
 	});
 
 	it("setCursor", () => {

--- a/src/modes/circle/circle.mode.spec.ts
+++ b/src/modes/circle/circle.mode.spec.ts
@@ -159,8 +159,8 @@ describe("TerraDrawCircleMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onChange).toBeCalledTimes(1);
-					expect(onChange).toBeCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 				});
 
 				it("finishes drawing circle on second click", () => {
@@ -188,10 +188,10 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					expect(onChange).toBeCalledTimes(3);
-					expect(onChange).toBeCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledTimes(3);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 
-					expect(onFinish).toBeCalledTimes(1);
+					expect(onFinish).toHaveBeenCalledTimes(1);
 				});
 			});
 
@@ -220,8 +220,8 @@ describe("TerraDrawCircleMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onChange).toBeCalledTimes(1);
-					expect(onChange).toBeCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 					expect(store.copyAll()[0].properties.radiusKilometers).toStrictEqual(
 						1000,
 					);
@@ -272,10 +272,10 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					expect(onChange).toBeCalledTimes(1);
-					expect(onChange).toBeCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 
-					expect(onFinish).toBeCalledTimes(0);
+					expect(onFinish).toHaveBeenCalledTimes(0);
 				});
 
 				it("does finish drawing circle on second click if validation returns true", () => {
@@ -305,9 +305,9 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					expect(onChange).toBeCalledTimes(3);
-					expect(onChange).toBeCalledWith([expect.any(String)], "create");
-					expect(onFinish).toBeCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(3);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onFinish).toHaveBeenCalledTimes(1);
 					expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 						action: "draw",
 						mode: "circle",
@@ -358,9 +358,9 @@ describe("TerraDrawCircleMode", () => {
 			features = store.copyAll();
 			expect(features.length).toBe(1);
 
-			expect(onChange).toBeCalledTimes(1);
-			expect(onChange).toBeCalledWith([expect.any(String)], "create");
-			expect(onFinish).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onFinish).toHaveBeenCalledTimes(1);
 			expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 				action: "draw",
 				mode: "circle",
@@ -395,7 +395,7 @@ describe("TerraDrawCircleMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenNthCalledWith(
 				1,
 				[expect.any(String)],
@@ -412,7 +412,7 @@ describe("TerraDrawCircleMode", () => {
 				button: "left",
 				heldKeys: [],
 			});
-			expect(onChange).toBeCalledTimes(3);
+			expect(onChange).toHaveBeenCalledTimes(3);
 			expect(onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],
@@ -445,7 +445,7 @@ describe("TerraDrawCircleMode", () => {
 
 		it("does not delete if no circle has been created", () => {
 			circleMode.cleanUp();
-			expect(onChange).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
 		});
 
 		it("does delete if a circle has been created", () => {
@@ -460,7 +460,7 @@ describe("TerraDrawCircleMode", () => {
 
 			circleMode.cleanUp();
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 			expect(onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],

--- a/src/modes/click-bounding-box.behavior.spec.ts
+++ b/src/modes/click-bounding-box.behavior.spec.ts
@@ -27,7 +27,7 @@ describe("ClickBoundingBoxBehavior", () => {
 			const bbox = clickBoundingBoxBehavior.create(mockDrawEvent());
 
 			// Ensure unproject is called correctly with screen space square
-			expect(config.unproject).toBeCalledTimes(5);
+			expect(config.unproject).toHaveBeenCalledTimes(5);
 			expect(config.unproject).toHaveBeenNthCalledWith(1, -20, -20);
 			expect(config.unproject).toHaveBeenNthCalledWith(2, 20, -20);
 			expect(config.unproject).toHaveBeenNthCalledWith(3, 20, 20);

--- a/src/modes/freehand/freehand.mode.spec.ts
+++ b/src/modes/freehand/freehand.mode.spec.ts
@@ -150,8 +150,8 @@ describe("TerraDrawFreehandMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(1);
-				expect(onChange).toBeCalledWith(
+				expect(onChange).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledWith(
 					[expect.any(String), expect.any(String)],
 					"create",
 				);
@@ -183,8 +183,8 @@ describe("TerraDrawFreehandMode", () => {
 				features = store.copyAll();
 				expect(features.length).toBe(1);
 
-				expect(onChange).toBeCalledTimes(2);
-				expect(onChange).toBeCalledWith(
+				expect(onChange).toHaveBeenCalledTimes(2);
+				expect(onChange).toHaveBeenCalledWith(
 					[expect.any(String), expect.any(String)],
 					"create",
 				);
@@ -237,8 +237,8 @@ describe("TerraDrawFreehandMode", () => {
 				features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				expect(onChange).toBeCalledTimes(1);
-				expect(onFinish).not.toBeCalled();
+				expect(onChange).toHaveBeenCalledTimes(1);
+				expect(onFinish).not.toHaveBeenCalled();
 			});
 
 			it("does finish drawing polygon on second click because validate returns true", () => {
@@ -306,7 +306,7 @@ describe("TerraDrawFreehandMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenNthCalledWith(
 				1,
 				[expect.any(String), expect.any(String)],
@@ -336,7 +336,7 @@ describe("TerraDrawFreehandMode", () => {
 				});
 			}
 
-			expect(onChange).toBeCalledTimes(6);
+			expect(onChange).toHaveBeenCalledTimes(6);
 
 			const updatedFeature = store.copyAll()[0];
 
@@ -356,7 +356,7 @@ describe("TerraDrawFreehandMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -374,7 +374,7 @@ describe("TerraDrawFreehandMode", () => {
 
 		it("does not delete if no freehand has been created", () => {
 			freehandMode.cleanUp();
-			expect(onChange).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
 		});
 
 		it("does delete if a freehand has been created", () => {
@@ -389,7 +389,7 @@ describe("TerraDrawFreehandMode", () => {
 
 			freehandMode.cleanUp();
 
-			expect(onChange).toBeCalledTimes(3);
+			expect(onChange).toHaveBeenCalledTimes(3);
 			expect(onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],
@@ -504,7 +504,7 @@ describe("TerraDrawFreehandMode", () => {
 				features = store.copyAll();
 				expect(features.length).toBe(1);
 
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 				expect(onChange).toHaveBeenNthCalledWith(
 					1,
 					[expect.any(String), expect.any(String)],

--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -128,7 +128,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).not.toBeCalled();
+			expect(onChange).not.toHaveBeenCalled();
 		});
 
 		it("updates the coordinate to the mouse position if a coordinate has been created", () => {
@@ -150,7 +150,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			const features = store.copyAll();
 			expect(features.length).toBe(1);
@@ -188,7 +188,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 
 			const features = store.copyAll();
 			expect(features.length).toBe(1);
@@ -227,7 +227,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(4);
+			expect(onChange).toHaveBeenCalledTimes(4);
 
 			const features = store.copyAll();
 
@@ -305,7 +305,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).not.toBeCalledWith([expect.any(String)], "delete");
+			expect(onChange).not.toHaveBeenCalledWith([expect.any(String)], "delete");
 
 			lineStringMode.onClick({
 				lng: 2,
@@ -316,7 +316,7 @@ describe("TerraDrawLineStringMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(9);
+			expect(onChange).toHaveBeenCalledTimes(9);
 
 			expect(onChange).toHaveBeenNthCalledWith(
 				9,
@@ -414,7 +414,7 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(7);
+				expect(onChange).toHaveBeenCalledTimes(7);
 
 				lineStringMode.onClick({
 					lng: -8.173828125,
@@ -427,7 +427,7 @@ describe("TerraDrawLineStringMode", () => {
 
 				// Update geometry is NOT called because
 				// there is a self intersection
-				expect(onChange).toBeCalledTimes(7);
+				expect(onChange).toHaveBeenCalledTimes(7);
 			});
 
 			it("does create a line if no intersections and validate returns true", () => {
@@ -510,7 +510,10 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalledWith([expect.any(String)], "delete");
+				expect(onChange).not.toHaveBeenCalledWith(
+					[expect.any(String)],
+					"delete",
+				);
 
 				lineStringMode.onClick({
 					lng: 2,
@@ -521,7 +524,7 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(9);
+				expect(onChange).toHaveBeenCalledTimes(9);
 
 				expect(onChange).toHaveBeenNthCalledWith(
 					9,
@@ -657,7 +660,10 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalledWith([expect.any(String)], "delete");
+				expect(onChange).not.toHaveBeenCalledWith(
+					[expect.any(String)],
+					"delete",
+				);
 
 				lineStringMode.onKeyUp({
 					key: "Enter",
@@ -665,7 +671,7 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(8);
+				expect(onChange).toHaveBeenCalledTimes(8);
 
 				expect(onChange).toHaveBeenNthCalledWith(
 					8,
@@ -761,7 +767,10 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalledWith([expect.any(String)], "delete");
+				expect(onChange).not.toHaveBeenCalledWith(
+					[expect.any(String)],
+					"delete",
+				);
 
 				lineStringMode.onKeyUp({
 					key: "Enter",
@@ -769,7 +778,7 @@ describe("TerraDrawLineStringMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(6);
+				expect(onChange).toHaveBeenCalledTimes(6);
 
 				features = store.copyAll();
 				expect(features.length).toBe(2);

--- a/src/modes/point/point.mode.spec.ts
+++ b/src/modes/point/point.mode.spec.ts
@@ -119,8 +119,8 @@ describe("TerraDrawPointMode", () => {
 				containerY: 0,
 			} as TerraDrawMouseEvent);
 
-			expect(mockConfig.onChange).toBeCalledTimes(1);
-			expect(mockConfig.onChange).toBeCalledWith(
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
+			expect(mockConfig.onChange).toHaveBeenCalledWith(
 				[expect.any(String)],
 				"create",
 			);
@@ -145,8 +145,8 @@ describe("TerraDrawPointMode", () => {
 					containerY: 0,
 				} as TerraDrawMouseEvent);
 
-				expect(mockConfig.onChange).toBeCalledTimes(0);
-				expect(mockConfig.onChange).not.toBeCalledWith(
+				expect(mockConfig.onChange).toHaveBeenCalledTimes(0);
+				expect(mockConfig.onChange).not.toHaveBeenCalledWith(
 					[expect.any(String)],
 					"create",
 				);
@@ -170,8 +170,8 @@ describe("TerraDrawPointMode", () => {
 					containerY: 0,
 				} as TerraDrawMouseEvent);
 
-				expect(mockConfig.onChange).toBeCalledTimes(1);
-				expect(mockConfig.onChange).toBeCalledWith(
+				expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
+				expect(mockConfig.onChange).toHaveBeenCalledWith(
 					[expect.any(String)],
 					"create",
 				);

--- a/src/modes/polygon/behaviors/closing-points.behavior.spec.ts
+++ b/src/modes/polygon/behaviors/closing-points.behavior.spec.ts
@@ -144,7 +144,7 @@ describe("ClosingPointsBehavior", () => {
 					"polygon",
 				);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 
 				startEndPointBehavior.update([
 					[0, 0],
@@ -154,7 +154,7 @@ describe("ClosingPointsBehavior", () => {
 					[0, 0],
 				]);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
 

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -137,7 +137,7 @@ describe("TerraDrawPolygonMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).not.toBeCalled();
+			expect(onChange).not.toHaveBeenCalled();
 		});
 
 		it("updates the coordinate to the mouse position after first click", () => {
@@ -159,7 +159,7 @@ describe("TerraDrawPolygonMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			const features = store.copyAll();
 			expect(features.length).toBe(1);
@@ -211,7 +211,7 @@ describe("TerraDrawPolygonMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(4);
+			expect(onChange).toHaveBeenCalledTimes(4);
 
 			const features = store.copyAll();
 			expect(features.length).toBe(1);
@@ -285,7 +285,7 @@ describe("TerraDrawPolygonMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(7);
+			expect(onChange).toHaveBeenCalledTimes(7);
 
 			// 1 times for the polygon
 			// 2 times for the closing points
@@ -772,37 +772,37 @@ describe("TerraDrawPolygonMode", () => {
 			polygonMode.onMouseMove(firstPoint);
 			polygonMode.onClick(firstPoint);
 
-			expect(store.updateGeometry).toBeCalledTimes(0);
-			expect(store.create).toBeCalledTimes(1);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(0);
+			expect(store.create).toHaveBeenCalledTimes(1);
 
 			polygonMode.onMouseMove(firstPoint);
-			expect(store.updateGeometry).toBeCalledTimes(1);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(1);
 
 			// Nothing happens here because the coordinates
 			// are identical
 
 			polygonMode.onClick(firstPoint);
-			expect(store.updateGeometry).toBeCalledTimes(1);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(1);
 
 			const secondPoint = mockDrawEvent({
 				lng: 2,
 				lat: 2,
 			});
 			polygonMode.onMouseMove(secondPoint);
-			expect(store.updateGeometry).toBeCalledTimes(2);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(2);
 
 			// This now updates because the coordinate is different
 
 			polygonMode.onClick(secondPoint);
-			expect(store.updateGeometry).toBeCalledTimes(3);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(3);
 
 			polygonMode.onMouseMove(secondPoint);
-			expect(store.updateGeometry).toBeCalledTimes(4);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(4);
 
 			// Again nothing happens because the coordinate is identical
 
 			polygonMode.onClick(secondPoint);
-			expect(store.updateGeometry).toBeCalledTimes(4);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(4);
 
 			const thirdPoint = mockDrawEvent({
 				lng: 3,
@@ -810,26 +810,26 @@ describe("TerraDrawPolygonMode", () => {
 			});
 
 			polygonMode.onMouseMove(thirdPoint);
-			expect(store.updateGeometry).toBeCalledTimes(5);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(5);
 
 			// This now updates because the coordinate is different
 
 			polygonMode.onClick(thirdPoint);
-			expect(store.updateGeometry).toBeCalledTimes(6);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(6);
 
 			// We have to mock project in the final block
 			project.mockReturnValueOnce({ x: 0, y: 0 });
 			project.mockReturnValueOnce({ x: 0, y: 0 });
 
 			polygonMode.onMouseMove(thirdPoint);
-			expect(store.updateGeometry).toBeCalledTimes(7);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(7);
 
 			// We have to mock project in the final block
 			project.mockReturnValueOnce({ x: 100, y: 100 });
 			project.mockReturnValueOnce({ x: 100, y: 100 });
 
 			polygonMode.onClick(thirdPoint);
-			expect(store.updateGeometry).toBeCalledTimes(7);
+			expect(store.updateGeometry).toHaveBeenCalledTimes(7);
 		});
 
 		describe("validate", () => {
@@ -928,7 +928,7 @@ describe("TerraDrawPolygonMode", () => {
 				// No closing points as feature is closed
 				features = store.copyAll();
 				expect(features.length).toBe(1);
-				expect(project).toBeCalledTimes(8);
+				expect(project).toHaveBeenCalledTimes(8);
 
 				// The overlapping coordinate is not included
 				expect(features[0].geometry.coordinates).toStrictEqual([

--- a/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/src/modes/rectangle/rectangle.mode.spec.ts
@@ -151,8 +151,8 @@ describe("TerraDrawRectangleMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(1);
-				expect(onChange).toBeCalledWith([expect.any(String)], "create");
+				expect(onChange).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 			});
 
 			it("finishes drawing rectangle on second click", () => {
@@ -180,8 +180,8 @@ describe("TerraDrawRectangleMode", () => {
 				features = store.copyAll();
 				expect(features.length).toBe(1);
 
-				expect(onChange).toBeCalledTimes(2);
-				expect(onChange).toBeCalledWith([expect.any(String)], "create");
+				expect(onChange).toHaveBeenCalledTimes(2);
+				expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 				expect(onFinish).toHaveBeenCalledTimes(1);
 				expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 					action: "draw",
@@ -239,9 +239,9 @@ describe("TerraDrawRectangleMode", () => {
 			// Two as the rectangle has been closed via enter
 			expect(features.length).toBe(2);
 
-			expect(onChange).toBeCalledTimes(2);
-			expect(onChange).toBeCalledWith([expect.any(String)], "create");
-			expect(onFinish).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(2);
+			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onFinish).toHaveBeenCalledTimes(1);
 		});
 
 		it("does not finish on key press when keyEvents null", () => {
@@ -277,9 +277,9 @@ describe("TerraDrawRectangleMode", () => {
 			// Only one as the click will close the rectangle
 			expect(features.length).toBe(1);
 
-			expect(onChange).toBeCalledTimes(1);
-			expect(onChange).toBeCalledWith([expect.any(String)], "create");
-			expect(onFinish).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onFinish).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -310,7 +310,7 @@ describe("TerraDrawRectangleMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 			expect(onChange).toHaveBeenNthCalledWith(
 				1,
 				[expect.any(String)],
@@ -327,7 +327,7 @@ describe("TerraDrawRectangleMode", () => {
 				button: "left",
 				heldKeys: [],
 			});
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 			expect(onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],
@@ -360,7 +360,7 @@ describe("TerraDrawRectangleMode", () => {
 
 		it("does not delete if no rectangle has been created", () => {
 			rectangleMode.cleanUp();
-			expect(onChange).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
 		});
 
 		it("does delete if a rectangle has been created", () => {
@@ -375,7 +375,7 @@ describe("TerraDrawRectangleMode", () => {
 
 			rectangleMode.cleanUp();
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 			expect(onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -141,7 +141,7 @@ describe("DragCoordinateResizeBehavior", () => {
 					"center-web-mercator",
 				);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("returns early if geometry is a point", () => {
@@ -153,7 +153,7 @@ describe("DragCoordinateResizeBehavior", () => {
 					"center-web-mercator",
 				);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			describe("validation", () => {
@@ -180,7 +180,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						},
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(0);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 				});
 			});
 
@@ -205,7 +205,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"center-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 
 				it("updates the LineString coordinate if within pointer distance", () => {
@@ -227,7 +227,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"center-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 			});
 
@@ -252,7 +252,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"opposite-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 
 				it("updates the LineString coordinate if within pointer distance", () => {
@@ -274,7 +274,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"opposite-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 			});
 
@@ -299,7 +299,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"center-fixed-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 
 				it("updates the LineString coordinate if within pointer distance", () => {
@@ -321,7 +321,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"center-fixed-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 			});
 
@@ -346,7 +346,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"opposite-fixed-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 
 				it("updates the LineString coordinate if within pointer distance", () => {
@@ -368,7 +368,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						"opposite-fixed-web-mercator",
 					);
 
-					expect(config.store.updateGeometry).toBeCalledTimes(1);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 				});
 			});
 		});

--- a/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -139,7 +139,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("returns early if geometry is a point", () => {
@@ -148,7 +148,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("validation returning false means updates are not called", () => {
@@ -167,7 +167,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true, () => false);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("validation returning false means updates are not called", () => {
@@ -186,7 +186,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true, () => true);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("updates the Polygon coordinate if within pointer distance", () => {
@@ -205,7 +205,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("updates the LineString coordinate if within pointer distance", () => {
@@ -220,7 +220,7 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.drag(mockDrawEvent(), true);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("does not update Polygon coordinate of self-intersecting Polygon if self-intersections are disabled", () => {
@@ -250,7 +250,7 @@ describe("DragCoordinateBehavior", () => {
 					lat: 0,
 				} as Partial<TerraDrawMouseEvent>);
 				dragCoordinateBehavior.drag(mde, false);
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("does not update LineString coordinate of self-intersecting LineString if self-intersections are disabled", () => {
@@ -276,7 +276,7 @@ describe("DragCoordinateBehavior", () => {
 					lat: 0,
 				} as Partial<TerraDrawMouseEvent>);
 				dragCoordinateBehavior.drag(mde, false);
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 		});
 	});

--- a/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -111,8 +111,8 @@ describe("DragFeatureBehavior", () => {
 
 				dragFeatureBehavior.drag(event);
 
-				expect(config.store.getGeometryCopy).toBeCalledTimes(0);
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("updates the polygon to the dragged position", () => {
@@ -135,8 +135,8 @@ describe("DragFeatureBehavior", () => {
 
 				dragFeatureBehavior.drag(mockDrawEvent());
 
-				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("validation returning false does not update the polygon to the dragged position", () => {
@@ -159,8 +159,8 @@ describe("DragFeatureBehavior", () => {
 
 				dragFeatureBehavior.drag(mockDrawEvent(), () => false);
 
-				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("validation returning true does update the polygon to the dragged position", () => {
@@ -183,8 +183,8 @@ describe("DragFeatureBehavior", () => {
 
 				dragFeatureBehavior.drag(mockDrawEvent(), () => true);
 
-				expect(config.store.getGeometryCopy).toBeCalledTimes(1);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/src/modes/select/behaviors/midpoint.behavior.spec.ts
+++ b/src/modes/select/behaviors/midpoint.behavior.spec.ts
@@ -86,7 +86,7 @@ describe("MidPointBehavior", () => {
 
 				jest.spyOn(config.store, "create");
 				const createdId = createStoreLineString(config);
-				expect(config.store.create).toBeCalledTimes(1);
+				expect(config.store.create).toHaveBeenCalledTimes(1);
 
 				midPointBehavior.create(
 					[
@@ -97,7 +97,7 @@ describe("MidPointBehavior", () => {
 					coordinatePrecision,
 				);
 
-				expect(config.store.create).toBeCalledTimes(2);
+				expect(config.store.create).toHaveBeenCalledTimes(2);
 				expect(midPointBehavior.ids.length).toBe(1);
 				expect(midPointBehavior.ids[0]).toBeUUID4();
 			});
@@ -191,7 +191,7 @@ describe("MidPointBehavior", () => {
 
 					jest.spyOn(config.store, "create");
 					const createdId = createStoreLineString(config);
-					expect(config.store.create).toBeCalledTimes(1);
+					expect(config.store.create).toHaveBeenCalledTimes(1);
 
 					midPointBehavior.create(
 						[
@@ -218,7 +218,7 @@ describe("MidPointBehavior", () => {
 
 					midPointBehavior.insert(midPointId, coordinatePrecision);
 
-					expect(config.store.create).toBeCalledTimes(4);
+					expect(config.store.create).toHaveBeenCalledTimes(4);
 
 					// New Midpoints
 					createCalls[2][0].forEach((call: any, i: number) => {
@@ -249,7 +249,7 @@ describe("MidPointBehavior", () => {
 
 					jest.spyOn(config.store, "create");
 					const createdId = createStorePolygon(config);
-					expect(config.store.create).toBeCalledTimes(1);
+					expect(config.store.create).toHaveBeenCalledTimes(1);
 
 					midPointBehavior.create(
 						[
@@ -279,7 +279,7 @@ describe("MidPointBehavior", () => {
 
 					midPointBehavior.insert(midPointId, coordinatePrecision);
 
-					expect(config.store.create).toBeCalledTimes(4);
+					expect(config.store.create).toHaveBeenCalledTimes(4);
 
 					// New Midpoints
 					createCalls[2][0].forEach((call: any, i: number) => {

--- a/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -45,7 +45,7 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("first event sets the initial bearing and does not update the LineString", () => {
@@ -53,7 +53,7 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("second event rotates the LineString", () => {
@@ -61,7 +61,7 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("second event rotates the Polygon", () => {
@@ -69,7 +69,7 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
 
@@ -83,7 +83,7 @@ describe("RotateFeatureBehavior", () => {
 				rotateFeatureBehavior.reset();
 				rotateFeatureBehavior.rotate(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 		});
 	});

--- a/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -45,7 +45,7 @@ describe("ScaleFeatureBehavior", () => {
 
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("first event sets the initial bearing and does not update the LineString", () => {
@@ -53,7 +53,7 @@ describe("ScaleFeatureBehavior", () => {
 
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("second event scales the LineString", () => {
@@ -61,7 +61,7 @@ describe("ScaleFeatureBehavior", () => {
 
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("second event scales the Polygon", () => {
@@ -69,7 +69,7 @@ describe("ScaleFeatureBehavior", () => {
 
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
-				expect(config.store.updateGeometry).toBeCalledTimes(1);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
 
@@ -83,7 +83,7 @@ describe("ScaleFeatureBehavior", () => {
 				scaleFeatureBehavior.reset();
 				scaleFeatureBehavior.scale(mockDrawEvent(), id);
 
-				expect(config.store.updateGeometry).toBeCalledTimes(0);
+				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 		});
 	});

--- a/src/modes/select/select.mode.spec.ts
+++ b/src/modes/select/select.mode.spec.ts
@@ -231,9 +231,9 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalled();
-				expect(onDeselect).not.toBeCalled();
-				expect(onSelect).not.toBeCalled();
+				expect(onChange).not.toHaveBeenCalled();
+				expect(onDeselect).not.toHaveBeenCalled();
+				expect(onSelect).not.toHaveBeenCalled();
 			});
 
 			describe("point", () => {
@@ -260,7 +260,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 				});
 
 				it("does not select if feature is not clicked", () => {
@@ -286,7 +286,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(0);
+					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 
 				it("does not select if selectable flag is false", () => {
@@ -314,7 +314,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(0);
+					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 
 				it("deselects selected when click is not on same or different feature", () => {
@@ -341,7 +341,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 
 					mockMouseEventBoundingBox();
 
@@ -354,8 +354,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onDeselect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onDeselect).toHaveBeenCalledTimes(1);
 				});
 			});
 
@@ -392,7 +392,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 				});
 
 				it("does not select if feature is not clicked", () => {
@@ -427,7 +427,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(0);
+					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 			});
 
@@ -458,7 +458,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 				});
 
 				it("does deselect if feature is clicked then map area is clicked and allowManualDeselection is true", () => {
@@ -494,9 +494,9 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 
-					expect(onDeselect).toBeCalledTimes(0);
+					expect(onDeselect).toHaveBeenCalledTimes(0);
 
 					mockMouseEventBoundingBox([
 						[0, 0],
@@ -514,8 +514,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onDeselect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onDeselect).toHaveBeenCalledTimes(1);
 				});
 
 				it("does not deselect if feature is clicked then map area is clicked but allowManualDeselection is false", () => {
@@ -551,9 +551,9 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 
-					expect(onDeselect).toBeCalledTimes(0);
+					expect(onDeselect).toHaveBeenCalledTimes(0);
 
 					mockMouseEventBoundingBox([
 						[0, 0],
@@ -571,8 +571,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onDeselect).toBeCalledTimes(0);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onDeselect).toHaveBeenCalledTimes(0);
 				});
 
 				it("does not select if feature is not clicked", () => {
@@ -601,7 +601,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(0);
+					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 
 				it("creates selection points when feature selection flag enabled", () => {
@@ -651,7 +651,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 					expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 					// Polygon selected set to true
@@ -728,7 +728,7 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 					expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 					// Polygon selected set to true
@@ -818,7 +818,7 @@ describe("TerraDrawSelectMode", () => {
 							heldKeys: [],
 						});
 
-						expect(onSelect).toBeCalledTimes(1);
+						expect(onSelect).toHaveBeenCalledTimes(1);
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
@@ -842,11 +842,11 @@ describe("TerraDrawSelectMode", () => {
 						});
 
 						// Second polygon selected
-						expect(onSelect).toBeCalledTimes(2);
+						expect(onSelect).toHaveBeenCalledTimes(2);
 						expect(onSelect).toHaveBeenNthCalledWith(2, idTwo[0]);
 
 						// Deselect first polygon
-						expect(onDeselect).toBeCalledTimes(1);
+						expect(onDeselect).toHaveBeenCalledTimes(1);
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to false
@@ -917,7 +917,7 @@ describe("TerraDrawSelectMode", () => {
 							heldKeys: [],
 						});
 
-						expect(onSelect).toBeCalledTimes(1);
+						expect(onSelect).toHaveBeenCalledTimes(1);
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
@@ -955,11 +955,11 @@ describe("TerraDrawSelectMode", () => {
 						});
 
 						// Second polygon selected
-						expect(onSelect).toBeCalledTimes(2);
+						expect(onSelect).toHaveBeenCalledTimes(2);
 						expect(onSelect).toHaveBeenNthCalledWith(2, idTwo[0]);
 
 						// Deselect first polygon selected set to false
-						expect(onDeselect).toBeCalledTimes(1);
+						expect(onDeselect).toHaveBeenCalledTimes(1);
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update");
@@ -1052,7 +1052,7 @@ describe("TerraDrawSelectMode", () => {
 							heldKeys: [],
 						});
 
-						expect(onSelect).toBeCalledTimes(1);
+						expect(onSelect).toHaveBeenCalledTimes(1);
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
@@ -1121,11 +1121,11 @@ describe("TerraDrawSelectMode", () => {
 						});
 
 						// Second polygon selected
-						expect(onSelect).toBeCalledTimes(2);
+						expect(onSelect).toHaveBeenCalledTimes(2);
 						expect(onSelect).toHaveBeenNthCalledWith(2, idTwo[0]);
 
 						// Deselect first polygon selected set to false
-						expect(onDeselect).toBeCalledTimes(1);
+						expect(onDeselect).toHaveBeenCalledTimes(1);
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						expect(onChange).toHaveBeenNthCalledWith(6, idOne, "update");
@@ -1175,9 +1175,9 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalled();
-				expect(onDeselect).not.toBeCalled();
-				expect(onSelect).not.toBeCalled();
+				expect(onChange).not.toHaveBeenCalled();
+				expect(onDeselect).not.toHaveBeenCalled();
+				expect(onSelect).not.toHaveBeenCalled();
 			});
 
 			it("returns if different feature than selected is clicked on", () => {
@@ -1235,7 +1235,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
@@ -1269,9 +1269,9 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(store.getGeometryCopy).toBeCalledTimes(4);
-				expect(onDeselect).toBeCalledTimes(0);
-				expect(store.getPropertiesCopy).toBeCalledTimes(0);
+				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
+				expect(onDeselect).toHaveBeenCalledTimes(0);
+				expect(store.getPropertiesCopy).toHaveBeenCalledTimes(0);
 			});
 
 			it("returns if selected feature is clicked on but deleteable is false", () => {
@@ -1317,7 +1317,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
@@ -1346,7 +1346,7 @@ describe("TerraDrawSelectMode", () => {
 
 				// Only called for checking distance to selection points,
 				// should hit early return otherwise
-				expect(store.getGeometryCopy).toBeCalledTimes(4);
+				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
 			});
 
 			it("returns if selected feature is clicked on but deleteable is false", () => {
@@ -1392,7 +1392,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
@@ -1421,7 +1421,7 @@ describe("TerraDrawSelectMode", () => {
 
 				// Only called for checking distance to selection points,
 				// should hit early return otherwise
-				expect(store.getGeometryCopy).toBeCalledTimes(4);
+				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
 			});
 
 			it("returns early if creates a invalid polygon by deleting coordinate", () => {
@@ -1466,7 +1466,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
@@ -1494,8 +1494,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(store.delete).toBeCalledTimes(0);
-				expect(store.updateGeometry).toBeCalledTimes(0);
+				expect(store.delete).toHaveBeenCalledTimes(0);
+				expect(store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
 			it("deletes a coordinate in deleteable set to true and a coordinate is clicked on", () => {
@@ -1541,7 +1541,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
@@ -1569,8 +1569,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(store.delete).toBeCalledTimes(1);
-				expect(store.updateGeometry).toBeCalledTimes(1);
+				expect(store.delete).toHaveBeenCalledTimes(1);
+				expect(store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
 	});
@@ -1584,8 +1584,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: ["Delete"],
 				});
 
-				expect(onChange).not.toBeCalled();
-				expect(onDeselect).not.toBeCalled();
+				expect(onChange).not.toHaveBeenCalled();
+				expect(onDeselect).not.toHaveBeenCalled();
 			});
 
 			it("deletes when feature is selected", () => {
@@ -1608,14 +1608,14 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 				expect(onChange).toHaveBeenNthCalledWith(
 					2,
 					[expect.any(String)],
 					"update",
 				);
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 
 				selectMode.onKeyUp({
 					key: "Delete",
@@ -1623,9 +1623,9 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onDeselect).toBeCalledTimes(1);
+				expect(onDeselect).toHaveBeenCalledTimes(1);
 
-				expect(onChange).toBeCalledTimes(3);
+				expect(onChange).toHaveBeenCalledTimes(3);
 				expect(onChange).toHaveBeenNthCalledWith(
 					3,
 					[expect.any(String)],
@@ -1642,8 +1642,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).not.toBeCalled();
-				expect(onDeselect).not.toBeCalled();
+				expect(onChange).not.toHaveBeenCalled();
+				expect(onDeselect).not.toHaveBeenCalled();
 			});
 
 			it("does nothing with no features selected", () => {
@@ -1665,7 +1665,7 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
+				expect(onSelect).toHaveBeenCalledTimes(1);
 
 				selectMode.onKeyUp({
 					key: "Escape",
@@ -1673,8 +1673,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onChange).toBeCalledTimes(3);
-				expect(onDeselect).toBeCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(3);
+				expect(onDeselect).toHaveBeenCalledTimes(1);
 			});
 		});
 	});
@@ -1693,10 +1693,10 @@ describe("TerraDrawSelectMode", () => {
 				jest.fn(),
 			);
 
-			expect(onChange).toBeCalledTimes(0);
-			expect(onDeselect).toBeCalledTimes(0);
-			expect(onSelect).toBeCalledTimes(0);
-			expect(project).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
+			expect(onDeselect).toHaveBeenCalledTimes(0);
+			expect(onSelect).toHaveBeenCalledTimes(0);
+			expect(project).toHaveBeenCalledTimes(0);
 		});
 
 		it("does not trigger starting of drag events if mode not draggable", () => {
@@ -1720,9 +1720,9 @@ describe("TerraDrawSelectMode", () => {
 
 			// Pointer set to move when teh cursor is
 			expect(setCursor).toHaveBeenCalledTimes(1);
-			expect(setCursor).toBeCalledWith("move");
+			expect(setCursor).toHaveBeenCalledWith("move");
 
-			expect(onSelect).toBeCalledTimes(1);
+			expect(onSelect).toHaveBeenCalledTimes(1);
 
 			const setMapDraggability = jest.fn();
 			selectMode.onDragStart(
@@ -1737,7 +1737,7 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(setMapDraggability).not.toBeCalled();
+			expect(setMapDraggability).not.toHaveBeenCalled();
 		});
 
 		it("does trigger onDragStart events if mode is draggable", () => {
@@ -1780,7 +1780,7 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onSelect).toBeCalledTimes(1);
+			expect(onSelect).toHaveBeenCalledTimes(1);
 
 			const setMapDraggability = jest.fn();
 			selectMode.onDragStart(
@@ -1794,8 +1794,8 @@ describe("TerraDrawSelectMode", () => {
 				},
 				setMapDraggability,
 			);
-			expect(setCursor).toBeCalled();
-			expect(setMapDraggability).toBeCalled();
+			expect(setCursor).toHaveBeenCalled();
+			expect(setMapDraggability).toHaveBeenCalled();
 		});
 	});
 
@@ -1814,10 +1814,10 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onChange).toBeCalledTimes(0);
-			expect(onDeselect).toBeCalledTimes(0);
-			expect(onSelect).toBeCalledTimes(0);
-			expect(project).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
+			expect(onDeselect).toHaveBeenCalledTimes(0);
+			expect(onSelect).toHaveBeenCalledTimes(0);
+			expect(project).toHaveBeenCalledTimes(0);
 		});
 
 		it("does not trigger drag events if mode not draggable", () => {
@@ -1838,8 +1838,8 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onSelect).toBeCalledTimes(1);
-			expect(onChange).toBeCalledTimes(2);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			const setMapDraggability = jest.fn();
 			selectMode.onDrag(
@@ -1854,7 +1854,7 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 		});
 
 		describe("drag feature", () => {
@@ -1878,8 +1878,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onChange).toBeCalledTimes(2);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(2);
 
 					const setMapDraggability = jest.fn();
 					selectMode.onDrag(
@@ -1894,7 +1894,7 @@ describe("TerraDrawSelectMode", () => {
 						setMapDraggability,
 					);
 
-					expect(onChange).toBeCalledTimes(2);
+					expect(onChange).toHaveBeenCalledTimes(2);
 				});
 
 				it("coordinate draggable flag has no effect for points", () => {
@@ -1927,8 +1927,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onChange).toBeCalledTimes(2);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(2);
 
 					const setMapDraggability = jest.fn();
 					selectMode.onDrag(
@@ -1943,7 +1943,7 @@ describe("TerraDrawSelectMode", () => {
 						setMapDraggability,
 					);
 
-					expect(onChange).toBeCalledTimes(2);
+					expect(onChange).toHaveBeenCalledTimes(2);
 				});
 
 				it("does trigger drag events if mode is draggable for point", () => {
@@ -1970,8 +1970,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onChange).toBeCalledTimes(2);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(2);
 
 					project.mockReturnValueOnce({
 						x: 0,
@@ -2016,7 +2016,7 @@ describe("TerraDrawSelectMode", () => {
 						setMapDraggability,
 					);
 
-					expect(onChange).toBeCalledTimes(3);
+					expect(onChange).toHaveBeenCalledTimes(3);
 				});
 			});
 
@@ -2031,7 +2031,7 @@ describe("TerraDrawSelectMode", () => {
 						[1, 1],
 					]);
 
-					expect(onChange).toBeCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(1);
 					const idOne = onChange.mock.calls[0][0] as string[];
 
 					mockMouseEventBoundingBox();
@@ -2071,9 +2071,9 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledTimes(1);
 					expect(onSelect).toHaveBeenNthCalledWith(1, id);
-					expect(onChange).toBeCalledTimes(2);
+					expect(onChange).toHaveBeenCalledTimes(2);
 
 					selectMode.onDragStart(
 						{
@@ -2121,7 +2121,7 @@ describe("TerraDrawSelectMode", () => {
 						setMapDraggability,
 					);
 
-					expect(onChange).toBeCalledTimes(3);
+					expect(onChange).toHaveBeenCalledTimes(3);
 					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
 				});
 			});
@@ -2140,7 +2140,7 @@ describe("TerraDrawSelectMode", () => {
 						[0, 0],
 					]);
 
-					expect(onChange).toBeCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(1);
 					const idOne = onChange.mock.calls[0][0] as string[];
 
 					// mock for both drag coordinate and drag feature
@@ -2181,8 +2181,8 @@ describe("TerraDrawSelectMode", () => {
 						heldKeys: [],
 					});
 
-					expect(onSelect).toBeCalledTimes(1);
-					expect(onChange).toBeCalledTimes(2);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledTimes(2);
 
 					selectMode.onDragStart(
 						{
@@ -2230,7 +2230,7 @@ describe("TerraDrawSelectMode", () => {
 						setMapDraggability,
 					);
 
-					expect(onChange).toBeCalledTimes(3);
+					expect(onChange).toHaveBeenCalledTimes(3);
 					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
 				});
 			});
@@ -2246,13 +2246,13 @@ describe("TerraDrawSelectMode", () => {
 
 				// We want to account for ignoring points branch
 				addPointToStore([100, 89]);
-				expect(onChange).toBeCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(1);
 
 				addLineStringToStore([
 					[0, 0],
 					[1, 1],
 				]);
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 
 				mockMouseEventBoundingBox();
 				project
@@ -2274,8 +2274,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
-				expect(onChange).toBeCalledTimes(4);
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(4);
 
 				// Select feature
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -2327,7 +2327,7 @@ describe("TerraDrawSelectMode", () => {
 					setMapDraggability,
 				);
 
-				expect(onChange).toBeCalledTimes(5);
+				expect(onChange).toHaveBeenCalledTimes(5);
 
 				// Update linestring position and 1 selection points
 				// that gets moved
@@ -2346,7 +2346,7 @@ describe("TerraDrawSelectMode", () => {
 				// We want to account for ignoring points branch
 				addPointToStore([100, 89]);
 
-				expect(onChange).toBeCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(1);
 
 				addPolygonToStore([
 					[0, 0],
@@ -2356,7 +2356,7 @@ describe("TerraDrawSelectMode", () => {
 					[0, 0],
 				]);
 
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 
 				mockMouseEventBoundingBox();
 
@@ -2379,8 +2379,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
-				expect(onChange).toBeCalledTimes(4);
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(4);
 
 				// Select feature
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -2437,7 +2437,7 @@ describe("TerraDrawSelectMode", () => {
 					setMapDraggability,
 				);
 
-				expect(onChange).toBeCalledTimes(5);
+				expect(onChange).toHaveBeenCalledTimes(5);
 
 				// Update linestring position and 1 selection points
 				// that gets moved
@@ -2466,13 +2466,13 @@ describe("TerraDrawSelectMode", () => {
 
 				// We want to account for ignoring points branch
 				addPointToStore([100, 89]);
-				expect(onChange).toBeCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(1);
 
 				addLineStringToStore([
 					[0, 0],
 					[1, 1],
 				]);
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 
 				mockMouseEventBoundingBox();
 				project
@@ -2494,8 +2494,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
-				expect(onChange).toBeCalledTimes(4);
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(4);
 
 				// Select feature
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -2571,7 +2571,7 @@ describe("TerraDrawSelectMode", () => {
 					setMapDraggability,
 				);
 
-				expect(onChange).toBeCalledTimes(6);
+				expect(onChange).toHaveBeenCalledTimes(6);
 
 				// Update linestring position and 1 selection points
 				// that gets moved
@@ -2599,7 +2599,7 @@ describe("TerraDrawSelectMode", () => {
 				// We want to account for ignoring points branch
 				addPointToStore([100, 89]);
 
-				expect(onChange).toBeCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(1);
 
 				addPolygonToStore([
 					[0, 0],
@@ -2609,7 +2609,7 @@ describe("TerraDrawSelectMode", () => {
 					[0, 0],
 				]);
 
-				expect(onChange).toBeCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(2);
 
 				mockMouseEventBoundingBox();
 
@@ -2632,8 +2632,8 @@ describe("TerraDrawSelectMode", () => {
 					heldKeys: [],
 				});
 
-				expect(onSelect).toBeCalledTimes(1);
-				expect(onChange).toBeCalledTimes(4);
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(4);
 
 				// Select feature
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -2714,7 +2714,7 @@ describe("TerraDrawSelectMode", () => {
 					setMapDraggability,
 				);
 
-				expect(onChange).toBeCalledTimes(6);
+				expect(onChange).toHaveBeenCalledTimes(6);
 
 				// Update polygon position and 1 selection points
 				// that gets moved
@@ -2750,10 +2750,10 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(setMapDraggability).toBeCalledTimes(1);
-			expect(setMapDraggability).toBeCalledWith(true);
-			expect(setCursor).toBeCalledTimes(1);
-			expect(setCursor).toBeCalledWith("move");
+			expect(setMapDraggability).toHaveBeenCalledTimes(1);
+			expect(setMapDraggability).toHaveBeenCalledWith(true);
+			expect(setCursor).toHaveBeenCalledTimes(1);
+			expect(setCursor).toHaveBeenCalledWith("move");
 		});
 
 		it("fires onFinish for dragged coordinate if it is currently being dragged", () => {
@@ -2764,7 +2764,7 @@ describe("TerraDrawSelectMode", () => {
 			// We want to account for ignoring points branch
 			addPointToStore([100, 89]);
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 
 			addPolygonToStore([
 				[0, 0],
@@ -2774,7 +2774,7 @@ describe("TerraDrawSelectMode", () => {
 				[0, 0],
 			]);
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			mockMouseEventBoundingBox();
 
@@ -2797,8 +2797,8 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onSelect).toBeCalledTimes(1);
-			expect(onChange).toBeCalledTimes(4);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(4);
 
 			// Select feature
 			expect(onChange).toHaveBeenNthCalledWith(
@@ -2867,8 +2867,8 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onFinish).toBeCalledTimes(1);
-			expect(onFinish).toBeCalledWith(expect.any(String), {
+			expect(onFinish).toHaveBeenCalledTimes(1);
+			expect(onFinish).toHaveBeenCalledWith(expect.any(String), {
 				action: "dragCoordinate",
 				mode: "select",
 			});
@@ -2887,7 +2887,7 @@ describe("TerraDrawSelectMode", () => {
 				[0, 0],
 			]);
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 
 			// mock for both drag coordinate and drag feature
 			mockMouseEventBoundingBox();
@@ -2927,8 +2927,8 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onSelect).toBeCalledTimes(1);
-			expect(onChange).toBeCalledTimes(2);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			selectMode.onDragStart(
 				{
@@ -2976,7 +2976,7 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onChange).toBeCalledTimes(3);
+			expect(onChange).toHaveBeenCalledTimes(3);
 
 			selectMode.onDragEnd(
 				{
@@ -2990,8 +2990,8 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onFinish).toBeCalledTimes(1);
-			expect(onFinish).toBeCalledWith(expect.any(String), {
+			expect(onFinish).toHaveBeenCalledTimes(1);
+			expect(onFinish).toHaveBeenCalledWith(expect.any(String), {
 				action: "dragFeature",
 				mode: "select",
 			});
@@ -3010,7 +3010,7 @@ describe("TerraDrawSelectMode", () => {
 			// We want to account for ignoring points branch
 			addPointToStore([100, 89]);
 
-			expect(onChange).toBeCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(1);
 
 			addPolygonToStore([
 				[0, 0],
@@ -3020,7 +3020,7 @@ describe("TerraDrawSelectMode", () => {
 				[0, 0],
 			]);
 
-			expect(onChange).toBeCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(2);
 
 			mockMouseEventBoundingBox();
 
@@ -3043,8 +3043,8 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onSelect).toBeCalledTimes(1);
-			expect(onChange).toBeCalledTimes(4);
+			expect(onSelect).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledTimes(4);
 
 			// Select feature
 			expect(onChange).toHaveBeenNthCalledWith(
@@ -3113,8 +3113,8 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
-			expect(onFinish).toBeCalledTimes(1);
-			expect(onFinish).toBeCalledWith(expect.any(String), {
+			expect(onFinish).toHaveBeenCalledTimes(1);
+			expect(onFinish).toHaveBeenCalledWith(expect.any(String), {
 				action: "dragCoordinateResize",
 				mode: "select",
 			});
@@ -3150,10 +3150,10 @@ describe("TerraDrawSelectMode", () => {
 				heldKeys: [],
 			});
 
-			expect(onChange).toBeCalledTimes(0);
-			expect(onDeselect).toBeCalledTimes(0);
-			expect(onSelect).toBeCalledTimes(0);
-			expect(project).toBeCalledTimes(0);
+			expect(onChange).toHaveBeenCalledTimes(0);
+			expect(onDeselect).toHaveBeenCalledTimes(0);
+			expect(onSelect).toHaveBeenCalledTimes(0);
+			expect(project).toHaveBeenCalledTimes(0);
 		});
 	});
 

--- a/src/store/store.spec.ts
+++ b/src/store/store.spec.ts
@@ -299,7 +299,7 @@ describe("GeoJSONStore", () => {
 			]);
 			store.delete([id]);
 
-			expect(mockCallback).toBeCalledTimes(3);
+			expect(mockCallback).toHaveBeenCalledTimes(3);
 			expect(mockCallback).toHaveBeenNthCalledWith(1, [id], "create");
 			expect(mockCallback).toHaveBeenNthCalledWith(2, [id], "update");
 			expect(mockCallback).toHaveBeenNthCalledWith(3, [id], "delete");


### PR DESCRIPTION
## Description of Changes

Removes all references to `toBeCalled`, `toBeCalledTimes`, `toBeCalledWith` and replaces with the non deprecated equivalents

## Link to Issue

<!--- Please provide a link to the issue for reference. If you have not created an issue, please do so before raising a PR so that it is possible to discuss the changes in advance -->

## PR Checklist

- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 