### PR TITLE
fix: add promoteId and properties.id to mapbox-gl.adapter.ts

### DIFF
--- a/src/adapters/mapbox-gl.adapter.ts
+++ b/src/adapters/mapbox-gl.adapter.ts
@@ -64,6 +64,7 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 				features: features,
 			},
 			tolerance: 0,
+			promoteId: 'id',
 		});
 	}
 
@@ -344,6 +345,8 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawBaseAdapter {
 
 				Object.keys(styling).forEach((mode) => {
 					const { properties } = feature;
+
+					properties.id = feature.id;
 
 					if (properties.mode !== mode) {
 						return;


### PR DESCRIPTION
## Description of Changes

Added promoteId to _addGeoJSONSource and properties.id in render.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/266

## PR Checklist

- [ x ] There is a associated GitHub issue 
- [ n/a ] If I have added significant code changes, there are relevant tests
- [ n/a ] If there are behaviour changes these are documented 