### PR TITLE
feat: add projection property for circle mode to allow globe and web mercator circle drawing

### DIFF
--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -152,7 +152,10 @@ const example = {
 							: undefined,
 				}),
 				new TerraDrawRectangleMode(),
-				new TerraDrawCircleMode(),
+				new TerraDrawCircleMode({
+					projection:
+						this.config === "geodesicCircle" ? "globe" : "web-mercator",
+				}),
 				new TerraDrawFreehandMode(),
 				new TerraDrawRenderMode({
 					modeName: "arbitary",

--- a/e2e/tests/leaflet.spec.ts
+++ b/e2e/tests/leaflet.spec.ts
@@ -331,8 +331,25 @@ test.describe("rectangle mode", () => {
 test.describe("circle mode", () => {
 	const mode = "circle";
 
-	test("mode can set and can be used to create a circle", async ({ page }) => {
+	test("mode can set and can be used to create a web mercator circle", async ({
+		page,
+	}) => {
 		const mapDiv = await setupMap({ page });
+		await changeMode({ page, mode });
+
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+		await page.mouse.click(mapDiv.width / 2 + 50, mapDiv.height / 2 + 50);
+
+		// One point + one line
+		await expectPaths({ page, count: 1 });
+
+		await expectPathDimensions({ page, width: 146, height: 146 });
+	});
+
+	test("mode can set and can be used to create a geodesic circle", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({ page, configQueryParam: "geodesicCircle" });
 		await changeMode({ page, mode });
 
 		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -6,7 +6,8 @@ export type TestConfigOptions =
 	| "validationSuccess"
 	| "validationFailure"
 	| "insertCoordinates"
-	| "insertCoordinatesGlobe";
+	| "insertCoordinatesGlobe"
+	| "geodesicCircle";
 
 export const setupMap = async ({
 	page,

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -141,7 +141,7 @@ Using these can help you write more customised behaviours, for example you may o
 
 As we move forward Terra Draw will work on supporting Web Mercator maps out the box with the ability to support Globes (i.e. 3D spherical representations of the earth with no projection) as a secondary option. This is made slightly more complicated by the fact we know sometimes users want to draw geodesic geometries on a web mercator map, for example a geodesic circle or a great circle line. In future we will better align by assuming developers want web mercator first behaviours, with secondary support for globes.
 
-* Circle mode is currently geodesic out the box. In future this will be controllable with the 'projection' argument and will default to being web mercator.
+* Circle mode currently supports both web mercator and geodesic circles, using the `projection` property, which can be `globe` or `web-mercator` (default is web mercator)
 * Select mode `scaleable` flag current uses geodesic scaling as opposed to web mercator. In future this will be configurable with the 'projection' property.
 * Select mode `resizeable` currently resizes depending on the string token passed. At the moment the tokens only support web mercator resizing. In future, the web-mercator suffixs will be removed and again this will be controlled by the 'projection' parameter to the mode.
 * Select mode midpoints are currently inserted along a straight line in the web mercator projection. Again in the future this will be controlled via 'projection' property

--- a/src/geometry/shape/create-circle.spec.ts
+++ b/src/geometry/shape/create-circle.spec.ts
@@ -1,30 +1,196 @@
-import { circle } from "./create-circle";
+import { haversineDistanceKilometers } from "../measure/haversine-distance";
+import { circle, circleWebMercator } from "./create-circle";
 
 describe("Geometry", () => {
 	describe("circle", () => {
-		it("creates a circle polygon", () => {
+		it("should generate a GeoJSON Polygon Feature", () => {
 			const result = circle({
 				center: [0, 0],
 				radiusKilometers: 1,
 				coordinatePrecision: 9,
 			});
-
+			expect(result.type).toBe("Feature");
 			expect(result.geometry.type).toBe("Polygon");
-			expect(result.geometry.coordinates[0].length).toBe(64 + 1);
-			expect(result.properties).toStrictEqual({});
+			expect(result.geometry.coordinates).toHaveLength(1);
 		});
 
-		it("creates a circle polygon with custom steps", () => {
+		it("should generate a closed polygon", () => {
 			const result = circle({
 				center: [0, 0],
 				radiusKilometers: 1,
-				steps: 20,
 				coordinatePrecision: 9,
 			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates[0]).toEqual(coordinates[coordinates.length - 1]);
+		});
 
+		it("should generate the correct number of coordinates", () => {
+			const points = 64;
+			const result = circle({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 64,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			// Including the closing point, so it should be coordinates + 1
+			expect(coordinates).toHaveLength(points + 1);
+		});
+
+		it("should handle a small number of coordinates", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 4,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates).toHaveLength(4 + 1);
+		});
+
+		it("should handle a large number of coordinates", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates).toHaveLength(360 + 1);
+		});
+
+		it("should have coordinates within a valid range", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			coordinates.forEach(([lon, lat]) => {
+				expect(lon).toBeGreaterThanOrEqual(-180);
+				expect(lon).toBeLessThanOrEqual(180);
+				expect(lat).toBeGreaterThanOrEqual(-90);
+				expect(lat).toBeLessThanOrEqual(90);
+			});
+		});
+
+		it("should have approximately uniform distance between circle coordinates", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 10,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			const distances = [];
+			for (let i = 0; i < coordinates.length - 1; i++) {
+				distances.push(
+					+haversineDistanceKilometers(
+						coordinates[i],
+						coordinates[i + 1],
+					).toFixed(6),
+				);
+			}
+			expect(
+				distances.every((val, i, arr) => i === 0 || val === arr[i - 1]),
+			).toBe(true);
+		});
+	});
+
+	describe("circleWebMercator", () => {
+		it("should generate a GeoJSON Polygon Feature", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+			});
+			expect(result.type).toBe("Feature");
 			expect(result.geometry.type).toBe("Polygon");
-			expect(result.geometry.coordinates[0].length).toBe(20 + 1);
-			expect(result.properties).toStrictEqual({});
+			expect(result.geometry.coordinates).toHaveLength(1);
+		});
+
+		it("should generate a closed polygon", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates[0]).toEqual(coordinates[coordinates.length - 1]);
+		});
+
+		it("should generate the correct number of coordinates", () => {
+			const points = 64;
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 64,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			// Including the closing point, so it should be coordinates + 1
+			expect(coordinates).toHaveLength(points + 1);
+		});
+
+		it("should handle a small number of coordinates", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 4,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates).toHaveLength(4 + 1);
+		});
+
+		it("should handle a large number of coordinates", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			expect(coordinates).toHaveLength(360 + 1);
+		});
+
+		it("should have coordinates within a valid range", () => {
+			const result = circleWebMercator({
+				center: [0, 0],
+				radiusKilometers: 1,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			coordinates.forEach(([lon, lat]) => {
+				expect(lon).toBeGreaterThanOrEqual(-180);
+				expect(lon).toBeLessThanOrEqual(180);
+				expect(lat).toBeGreaterThanOrEqual(-90);
+				expect(lat).toBeLessThanOrEqual(90);
+			});
+		});
+
+		it("should not have approximately uniform distance between circle coordinates due to mercator distortions", () => {
+			const result = circle({
+				center: [0, 0],
+				radiusKilometers: 10,
+				coordinatePrecision: 9,
+				steps: 360,
+			});
+			const coordinates = result.geometry.coordinates[0];
+			const distances = [];
+			for (let i = 0; i < coordinates.length - 1; i++) {
+				distances.push(
+					+haversineDistanceKilometers(
+						coordinates[i],
+						coordinates[i + 1],
+					).toFixed(6),
+				);
+			}
+			expect(
+				distances.every((val, i, arr) => i === 0 || val === arr[i - 1]),
+			).toBe(false);
 		});
 	});
 });

--- a/src/geometry/shape/web-mercator-distortion.spec.ts
+++ b/src/geometry/shape/web-mercator-distortion.spec.ts
@@ -1,0 +1,20 @@
+import { calculateWebMercatorDistortion } from "./web-mercator-distortion";
+
+describe("Geometry", () => {
+	describe("calculateWebMercatorDistortion", () => {
+		it("returns 1 for identical coordinates", () => {
+			const result = calculateWebMercatorDistortion([0, 0], [0, 0]);
+			expect(result).toBe(1);
+		});
+
+		it("returns almost 1 for coordinates along the equator", () => {
+			const result = calculateWebMercatorDistortion([0, 0], [179, 0]);
+			expect(result).toBe(1.0011202323026207);
+		});
+
+		it("returns high value for high latitudes", () => {
+			const result = calculateWebMercatorDistortion([0, 0], [0, 89]);
+			expect(result).toBe(3.0557707265347394);
+		});
+	});
+});

--- a/src/geometry/shape/web-mercator-distortion.ts
+++ b/src/geometry/shape/web-mercator-distortion.ts
@@ -1,0 +1,24 @@
+import { Position } from "geojson";
+import { haversineDistanceKilometers } from "../measure/haversine-distance";
+import { lngLatToWebMercatorXY } from "../project/web-mercator";
+
+/*
+ * Function to calculate the web mercator vs geodesic distortion between two coordinates
+ * Value of 1 means no distortion, higher values mean higher distortion
+ * */
+export function calculateWebMercatorDistortion(
+	source: Position,
+	target: Position,
+): number {
+	const geodesicDistance = haversineDistanceKilometers(source, target) * 1000;
+	if (geodesicDistance === 0) {
+		return 1;
+	}
+
+	const { x: x1, y: y1 } = lngLatToWebMercatorXY(source[0], source[1]);
+	const { x: x2, y: y2 } = lngLatToWebMercatorXY(target[0], target[1]);
+	const euclideanDistance = Math.sqrt(
+		Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2),
+	);
+	return euclideanDistance / geodesicDistance;
+}

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -113,6 +113,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		this.validate = options?.validation;
 
 		this.insertCoordinates = options?.insertCoordinates;
+
+		this.projection = options?.projection ?? "web-mercator";
 	}
 
 	private close() {


### PR DESCRIPTION
## Description of Changes

Default to drawing Web Mercator circles in TerraDrawCircleMode, with the option to draw geodesic circles using `projection: "globe"` 

## Link to Issue

#275 

## PR Checklist

- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 