### PR TITLE
chore: add a action for ensuring conventional commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 
 ## PR Checklist
 
+- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
 - [ ] There is a associated GitHub issue 
 - [ ] If I have added significant code changes, there are relevant tests
 - [ ] If there are behaviour changes these are documented 

--- a/.github/workflows/conventional-commit-prs.yml
+++ b/.github/workflows/conventional-commit-prs.yml
@@ -1,0 +1,18 @@
+name: PR Conventional Commit Validation
+
+permissions: 
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1.1.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'

--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -171,7 +171,7 @@ If you wish to contribute to Terra Draw, we request that you:
 1. Make an issue on GitHub describing the bug you intend to fix or the feature you intend to add.
 2. Create a fork of the project, and work on a branch that represents the issue.
 3. Ensure that the work you have done is unit tested, aiming for 80% code coverage.
-4. Create a PR that represents this work. Please refer to the issue from the PR.
+4. Create a PR that represents this work with a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) title (this ensures the automated changelog is generated correctly). Please refer to the issue from the PR and follow the PR template. 
 5. We will address the PR and give you feedback.
 
 Please note that we can not guarantee that all PRs will be merged. There are cases where a PR may deviate from the long-term vision for Terra Draw and hence we may have to decline it. Creating the issue in advance helps us discuss any potential issues upfront before the PR is made.


### PR DESCRIPTION
## Description of Changes

Ensures that PRs can't have non conventional commit titles. This is to ensure the changelog is correctly generated.

## Link to Issue

#277 

## PR Checklist

- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 