### PR TITLE
fix: ensure the correct z-index for circle, rectangle, freehand

### DIFF
--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -261,7 +261,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 				feature,
 			);
 
-			styles.zIndex = 30;
+			styles.zIndex = 10;
 
 			return styles;
 		}

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -346,7 +346,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				feature,
 			);
 
-			styles.zIndex = 30;
+			styles.zIndex = 10;
 
 			return styles;
 		} else if (

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -254,7 +254,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 				feature,
 			);
 
-			styles.zIndex = 30;
+			styles.zIndex = 10;
 
 			return styles;
 		}


### PR DESCRIPTION
## Description of Changes

Minor fixes to ensure z-indexs are correct for circle, rectangle and freehand modes. This is mostly an issue in the Leaflet adapter.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 