### PR TITLE
chore: allow configuration of loaded mapping libraries on the development page

### DIFF
--- a/development/public/index.html
+++ b/development/public/index.html
@@ -20,16 +20,6 @@
 			border: solid 3px #222222;
 		}
 
-		.example {
-			position: relative;
-
-			cursor: pointer;
-			font-family: sans-serif;
-			height: 100%;
-			width: 25%;
-			outline: solid 1px #d7d7d7;
-		}
-
 		.label {
 			position: absolute;
 			top: 0;
@@ -64,25 +54,8 @@
 </head>
 
 <body style="width: 100%; height: 100%; margin: 0">
-	<div style="display: flex; flex-direction: row; height: 100%; width: 100%">
-		<div class="example" id="leaflet-map">
-			<div class="label">Leaflet</div>
-		</div>
-		<div class="example" id="openlayers-map">
-			<div class="label">OpenLayers</div>
-		</div>
-		<div class="example" id="mapbox-map">
-			<div class="label">Mapbox</div>
-		</div>
-		<div class="example" id="maplibre-map">
-			<div class="label">MapLibre</div>
-		</div>
-		<div class="example" id="google-map">
-			<div class="label">Google Maps</div>
-		</div>
-		<div class="example" id="arcgis-maps-sdk">
-			<div class="label">ArcGIS Maps</div>
-		</div>
+	<div id="library-container" style="display: flex; flex-direction: row; height: 100%; width: 100%">
+
 	</div>
 
 	<div style="

--- a/development/src/config.ts
+++ b/development/src/config.ts
@@ -1,0 +1,22 @@
+export const Libraries = {
+	Leaflet: "Leaflet",
+	Mapbox: "Mapbox",
+	OpenLayers: "OpenLayers",
+	Google: "Google",
+	ArcGIS: "ArcGIS",
+	MapLibre: "MapLibre",
+} as const;
+
+export const Config = {
+	// You can set this array to just one library or any number and combination
+	// and the development page will respond accordingly. This is useful if you just want to
+	// test one map at a time, or you're on a low powered machine.
+	libraries: [
+		Libraries.Leaflet,
+		Libraries.MapLibre,
+		Libraries.Mapbox,
+		Libraries.Google,
+		Libraries.OpenLayers,
+		Libraries.ArcGIS,
+	] as const,
+};


### PR DESCRIPTION
## Description of Changes

This PR allows the development page to be configurable in terms of which mapping library examples are initialised/rendered. 

## Link to Issue

#281 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 