### PR TITLE
chore: fix beta release script to set release-as flag correctly

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -47,7 +47,7 @@ jobs:
           git config --global user.name "James Milner"
 
       - name: Release
-        run: npm run release -- --prerelease --release-as $(echo ${{ env.NEXT }})
+        run: npm run release -- --prerelease --release-as ${{ env.NEXT }}
 
       - name: Check changelog is correct
         run: npm run release:beta:changelog


### PR DESCRIPTION
## Description of Changes

- The release-as was being passed an invalid release version. Hopefully fixing the script will resolve releases and allow for a beta release

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 