### PR TITLE
test: add extra unit test to openlayers.adapter.spec

### DIFF
--- a/src/adapters/openlayers.adapter.spec.ts
+++ b/src/adapters/openlayers.adapter.spec.ts
@@ -1,22 +1,33 @@
 import { TerraDrawOpenLayersAdapter } from "./openlayers.adapter";
+import Map from "ol/Map";
+import { getMockPointerEvent } from "../test/mock-pointer-event";
 
 jest.mock("ol/style/Circle", () => jest.fn());
 jest.mock("ol/style/Fill", () => jest.fn());
 jest.mock("ol/style/Stroke", () => jest.fn());
 jest.mock("ol/style/Style", () => jest.fn());
-jest.mock("ol/proj", () => jest.fn());
+jest.mock("ol/proj", () => ({ toLonLat: () => [45, 45] }));
 jest.mock("ol/geom/Geometry", () => jest.fn());
+
+const createMockOLMap = () => {
+	return {
+		getViewport: jest.fn(() => ({
+			setAttribute: jest.fn(),
+			querySelectorAll: jest.fn(() => [
+				{
+					getBoundingClientRect: jest.fn(() => ({ top: 0, left: 0 })),
+				},
+			]),
+		})),
+		addLayer: jest.fn(),
+	} as unknown as Map;
+};
 
 describe("TerraDrawOpenLayersAdapter", () => {
 	describe("constructor", () => {
 		it("instantiates the adapter correctly", () => {
 			const adapter = new TerraDrawOpenLayersAdapter({
-				map: {
-					getViewport: jest.fn(() => ({
-						setAttribute: jest.fn(),
-					})),
-					addLayer: jest.fn(),
-				} as any,
+				map: createMockOLMap(),
 				lib: {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
@@ -36,6 +47,28 @@ describe("TerraDrawOpenLayersAdapter", () => {
 			expect(adapter.project).toBeDefined();
 			expect(adapter.unproject).toBeDefined();
 			expect(adapter.setCursor).toBeDefined();
+		});
+	});
+
+	describe("getLngLatFromEvent", () => {
+		let adapter: TerraDrawOpenLayersAdapter;
+		const map = createMockOLMap() as Map;
+		beforeEach(() => {
+			adapter = new TerraDrawOpenLayersAdapter({
+				map,
+				lib: {
+					GeoJSON: jest.fn(),
+					VectorSource: jest.fn(),
+					VectorLayer: jest.fn(),
+				} as any,
+			});
+		});
+		it("getLngLatFromEvent returns correct coordinates", () => {
+			// Mock the getCoordinateFromPixel function
+			map.getCoordinateFromPixel = jest.fn(() => [0, 0]);
+
+			const result = adapter.getLngLatFromEvent(getMockPointerEvent());
+			expect(result).toEqual({ lat: 45, lng: 45 });
 		});
 	});
 });


### PR DESCRIPTION
## Description of Changes

Add in a test for getLngLatFromEvent method in open layers adaptor
Slightly change the way we pass in the mock map in the adaptor for testing so this is easier to reuse

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/90

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 