### PR TITLE
fix: ensure handling of containerPointToLatLng returning invalid values is handled correctly

### DIFF
--- a/src/adapters/leaflet.adapter.spec.ts
+++ b/src/adapters/leaflet.adapter.spec.ts
@@ -91,6 +91,17 @@ describe("TerraDrawLeafletAdapter", () => {
 			const result = adapter.getLngLatFromEvent(getMockPointerEvent());
 			expect(result).toEqual({ lat: 51.507222, lng: -0.1275 });
 		});
+
+		it("getLngLatFromEvent handles null returns from containerPointToLatLng correctly", () => {
+			// Mock the containerPointToLatLng function
+			map.containerPointToLatLng = jest.fn(() => ({
+				lat: null,
+				lng: -0.1275,
+			})) as unknown as (point: L.PointExpression) => L.LatLng;
+
+			const result = adapter.getLngLatFromEvent(getMockPointerEvent());
+			expect(result).toEqual(null);
+		});
 	});
 
 	describe("setDraggability", () => {

--- a/src/adapters/leaflet.adapter.ts
+++ b/src/adapters/leaflet.adapter.ts
@@ -175,12 +175,22 @@ export class TerraDrawLeafletAdapter extends TerraDrawBaseAdapter {
 		const point = { x, y } as L.Point;
 
 		// If is not valid point we don't want to convert
-		if (isNaN(point.x) || isNaN(point.y)) {
+		if (
+			point.x === null ||
+			isNaN(point.x) ||
+			point.y === null ||
+			isNaN(point.y)
+		) {
 			return null;
 		}
 
 		const latLng = this._map.containerPointToLatLng(point);
-		if (isNaN(latLng.lng) || isNaN(latLng.lat)) {
+		if (
+			latLng.lng === null ||
+			isNaN(latLng.lng) ||
+			latLng.lat === null ||
+			isNaN(latLng.lat)
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
## Description of Changes

Noticed at the codesprint - if containerPointToLatLng returned null or undefined the null value would not be returned

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 