### PR TITLE
fix: when clearing ensure ids are reset first before updating store as it may trigger events

### DIFF
--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -212,17 +212,20 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 
 	/** @internal */
 	cleanUp() {
-		try {
-			if (this.currentCircleId !== undefined) {
-				this.store.delete([this.currentCircleId]);
-			}
-		} catch (error) {}
+		const cleanUpId = this.currentCircleId;
+
 		this.center = undefined;
 		this.currentCircleId = undefined;
 		this.clickCount = 0;
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		try {
+			if (cleanUpId !== undefined) {
+				this.store.delete([cleanUpId]);
+			}
+		} catch (error) {}
 	}
 
 	/** @internal */

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -159,10 +159,9 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			this.currentId,
 		);
 
+		const previousIndex = currentLineGeometry.coordinates[0].length - 2;
 		const [previousLng, previousLat] =
-			currentLineGeometry.coordinates[0][
-				currentLineGeometry.coordinates[0].length - 2
-			];
+			currentLineGeometry.coordinates[0][previousIndex];
 		const { x, y } = this.project(previousLng, previousLat);
 		const distance = pixelDistance(
 			{ x, y },
@@ -297,20 +296,24 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 
 	/** @internal */
 	cleanUp() {
-		try {
-			if (this.currentId) {
-				this.store.delete([this.currentId]);
-			}
-			if (this.closingPointId) {
-				this.store.delete([this.closingPointId]);
-			}
-		} catch (error) {}
+		const cleanUpId = this.currentId;
+		const cleanUpClosingPointId = this.closingPointId;
+
 		this.closingPointId = undefined;
 		this.currentId = undefined;
 		this.startingClick = false;
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		try {
+			if (cleanUpId !== undefined) {
+				this.store.delete([cleanUpId]);
+			}
+			if (cleanUpClosingPointId !== undefined) {
+				this.store.delete([cleanUpClosingPointId]);
+			}
+		} catch (error) {}
 	}
 
 	/** @internal */

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -484,14 +484,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 	/** @internal */
 	cleanUp() {
-		try {
-			if (this.currentId) {
-				this.store.delete([this.currentId]);
-			}
-			if (this.closingPointId) {
-				this.store.delete([this.closingPointId]);
-			}
-		} catch (error) {}
+		const cleanUpId = this.currentId;
 
 		this.closingPointId = undefined;
 		this.currentId = undefined;
@@ -499,6 +492,15 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		try {
+			if (cleanUpId !== undefined) {
+				this.store.delete([cleanUpId]);
+			}
+			if (this.closingPointId !== undefined) {
+				this.store.delete([this.closingPointId]);
+			}
+		} catch (error) {}
 	}
 
 	/** @internal */

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -479,19 +479,22 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 	/** @internal */
 	cleanUp() {
-		try {
-			if (this.currentId) {
-				this.store.delete([this.currentId]);
-			}
-			if (this.closingPoints.ids.length) {
-				this.closingPoints.delete();
-			}
-		} catch (error) {}
+		const cleanUpId = this.currentId;
+
 		this.currentId = undefined;
 		this.currentCoordinate = 0;
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		try {
+			if (cleanUpId !== undefined) {
+				this.store.delete([cleanUpId]);
+			}
+			if (this.closingPoints.ids.length) {
+				this.closingPoints.delete();
+			}
+		} catch (error) {}
 	}
 
 	/** @internal */

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -209,15 +209,18 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 	/** @internal */
 	cleanUp() {
-		if (this.currentRectangleId) {
-			this.store.delete([this.currentRectangleId]);
-		}
+		const cleanUpId = this.currentRectangleId;
 
 		this.center = undefined;
 		this.currentRectangleId = undefined;
 		this.clickCount = 0;
+
 		if (this.state === "drawing") {
 			this.setStarted();
+		}
+
+		if (cleanUpId !== undefined) {
+			this.store.delete([cleanUpId]);
 		}
 	}
 


### PR DESCRIPTION
## Description of Changes

Because store changes can trigger events, we must reset the ids _before_ we go to delete, so if clear gets called again from the event, the ids are already reset, avoiding errors.

## Link to Issue

#304 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 