### PR TITLE
fix: ensure correct order of geometries when selecting (point, linestring, polygon)

### DIFF
--- a/src/test/mock-behavior-config.ts
+++ b/src/test/mock-behavior-config.ts
@@ -5,8 +5,8 @@ export const mockBehaviorConfig = (mode: string) =>
 	({
 		store: new GeoJSONStore(),
 		mode,
-		project: jest.fn(),
-		unproject: jest.fn(),
+		project: jest.fn((lng, lat) => ({ x: lng, y: lat })),
+		unproject: jest.fn((x, y) => ({ lng: x, lat: y })),
 		pointerDistance: 40,
 		coordinatePrecision: 9,
 		projection: "web-mercator",


### PR DESCRIPTION
## Description of Changes

Fixes selection order to so that it follows Point, then LineString, then Polygon

## Link to Issue

#268 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 