### PR TITLE
chore: add margin to bottom of logo to avoid overcrowding in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./assets/logo-dark-mode.png">
   <source media="(prefers-color-scheme: light)" srcset="./assets/logo.png">
-  <img alt="Terra Draw logo" src="./assets/logo" width="400px">
+  <img alt="Terra Draw logo" src="./assets/logo" width="400px" style="margin-bottom: 20px">
 </picture>
 
 ![Terra Draw CI Badge](https://github.com/JamesLMilner/terra-draw/actions/workflows/ci.yml/badge.svg)


### PR DESCRIPTION
## Description of Changes

Adds a small margin under the new logo to avoid visual clutter

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 