### PR TITLE
chore: use linebreak under logo as margin does not work on github readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <img alt="Terra Draw logo" src="./assets/logo" width="400px">
 </picture>
 
+<br/>
+
 ![Terra Draw CI Badge](https://github.com/JamesLMilner/terra-draw/actions/workflows/ci.yml/badge.svg)
 [![npm version](https://badge.fury.io/js/terra-draw.svg)](https://badge.fury.io/js/terra-draw)
 


### PR DESCRIPTION
## Description of Changes

The margin changes did not work aa it appears GitHub strips out style from the rendered readme. This approach should work.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 