### PR TITLE
feat: add/read features by user projection in openlayers

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -32,7 +32,14 @@ import View from "ol/View";
 import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
-import { fromLonLat, toLonLat, getUserProjection } from "ol/proj";
+import {
+	fromLonLat,
+	toLonLat,
+	getUserProjection,
+	setUserProjection,
+} from "ol/proj";
+import { register, fromEPSGCode } from "ol/proj/proj4";
+import proj4 from "proj4";
 import EsriMap from "@arcgis/core/Map";
 import MapView from "@arcgis/core/views/MapView.js";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
@@ -389,6 +396,21 @@ const example = {
 			controls: [],
 		});
 
+		// Set user projection to EPSG:4326
+		// setUserProjection("EPSG:4326")
+
+		// Set user projection to ESRI:102400 (London Survey Grid)
+		// register(proj4);
+		// fromEPSGCode("102400")
+		// 	.then(londonGrid => {
+		// 		setUserProjection(londonGrid)
+		// 	})
+		// 	.catch((_) => console.error("Fail to retrieve projection from epsg.io"))
+		//
+		// map.on('click', (event) => {
+		//   console.log(event.coordinate)
+		// })
+
 		map.once("postrender", () => {
 			const draw = new TerraDraw({
 				adapter: new TerraDrawOpenLayersAdapter({
@@ -411,6 +433,11 @@ const example = {
 				modes: getModes(),
 			});
 			draw.start();
+
+			draw.on("change", (e) => {
+				console.log(e);
+				console.log(draw.getSnapshot());
+			});
 
 			addModeChangeHandler(draw, currentSelected);
 

--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -423,8 +423,6 @@ const example = {
 						VectorSource,
 						Stroke,
 						CircleStyle,
-						toLonLat,
-						fromLonLat,
 						getUserProjection,
 					},
 					map,

--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -32,14 +32,7 @@ import View from "ol/View";
 import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
-import {
-	fromLonLat,
-	toLonLat,
-	getUserProjection,
-	setUserProjection,
-} from "ol/proj";
-import { register, fromEPSGCode } from "ol/proj/proj4";
-import proj4 from "proj4";
+import { fromLonLat, getUserProjection } from "ol/proj";
 import EsriMap from "@arcgis/core/Map";
 import MapView from "@arcgis/core/views/MapView.js";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
@@ -396,21 +389,6 @@ const example = {
 			controls: [],
 		});
 
-		// Set user projection to EPSG:4326
-		// setUserProjection("EPSG:4326")
-
-		// Set user projection to ESRI:102400 (London Survey Grid)
-		// register(proj4);
-		// fromEPSGCode("102400")
-		// 	.then(londonGrid => {
-		// 		setUserProjection(londonGrid)
-		// 	})
-		// 	.catch((_) => console.error("Fail to retrieve projection from epsg.io"))
-		//
-		// map.on('click', (event) => {
-		//   console.log(event.coordinate)
-		// })
-
 		map.once("postrender", () => {
 			const draw = new TerraDraw({
 				adapter: new TerraDrawOpenLayersAdapter({
@@ -431,11 +409,6 @@ const example = {
 				modes: getModes(),
 			});
 			draw.start();
-
-			draw.on("change", (e) => {
-				console.log(e);
-				console.log(draw.getSnapshot());
-			});
 
 			addModeChangeHandler(draw, currentSelected);
 

--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -32,7 +32,7 @@ import View from "ol/View";
 import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
-import { fromLonLat, toLonLat } from "ol/proj";
+import { fromLonLat, toLonLat, getUserProjection } from "ol/proj";
 import EsriMap from "@arcgis/core/Map";
 import MapView from "@arcgis/core/views/MapView.js";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
@@ -375,7 +375,6 @@ const example = {
 
 		console.log(lng, lat, zoom);
 		const center = fromLonLat([lng, lat]);
-
 		const map = new Map({
 			layers: [
 				new TileLayer({
@@ -401,8 +400,10 @@ const example = {
 						VectorLayer,
 						VectorSource,
 						Stroke,
-						toLonLat,
 						CircleStyle,
+						toLonLat,
+						fromLonLat,
+						getUserProjection,
 					},
 					map,
 					coordinatePrecision: 9,

--- a/guides/3.ADAPTERS.md
+++ b/guides/3.ADAPTERS.md
@@ -268,7 +268,7 @@ import View from "ol/View";
 import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
-import { fromLonLat, toLonLat, getUserProjection } from "ol/proj";
+import { fromLonLat, getUserProjection } from "ol/proj";
 
 // Create map
 const map = new Map({
@@ -298,8 +298,6 @@ map.once("postrender", () => {
                 VectorSource,
                 Stroke,
                 CircleStyle,
-                toLonLat,
-                fromLonLat,
                 getUserProjection,
             },
             map,

--- a/guides/3.ADAPTERS.md
+++ b/guides/3.ADAPTERS.md
@@ -268,7 +268,7 @@ import View from "ol/View";
 import { Circle as CircleStyle, Stroke, Style } from "ol/style";
 import { OSM, Vector as VectorSource } from "ol/source";
 import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
-import { fromLonLat, toLonLat } from "ol/proj";
+import { fromLonLat, toLonLat, getUserProjection } from "ol/proj";
 
 // Create map
 const map = new Map({
@@ -297,8 +297,10 @@ map.once("postrender", () => {
                 VectorLayer,
                 VectorSource,
                 Stroke,
-                toLonLat,
                 CircleStyle,
+                toLonLat,
+                fromLonLat,
+                getUserProjection,
             },
             map,
             coordinatePrecision: 9,

--- a/src/adapters/openlayers.adapter.spec.ts
+++ b/src/adapters/openlayers.adapter.spec.ts
@@ -8,6 +8,10 @@ jest.mock("ol/style/Circle", () => jest.fn());
 jest.mock("ol/style/Fill", () => jest.fn());
 jest.mock("ol/style/Stroke", () => jest.fn());
 jest.mock("ol/style/Style", () => jest.fn());
+jest.mock("ol/proj", () => ({
+	toLonLat: () => [45, 45],
+	fromLonLat: () => [0, 0],
+}));
 jest.mock("ol/geom/Geometry", () => jest.fn());
 
 const createMockOLMap = () => {
@@ -35,7 +39,6 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
-					toLonLat: jest.fn(),
 					getUserProjection: jest.fn(),
 				} as any,
 				minPixelDragDistance: 1,
@@ -65,7 +68,6 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
-					toLonLat: jest.fn(() => [45, 45]),
 					getUserProjection: jest.fn(() => "EPSG:3857"),
 				} as any,
 			});
@@ -85,8 +87,6 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
-					toLonLat: jest.fn(() => [0, 0]),
-					fromLonLat: jest.fn(() => [0, 0]),
 					getUserProjection: jest.fn(() => "EPSG:3857"),
 				} as any,
 			});
@@ -107,7 +107,6 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
-					toLonLat: jest.fn(() => [45, 45]),
 					getUserProjection: jest.fn(() => "EPSG:3857"),
 				} as any,
 			});

--- a/src/adapters/openlayers.adapter.spec.ts
+++ b/src/adapters/openlayers.adapter.spec.ts
@@ -1,16 +1,19 @@
 import { TerraDrawOpenLayersAdapter } from "./openlayers.adapter";
 import Map from "ol/Map";
+import { Pixel } from "ol/pixel";
+import { Coordinate } from "ol/coordinate";
 import { getMockPointerEvent } from "../test/mock-pointer-event";
 
 jest.mock("ol/style/Circle", () => jest.fn());
 jest.mock("ol/style/Fill", () => jest.fn());
 jest.mock("ol/style/Stroke", () => jest.fn());
 jest.mock("ol/style/Style", () => jest.fn());
-jest.mock("ol/proj", () => ({ toLonLat: () => [45, 45] }));
 jest.mock("ol/geom/Geometry", () => jest.fn());
 
 const createMockOLMap = () => {
 	return {
+		getCoordinateFromPixel: jest.fn(() => [0, 0] as Pixel),
+		getPixelFromCoordinate: jest.fn(() => [0, 0] as Coordinate),
 		getViewport: jest.fn(() => ({
 			setAttribute: jest.fn(),
 			querySelectorAll: jest.fn(() => [
@@ -32,6 +35,8 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
+					toLonLat: jest.fn(),
+					getUserProjection: jest.fn(),
 				} as any,
 				minPixelDragDistance: 1,
 				minPixelDragDistanceSelecting: 8,
@@ -60,15 +65,57 @@ describe("TerraDrawOpenLayersAdapter", () => {
 					GeoJSON: jest.fn(),
 					VectorSource: jest.fn(),
 					VectorLayer: jest.fn(),
+					toLonLat: jest.fn(() => [45, 45]),
+					getUserProjection: jest.fn(() => "EPSG:3857"),
 				} as any,
 			});
 		});
 		it("getLngLatFromEvent returns correct coordinates", () => {
-			// Mock the getCoordinateFromPixel function
-			map.getCoordinateFromPixel = jest.fn(() => [0, 0]);
-
 			const result = adapter.getLngLatFromEvent(getMockPointerEvent());
 			expect(result).toEqual({ lat: 45, lng: 45 });
+		});
+	});
+
+	describe("project", () => {
+		it("returns the correct lat lng as expected", () => {
+			const map = createMockOLMap() as Map;
+			const adapter = new TerraDrawOpenLayersAdapter({
+				map,
+				lib: {
+					GeoJSON: jest.fn(),
+					VectorSource: jest.fn(),
+					VectorLayer: jest.fn(),
+					toLonLat: jest.fn(() => [0, 0]),
+					fromLonLat: jest.fn(() => [0, 0]),
+					getUserProjection: jest.fn(() => "EPSG:3857"),
+				} as any,
+			});
+
+			// Test enabling dragging
+			adapter.project(0, 0);
+			expect(map.getPixelFromCoordinate).toHaveBeenCalledTimes(1);
+			expect(map.getPixelFromCoordinate).toHaveBeenCalledWith([0, 0]);
+		});
+	});
+
+	describe("unproject", () => {
+		it("returns the correct x y as expected", () => {
+			const map = createMockOLMap() as Map;
+			const adapter = new TerraDrawOpenLayersAdapter({
+				map,
+				lib: {
+					GeoJSON: jest.fn(),
+					VectorSource: jest.fn(),
+					VectorLayer: jest.fn(),
+					toLonLat: jest.fn(() => [45, 45]),
+					getUserProjection: jest.fn(() => "EPSG:3857"),
+				} as any,
+			});
+
+			// Test enabling dragging
+			adapter.unproject(0, 0);
+			expect(map.getCoordinateFromPixel).toHaveBeenCalledTimes(1);
+			expect(map.getCoordinateFromPixel).toHaveBeenCalledWith([0, 0]);
 		});
 	});
 });

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -24,6 +24,7 @@ import {
 } from "ol/proj";
 import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
 import { Coordinate } from "ol/coordinate";
+import { Pixel } from "ol/pixel";
 
 type InjectableOL = {
 	Circle: typeof CircleGeom;
@@ -262,7 +263,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	 */
 	public project(lng: number, lat: number) {
 		const [x, y] = this._map.getPixelFromCoordinate(
-			this._fromLonLat([lng, lat], this._projection),
+			this._fromLonLat([lng, lat], this._projection) as Coordinate,
 		);
 		return { x, y };
 	}
@@ -275,7 +276,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	 */
 	public unproject(x: number, y: number) {
 		const [lng, lat] = this._toLonLat(
-			this._map.getCoordinateFromPixel([x, y]),
+			this._map.getCoordinateFromPixel([x, y]) as Pixel,
 			this._projection,
 		);
 		return { lng, lat };

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -53,7 +53,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 		this._lib = config.lib;
 
 		this._geoJSONReader = new this._lib.GeoJSON();
-		this._projection = this._lib.getUserProjection() || "EPSG:4326";
+		this._projection = this._lib.getUserProjection() || "EPSG:3857";
 		this._fromLonLat = this._lib.fromLonLat;
 		this._toLonLat = this._lib.toLonLat;
 

--- a/src/adapters/openlayers.adapter.ts
+++ b/src/adapters/openlayers.adapter.ts
@@ -16,8 +16,14 @@ import Style from "ol/style/Style";
 import VectorSource from "ol/source/Vector";
 import { Geometry } from "ol/geom";
 import VectorLayer from "ol/layer/Vector";
-import { fromLonLat, toLonLat } from "ol/proj";
+import {
+	toLonLat,
+	fromLonLat,
+	getUserProjection,
+	ProjectionLike,
+} from "ol/proj";
 import { BaseAdapterConfig, TerraDrawBaseAdapter } from "./common/base.adapter";
+import { Coordinate } from "ol/coordinate";
 
 type InjectableOL = {
 	Circle: typeof CircleGeom;
@@ -28,7 +34,9 @@ type InjectableOL = {
 	VectorLayer: typeof VectorLayer;
 	VectorSource: typeof VectorSource;
 	Stroke: typeof Stroke;
+	getUserProjection: typeof getUserProjection;
 	toLonLat: typeof toLonLat;
+	fromLonLat: typeof fromLonLat;
 };
 
 export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
@@ -44,6 +52,9 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 		this._lib = config.lib;
 
 		this._geoJSONReader = new this._lib.GeoJSON();
+		this._projection = this._lib.getUserProjection() || "EPSG:4326";
+		this._fromLonLat = this._lib.fromLonLat;
+		this._toLonLat = this._lib.toLonLat;
 
 		this._container = this._map.getViewport();
 
@@ -71,7 +82,15 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	private _lib: InjectableOL;
 	private _map: Map;
 	private _container: HTMLElement;
-	private _projection = "EPSG:3857" as const;
+	private _projection: ProjectionLike;
+	private _fromLonLat: (
+		coordinate: Coordinate,
+		projection: ProjectionLike,
+	) => Coordinate;
+	private _toLonLat: (
+		coordinate: Coordinate,
+		projection: ProjectionLike,
+	) => Coordinate;
 	private _vectorSource: undefined | VectorSource<Feature<Geometry>>;
 	private _geoJSONReader: undefined | GeoJSON;
 
@@ -171,6 +190,7 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	private addFeature(feature: GeoJSONStoreFeatures) {
 		if (this._vectorSource && this._geoJSONReader) {
 			const olFeature = this._geoJSONReader.readFeature(feature, {
+				dataProjection: "EPSG:4326",
 				featureProjection: this._projection,
 			}) as Feature<Geometry>;
 			this._vectorSource.addFeature(olFeature);
@@ -241,7 +261,9 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	 * @returns An object with 'x' and 'y' properties representing the pixel coordinates within the map container.
 	 */
 	public project(lng: number, lat: number) {
-		const [x, y] = this._map.getPixelFromCoordinate(fromLonLat([lng, lat]));
+		const [x, y] = this._map.getPixelFromCoordinate(
+			this._fromLonLat([lng, lat], this._projection),
+		);
 		return { x, y };
 	}
 
@@ -252,7 +274,10 @@ export class TerraDrawOpenLayersAdapter extends TerraDrawBaseAdapter {
 	 * @returns An object with 'lng' and 'lat' properties representing the longitude and latitude coordinates.
 	 */
 	public unproject(x: number, y: number) {
-		const [lng, lat] = toLonLat(this._map.getCoordinateFromPixel([x, y]));
+		const [lng, lat] = this._toLonLat(
+			this._map.getCoordinateFromPixel([x, y]),
+			this._projection,
+		);
 		return { lng, lat };
 	}
 


### PR DESCRIPTION
## Description of Changes

Add/display GeoJSON features with EPSG:4326 coordinates, when custom user projection set by user.

Since `ol/proj.transform()` uses defined projections in module, this PR add more inject items for openlayers adapter.

The following example use patched adapter:
- [EPSG:4326] WGS84
- [EPSG:3857] WGS 84 / Pseudo-Mercator
- [EPSG:3826] (Not built-in projection in `ol/proj`)

## Link to Issue
#319 

[EPSG:4326]: https://outdoorsafetylab.github.io/dumbymap/#%7B%22content%22%3A%22%60%60%60map%5Cnid%3A%204326%5Cnuse%3A%20https%3A%2F%2Funpkg.com%2Fmapclay%400.6.5%2Fdist%2Frenderers%2Fopenlayers.mjs%5Cnproj%3A%20EPSG%3A4326%5Cndraw%3A%20true%5Cncenter%3A%20%5B121%2C24%5D%5Cn%5Cn---%5Cn%5Cnconst%20coords%20%3D%20document.querySelector('%23coords')%3B%5Cnconst%20projection%20%3D%20ol.proj.getUserProjection().getCode()%3B%5Cnmap.on('pointermove'%2C%20e%20%3D%3E%20%7B%5Cn%20%20const%20%5Bx%2C%20y%5D%20%3D%20map.getCoordinateFromPixel(e.pixel)%3B%5Cn%20%20coords.innerHTML%20%3D%20%60%5Cn%20%20%20%20%24%7Bprojection%7D%3Cbr%3E%5Cn%20%20%20%20x%20%3D%3E%20%24%7BNumber(x).toFixed(5)%7D%20%2F%20%5Cn%20%20%20%20y%20%3D%3E%20%24%7BNumber(y).toFixed(5)%7D%5Cn%20%20%60%3B%5Cn%7D)%3B%5Cn%5Cnconst%20textArea%20%3D%20document.querySelector('%23features')%3B%5Cn%5Cndraw.on('change'%2C%20(id%2C_)%20%3D%3E%20%7B%5Cn%20%20const%20features%20%3D%20draw.getSnapshot().filter(f%20%3D%3E%20%5Cn%20%20%20%20f.id.startsWith(target.id)%5Cn%20%20)%3B%5Cn%20%20textArea.textContent%20%3D%20features.length%20%2B%20%5C%22%20features%5C%5Cn%5C%5Cn%5C%22%5Cn%20%20%20%20%2B%20JSON.stringify(features%2C%20null%2C%204)%3B%5Cn%7D)%3B%5Cn%60%60%60%5Cn%5Cn-%20%5BSelect%20%5C%22Points%5C%22%5D(%23Here%20%5C%22%3D%3Eselect%5C%22)%20to%20add%20features%5Cn-%20%5BAnchor%20for%20ref%5D(geo%3A24%2C121)%20%5B121%2C24%5D%5Cn%5Cn%5Cn%3Cdiv%20id%3D%5C%22coords%5C%22%20stye%3D%5C%22background-color%3A%20gray%3B%20height%3A%20200px%3B%5C%22%3E%3C%2Fdiv%3E%5Cn%3Ctextarea%20id%3D%5C%22features%5C%22%20style%3D%5C%22width%3A%20100%25%3B%20height%3A%20500px%5C%22%3E%3C%2Ftextarea%3E%22%7D
[EPSG:3857]: https://outdoorsafetylab.github.io/dumbymap/#%7B%22content%22%3A%22%60%60%60map%5Cnid%3A%203857%5Cnuse%3A%20https%3A%2F%2Funpkg.com%2Fmapclay%400.6.5%2Fdist%2Frenderers%2Fopenlayers.mjs%5Cnproj%3A%20EPSG%3A3857%5Cndraw%3A%20true%5Cncenter%3A%20%5B13469658%2C%202753408%5D%5Cn%5Cn---%5Cnwindow.proj%20%3D%20ol.proj%3B%5Cnconst%20coords%20%3D%20document.querySelector('%23coords')%3B%5Cnconst%20projection%20%3D%20ol.proj.getUserProjection().getCode()%3B%5Cnmap.on('pointermove'%2C%20e%20%3D%3E%20%7B%5Cn%20%20const%20%5Bx%2C%20y%5D%20%3D%20map.getCoordinateFromPixel(e.pixel)%3B%5Cn%20%20coords.innerHTML%20%3D%20%60%5Cn%20%20%20%20%24%7Bprojection%7D%3Cbr%3E%5Cn%20%20%20%20x%20%3D%3E%20%24%7BNumber(x).toFixed(5)%7D%20%2F%20%5Cn%20%20%20%20y%20%3D%3E%20%24%7BNumber(y).toFixed(5)%7D%5Cn%20%20%60%3B%5Cn%7D)%3B%5Cn%5Cnconst%20textArea%20%3D%20document.querySelector('%23features')%3B%5Cn%5Cndraw.on('change'%2C%20(id%2C_)%20%3D%3E%20%7B%5Cn%20%20const%20features%20%3D%20draw.getSnapshot().filter(f%20%3D%3E%20%5Cn%20%20%20%20f.id.startsWith(target.id)%5Cn%20%20)%3B%5Cn%20%20textArea.textContent%20%3D%20features.length%20%2B%20%5C%22%20features%5C%5Cn%5C%5Cn%5C%22%5Cn%20%20%20%20%2B%20JSON.stringify(features%2C%20null%2C%204)%3B%5Cn%7D)%3B%5Cn%60%60%60%5Cn%5Cn-%20%5BSelect%20%5C%22Points%5C%22%5D(%23Here%20%5C%22%3D%3Eselect%5C%22)%20to%20add%20features%5Cn-%20%5BAnchor%20for%20ref%5D(geo%3A2753408%2C13469658)%20%5B13469658%2C%202753408%5D%5Cn%5Cn%5Cn%3Cdiv%20id%3D%5C%22coords%5C%22%20stye%3D%5C%22background-color%3A%20gray%3B%20height%3A%20200px%3B%5C%22%3E%3C%2Fdiv%3E%5Cn%3Ctextarea%20id%3D%5C%22features%5C%22%20style%3D%5C%22width%3A%20100%25%3B%20height%3A%20500px%5C%22%3E%3C%2Ftextarea%3E%22%7D
[EPSG:3826]: https://outdoorsafetylab.github.io/dumbymap/#%7B%22content%22%3A%22%60%60%60map%5Cnid%3A%203826%5Cnuse%3A%20https%3A%2F%2Funpkg.com%2Fmapclay%400.6.5%2Fdist%2Frenderers%2Fopenlayers.mjs%5Cnproj%3A%20EPSG%3A3826%5Cndraw%3A%20true%5Cncenter%3A%20%5B250000%2C%202655023%5D%5Cn%5Cn---%5Cn%5Cnwindow.proj%20%3D%20ol.proj%3B%5Cnconst%20coords%20%3D%20document.querySelector('%23coords')%3B%5Cnconst%20projection%20%3D%20ol.proj.getUserProjection().getCode()%3B%5Cnmap.on('pointermove'%2C%20e%20%3D%3E%20%7B%5Cn%20%20const%20%5Bx%2C%20y%5D%20%3D%20map.getCoordinateFromPixel(e.pixel)%3B%5Cn%20%20coords.innerHTML%20%3D%20%60%5Cn%20%20%20%20%24%7Bprojection%7D%3Cbr%3E%5Cn%20%20%20%20x%20%3D%3E%20%24%7BNumber(x).toFixed(5)%7D%20%2F%20%5Cn%20%20%20%20y%20%3D%3E%20%24%7BNumber(y).toFixed(5)%7D%5Cn%20%20%60%3B%5Cn%7D)%3B%5Cn%5Cnconst%20textArea%20%3D%20document.querySelector('%23features')%3B%5Cn%5Cndraw.on('change'%2C%20(id%2C_)%20%3D%3E%20%7B%5Cn%20%20const%20features%20%3D%20draw.getSnapshot().filter(f%20%3D%3E%20%5Cn%20%20%20%20f.id.startsWith(target.id)%5Cn%20%20)%3B%5Cn%20%20textArea.textContent%20%3D%20features.length%20%2B%20%5C%22%20features%5C%5Cn%5C%5Cn%5C%22%5Cn%20%20%20%20%2B%20JSON.stringify(features%2C%20null%2C%204)%3B%5Cn%7D)%3B%5Cn%60%60%60%5Cn%5Cn-%20%5BSelect%20%5C%22Points%5C%22%5D(%23Here%20%5C%22%3D%3Eselect%5C%22)%20to%20add%20features%5Cn-%20%5BAnchor%20for%20ref%5D(geo%3A2655023%2C250000)%20%5B250000%2C%202655023%5D%5Cn%5Cn%5Cn%3Cdiv%20id%3D%5C%22coords%5C%22%20stye%3D%5C%22background-color%3A%20gray%3B%20height%3A%20200px%3B%5C%22%3E%3C%2Fdiv%3E%5Cn%3Ctextarea%20id%3D%5C%22features%5C%22%20style%3D%5C%22width%3A%20100%25%3B%20height%3A%20500px%5C%22%3E%3C%2Ftextarea%3E%22%7D