### PR TITLE
test: improve unit test coverage for terra-draw.ts and set unit test coverage threshold to 80%

### DIFF
--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -186,6 +186,8 @@ You can also check the coverage by running:
 npm run test:coverage
 ```
 
+If coverage (either lines, branches, functions or statements) falls under 80%, this script will fail.
+
 For local development you may benefit from the `nocheck` option which allows you to avoid running TypeScript type checking when running the tests. This option also only checks files which are explicitly tested (i.e. have a spec file.)
 
 ```shell

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,10 @@ module.exports = {
 	collectCoverageFrom: ["./src/**"],
 	coverageThreshold: {
 		global: {
-			lines: 65,
+			lines: 80,
+			functions: 80,
+			branches: 80,
+			statements: 80,
 		},
 	},
 };


### PR DESCRIPTION
## Description of Changes

* Adds test coverage for `terra-draw.ts` file, i.e. the core Terra Draw API
* Sets the minimum test coverage to 80%

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 