### PR TITLE
fix: remove closing point correctly

### DIFF
--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -814,7 +814,7 @@ describe("TerraDrawLineStringMode", () => {
 			}).not.toThrowError();
 		});
 
-		it("cleans up correctly if drawing has started", () => {
+		it("cleans up correctly if drawing has started and there is no closing point", () => {
 			lineStringMode.onClick({
 				lng: 0,
 				lat: 0,
@@ -825,6 +825,42 @@ describe("TerraDrawLineStringMode", () => {
 			});
 
 			expect(store.copyAll().length).toBe(1);
+
+			lineStringMode.cleanUp();
+
+			// Removes the LineString that was being created
+			expect(store.copyAll().length).toBe(0);
+		});
+
+		it("cleans up correctly if drawing has started and there is a closing point", () => {
+			lineStringMode.onClick({
+				lng: 0,
+				lat: 0,
+				containerX: 0,
+				containerY: 0,
+				button: "left",
+				heldKeys: [],
+			});
+
+			lineStringMode.onMouseMove({
+				lng: 1,
+				lat: 1,
+				containerX: 0,
+				containerY: 0,
+				button: "left",
+				heldKeys: [],
+			});
+
+			lineStringMode.onClick({
+				lng: 1,
+				lat: 1,
+				containerX: 0,
+				containerY: 0,
+				button: "left",
+				heldKeys: [],
+			});
+
+			expect(store.copyAll().length).toBe(2);
 
 			lineStringMode.cleanUp();
 

--- a/src/modes/linestring/linestring.mode.ts
+++ b/src/modes/linestring/linestring.mode.ts
@@ -488,6 +488,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	/** @internal */
 	cleanUp() {
 		const cleanUpId = this.currentId;
+		const cleanupClosingPointId = this.closingPointId;
 
 		this.closingPointId = undefined;
 		this.currentId = undefined;
@@ -500,8 +501,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			if (cleanUpId !== undefined) {
 				this.store.delete([cleanUpId]);
 			}
-			if (this.closingPointId !== undefined) {
-				this.store.delete([this.closingPointId]);
+			if (cleanupClosingPointId !== undefined) {
+				this.store.delete([cleanupClosingPointId]);
 			}
 		} catch (error) {}
 	}


### PR DESCRIPTION
## Description of Changes

Ensures closing point is removed correctly for TerraDrawLineString mode when clean up is called

## Link to Issue

#340 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 