### PR TITLE
fix: ensure TerraDrawSensorMode line arc can be styled correctly

### DIFF
--- a/src/modes/sensor/sensor.mode.spec.ts
+++ b/src/modes/sensor/sensor.mode.spec.ts
@@ -829,6 +829,28 @@ describe("TerraDrawSensorMode", () => {
 			});
 		});
 
+		it("returns the correct styles for polygon", () => {
+			const sensorMode = new TerraDrawSensorMode({
+				styles: {
+					fillColor: "#ffffff",
+					outlineColor: "#111111",
+					outlineWidth: 2,
+					fillOpacity: 0.5,
+				},
+			});
+
+			expect(
+				sensorMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "LineString", coordinates: [] },
+					properties: { mode: "sensor" },
+				}),
+			).toMatchObject({
+				lineStringColor: "#111111",
+				lineStringWidth: 2,
+			});
+		});
+
 		it("returns the correct styles for point", () => {
 			const sensorMode = new TerraDrawSensorMode({
 				styles: {

--- a/src/modes/sensor/sensor.mode.ts
+++ b/src/modes/sensor/sensor.mode.ts
@@ -598,6 +598,20 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 				);
 
 				styles.zIndex = 10;
+			} else if (feature.geometry.type === "LineString") {
+				styles.lineStringColor = this.getHexColorStylingValue(
+					this.styles.outlineColor,
+					styles.polygonOutlineColor,
+					feature,
+				);
+
+				styles.lineStringWidth = this.getNumericStylingValue(
+					this.styles.outlineWidth,
+					styles.polygonOutlineWidth,
+					feature,
+				);
+
+				styles.zIndex = 10;
 			} else if (feature.geometry.type === "Point") {
 				styles.pointColor = this.getHexColorStylingValue(
 					this.styles.centerPointColor,


### PR DESCRIPTION
## Description of Changes

* Ensures that the linestring that gets generated whilst drawing the Sensor retains the same styling as the final polygon

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 