### PR TITLE
fix: provide smoother transition of sensor depth when cursor goes into inner radius

### DIFF
--- a/src/modes/sensor/sensor.mode.ts
+++ b/src/modes/sensor/sensor.mode.ts
@@ -308,10 +308,10 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 
 			const hasLessThanZeroSize = outerRadius < innerRadius;
 
-			// We don't need to continue if the users cursor is not in front of the arc
-			if (hasLessThanZeroSize) {
-				return;
-			}
+			// If the cursor is inside the inner radius, the depth of the sensor is always 0
+			const radiusCalculationPosition = hasLessThanZeroSize
+				? webMercatorCoordOne
+				: webMercatorCursor;
 
 			const cursorBearing = webMercatorBearing(
 				webMercatorCenter,
@@ -357,7 +357,10 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 			const multiplier = this.direction === "anticlockwise" ? 1 : -1;
 			const bearingStep = (multiplier * deltaBearing) / numberOfPoints;
 
-			const radius = cartesianDistance(webMercatorCenter, webMercatorCursor);
+			const radius = cartesianDistance(
+				webMercatorCenter,
+				radiusCalculationPosition,
+			);
 
 			// Add all the arc points
 			const finalArc = [];


### PR DESCRIPTION
## Description of Changes

Makes it so the transition when moving the cursor inside the inner arc is smoother and doesn't leave a depth of greater than 0 when the cursor is inside the inner radius

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 