### PR TITLE
fix: ensure that common folder files are published so types are not missing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,6 @@ data/
 .husky/
 .github/
 ROADMAP.md
-common/
 guides/
 readme.gif
 jest.config.ts


### PR DESCRIPTION
## Description of Changes

* Ensures the common folders are published to npm, which I believe has been causing type failures relating to `adapters/common.ts`

## Link to Issue

I think this partially resolves #350 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 