### PR TITLE
fix: handle multiple layers in TerraDrawOpenLayersAdapter

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -380,6 +380,17 @@ const example = {
 				new TileLayer({
 					source: new OSM(),
 				}),
+				// If you want to experiment with multiple layers uncomment this
+				// new VectorLayer({
+				// 	background: '#1a2b39',
+				// 	source: new VectorSource({
+				// 		url: 'https://openlayers.org/data/vector/ecoregions.json',
+				// 		format: new GeoJSON(),
+				// 	}),
+				// 	style: {
+				// 		'fill-color': ['string', ['get', 'COLOR'], '#eee'],
+				// 	},
+				// })
 			],
 			target: this.generateId(Libraries.OpenLayers),
 			view: new View({
@@ -389,7 +400,8 @@ const example = {
 			controls: [],
 		});
 
-		map.once("postrender", () => {
+		// All layers must be rendered before we can start drawing
+		map.once("rendercomplete", () => {
 			const draw = new TerraDraw({
 				adapter: new TerraDrawOpenLayersAdapter({
 					lib: {

--- a/src/adapters/common/base.adapter.ts
+++ b/src/adapters/common/base.adapter.ts
@@ -136,7 +136,7 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 		return this._coordinatePrecision;
 	}
 
-	private getAdapterListeners() {
+	protected getAdapterListeners() {
 		return [
 			new AdapterListener<BasePointerListener>({
 				name: "pointerdown",


### PR DESCRIPTION
## Description of Changes

Fix TerraDrawOpenLayersAdapter not being able to handle multiple layers, preventing users from having more than one layer. This fix attempts to go a bit deeper, handling the scenario where layers are added or removed also. This is necessary because Terra Draw intercepts events on the 'top' canvas DOM element that is present in the browser. If we remove a layer or add layer we want to ensure the top layer is correct.

## Link to Issue

#357 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 