### PR TITLE
fix: ensure that features are dragged in the projection set in TerraDrawSelectMode

### DIFF
--- a/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -33,12 +33,15 @@ describe("DragFeatureBehavior", () => {
 		});
 	});
 
-	describe("api", () => {
+	describe.each(["web-mercator", "globe"])("api", (projection) => {
 		let config: BehaviorConfig;
 		let dragFeatureBehavior: DragFeatureBehavior;
 
 		beforeEach(() => {
-			config = MockBehaviorConfig("test");
+			config = MockBehaviorConfig(
+				"test",
+				projection as "web-mercator" | "globe",
+			);
 			const selectionPointBehavior = new SelectionPointBehavior(config);
 			const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
 				config,
@@ -110,6 +113,22 @@ describe("DragFeatureBehavior", () => {
 
 				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
+
+				expect(config.store.updateGeometry).not.toHaveBeenCalledWith({
+					id,
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[0, 1],
+								[1, 1],
+								[1, 0],
+								[0, 0],
+							],
+						],
+					},
+				});
 			});
 
 			it("validation returning false does not update the polygon to the dragged position", () => {

--- a/src/test/mock-behavior-config.ts
+++ b/src/test/mock-behavior-config.ts
@@ -1,7 +1,10 @@
 import { BehaviorConfig } from "../modes/base.behavior";
 import { GeoJSONStore } from "../store/store";
 
-export const MockBehaviorConfig = (mode: string) =>
+export const MockBehaviorConfig = (
+	mode: string,
+	projection?: "web-mercator" | "globe",
+) =>
 	({
 		store: new GeoJSONStore(),
 		mode,
@@ -9,5 +12,5 @@ export const MockBehaviorConfig = (mode: string) =>
 		unproject: jest.fn((x, y) => ({ lng: x / 40, lat: y / 40 })),
 		pointerDistance: 40,
 		coordinatePrecision: 9,
-		projection: "web-mercator",
+		projection: projection ? projection : "web-mercator",
 	}) as BehaviorConfig;


### PR DESCRIPTION
## Description of Changes

This change ensures that features are moved in a way that is appropriate for the provided `projection` that is passed to `TerraDrawSelectMode`

## Link to Issue

#359 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 