### PR TITLE
fix: create circle with minimum starting radius if there is no cursor movement

### DIFF
--- a/src/modes/circle/circle.mode.spec.ts
+++ b/src/modes/circle/circle.mode.spec.ts
@@ -150,7 +150,7 @@ describe("TerraDrawCircleMode", () => {
 					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 				});
 
-				it("finishes drawing circle on second click", () => {
+				it("finishes drawing circle on second click with no cursor movement", () => {
 					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
 					let features = store.copyAll();
@@ -161,7 +161,27 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					expect(onChange).toHaveBeenCalledTimes(3);
+					// We don't expect any changes if there is no cursor movement
+					expect(onChange).toHaveBeenCalledTimes(1);
+					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+
+					expect(onFinish).toHaveBeenCalledTimes(1);
+				});
+
+				it("finishes drawing circle on second click with cursor movement", () => {
+					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+					let features = store.copyAll();
+					expect(features.length).toBe(1);
+
+					circleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					circleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					features = store.copyAll();
+					expect(features.length).toBe(1);
+
+					expect(onChange).toHaveBeenCalledTimes(5);
 					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 
 					expect(onFinish).toHaveBeenCalledTimes(1);
@@ -230,7 +250,7 @@ describe("TerraDrawCircleMode", () => {
 					expect(onFinish).toHaveBeenCalledTimes(0);
 				});
 
-				it("does finish drawing circle on second click if validation returns true", () => {
+				it("does finish drawing circle on second click if validation returns true with no cursor movement", () => {
 					valid = true;
 
 					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
@@ -243,7 +263,7 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					expect(onChange).toHaveBeenCalledTimes(3);
+					expect(onChange).toHaveBeenCalledTimes(1);
 					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 					expect(onFinish).toHaveBeenCalledTimes(1);
 					expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {

--- a/src/modes/circle/circle.mode.ts
+++ b/src/modes/circle/circle.mode.ts
@@ -54,6 +54,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	private keyEvents: TerraDrawCircleModeKeyEvents;
 	private cursors: Required<Cursors>;
 	private startingRadiusKilometers = 0.00001;
+	private cursorMovedAfterInitialCursorDown = false;
 
 	/**
 	 * Create a new circle mode instance
@@ -123,6 +124,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 			}
 		}
 
+		this.cursorMovedAfterInitialCursorDown = false;
 		this.center = undefined;
 		this.currentCircleId = undefined;
 		this.clickCount = 0;
@@ -169,12 +171,14 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 			]);
 			this.currentCircleId = createdId;
 			this.clickCount++;
+			this.cursorMovedAfterInitialCursorDown = false;
 			this.setDrawing();
 		} else {
 			if (
 				this.clickCount === 1 &&
 				this.center &&
-				this.currentCircleId !== undefined
+				this.currentCircleId !== undefined &&
+				this.cursorMovedAfterInitialCursorDown
 			) {
 				this.updateCircle(event);
 			}
@@ -186,6 +190,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 
 	/** @internal */
 	onMouseMove(event: TerraDrawMouseEvent) {
+		this.cursorMovedAfterInitialCursorDown = true;
 		this.updateCircle(event);
 	}
 


### PR DESCRIPTION
## Description of Changes

Ensures that the visible Circle drawn which respects the `startingRadiusKilometers` if the users cursor does not move

## Link to Issue

#369 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 