### PR TITLE
chore: move GitHub actions and guidance to Node.js version 22 (current LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Install Parent Folder
         run: npm install
       - name: Run linting
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Install Parent Folder
         run: npm install
       - name: Run unused code checking
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Install Parent Folder
         run: npm install
       - name: Ensure no package-lock.json changes
@@ -58,7 +58,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
       - name: Install Parent Folder
         run: npm install
       - name: Test
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: "20.x"
+        node-version: "22.x"
     - name: Install parent directory
       run: npm install
     - name: Get installed Playwright version

--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -7,7 +7,7 @@ How to develop the Terra Draw project locally.
 You will need to have the following installed:
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Node.js v20.x](https://nodejs.org/en/download/)
+- [Node.js v22.x](https://nodejs.org/en/download/)
 - [npm v10.x](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 ## Folder Structure


### PR DESCRIPTION
## Description of Changes

Makes use of the latest Node.js LTS, version 22

## Link to Issue

#368 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 