### PR TITLE
fix: ensure that closingPoint property exists on closingPoint of freehand mode

### DIFF
--- a/src/modes/freehand/freehand.mode.spec.ts
+++ b/src/modes/freehand/freehand.mode.spec.ts
@@ -142,6 +142,12 @@ describe("TerraDrawFreehandMode", () => {
 					[expect.any(String), expect.any(String)],
 					"create",
 				);
+
+				const features = store.copyAll();
+				expect(features.length).toBe(2);
+				expect(features[0].geometry.type).toBe("Polygon");
+				expect(features[1].geometry.type).toBe("Point");
+				expect(features[1].properties.closingPoint).toBe(true);
 			});
 
 			it("finishes drawing polygon on second click", () => {

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -6,6 +6,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
+	POLYGON_PROPERTIES,
 } from "../../common";
 import { Polygon } from "geojson";
 
@@ -258,7 +259,10 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 						type: "Point",
 						coordinates: [event.lng, event.lat],
 					},
-					properties: { mode: this.mode },
+					properties: {
+						mode: this.mode,
+						[POLYGON_PROPERTIES.CLOSING_POINT]: true,
+					},
 				},
 			]);
 


### PR DESCRIPTION
## Description of Changes

Adds the `closingPoint` property to freehand mode closing points to easily identify them as closing points

## Link to Issue

#365 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 