### PR TITLE
feat: allow freehand features to be automatically closed with the autoClose option

### DIFF
--- a/development/src/config.ts
+++ b/development/src/config.ts
@@ -12,11 +12,11 @@ export const Config = {
 	// and the development page will respond accordingly. This is useful if you just want to
 	// test one map at a time, or you're on a low powered machine.
 	libraries: [
-		Libraries.Leaflet,
+		// Libraries.Leaflet,
 		Libraries.MapLibre,
-		Libraries.Mapbox,
-		Libraries.Google,
-		Libraries.OpenLayers,
-		Libraries.ArcGIS,
+		// Libraries.Mapbox,
+		// Libraries.Google,
+		// Libraries.OpenLayers,
+		// Libraries.ArcGIS,
 	] as const,
 };

--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -189,7 +189,11 @@ const getModes = () => {
 		}),
 		new TerraDrawRectangleMode(),
 		new TerraDrawCircleMode(),
-		new TerraDrawFreehandMode(),
+		new TerraDrawFreehandMode({
+			autoClose: true,
+			minDistance: 10,
+			pointerDistance: 10,
+		}),
 		new TerraDrawRenderMode({
 			modeName: "arbitrary",
 			styles: {


### PR DESCRIPTION
## Description of Changes

Adds autoclose feature to Freehand mode, allowing polygons to closed without clicking. This can be enabled with `autoClose: true` being provided to the mode. There is some basic protection against creating a new polygon if the user clicks by accident on the closing point. This is controllable via the `autoCloseTimeout` option property.

## Link to Issue

#367 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 