### PR TITLE
fix: export TerraDrawCallbacks for adapters

### DIFF
--- a/src/extend.ts
+++ b/src/extend.ts
@@ -2,7 +2,7 @@ import {
 	TerraDrawBaseAdapter,
 	BaseAdapterConfig,
 } from "./adapters/common/base.adapter";
-import { HexColorStyling, NumericStyling } from "./common";
+import { HexColorStyling, NumericStyling, TerraDrawCallbacks } from "./common";
 import { BaseModeOptions, TerraDrawBaseDrawMode } from "./modes/base.mode";
 
 // This object allows 3rd party developers to
@@ -15,4 +15,5 @@ export {
 	NumericStyling,
 	HexColorStyling,
 	BaseModeOptions,
+	TerraDrawCallbacks,
 };

--- a/src/terra-draw.extensions.spec.ts
+++ b/src/terra-draw.extensions.spec.ts
@@ -160,6 +160,10 @@ class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 	public render(_1: TerraDrawChanges, _2: TerraDrawStylingFunction): void {
 		// pass
 	}
+
+	public register(_: TerraDrawExtend.TerraDrawCallbacks): void {
+		// pass
+	}
 }
 
 /**


### PR DESCRIPTION
## Description of Changes

Exposes the TerraDrawCallback type so you can use it when calling `register`

## Link to Issue

#342 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 