### PR TITLE
feat: no longer throw error on validation failures in addFeatures and return validation status

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -150,10 +150,17 @@ const getModes = () => {
 					feature: {
 						validation: (feature) => {
 							if (feature.geometry.type !== "Polygon") {
-								return false;
+								return {
+									valid: false,
+									reason: "Feature is not a valid Polygon feature",
+								};
 							}
 
-							return ValidateMinAreaSquareMeters(feature, 1000);
+							const result = ValidateMinAreaSquareMeters(feature, 1000);
+							return {
+								valid: result,
+								reason: result ? undefined : "Area too small",
+							};
 						},
 						draggable: true,
 						coordinates: {
@@ -182,9 +189,13 @@ const getModes = () => {
 			snapping: true,
 			validation: (feature, { updateType }) => {
 				if (updateType === "finish" || updateType === "commit") {
-					return ValidateNotSelfIntersecting(feature);
+					const valid = ValidateNotSelfIntersecting(feature);
+					return {
+						valid,
+						reason: valid ? undefined : "Polygon must not self-intersect",
+					};
 				}
-				return true;
+				return { valid: true };
 			},
 		}),
 		new TerraDrawRectangleMode(),

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -71,12 +71,16 @@ const example = {
 									this.config?.includes("validationSuccess") ||
 									this.config?.includes("validationFailure")
 										? (feature) => {
-												return ValidateMaxAreaSquareMeters(
+												const result = ValidateMaxAreaSquareMeters(
 													feature,
 													this.config?.includes("validationFailure")
 														? 1000000
 														: 2000000,
 												);
+												return {
+													valid: result,
+													reason: result ? undefined : "Area too large",
+												};
 										  }
 										: undefined,
 								draggable: true,
@@ -151,12 +155,16 @@ const example = {
 						this.config?.includes("validationSuccess") ||
 						this.config?.includes("validationFailure")
 							? (feature) => {
-									return ValidateMaxAreaSquareMeters(
+									const result = ValidateMaxAreaSquareMeters(
 										feature,
 										this.config?.includes("validationFailure")
 											? 1000000
 											: 2000000,
 									);
+									return {
+										valid: result,
+										reason: "Area too large",
+									};
 							  }
 							: undefined,
 				}),

--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -63,7 +63,7 @@ Features can also be added to the Store programmatically using the `addFeatures`
 
 ```javascript
 // Add a Point to the Store
-draw.addFeatures([
+const result = draw.addFeatures([
   {
     type: "Feature",
     geometry: {
@@ -75,6 +75,21 @@ draw.addFeatures([
     },
   },
 ]);
+
+console.log(result)
+
+// Will log:
+// [{
+//  id: 'aa5c8826-cbf1-4489-9b31-987c871866af',
+//  valid: true,
+// }]
+```
+
+`addFeatures` returns an array of objects providing information about the added features such as the id and the feature was valid. Only valid features are added to the store. This allows developers to handle failure cases how they see fit:
+
+```typescript
+const invalidFeatures = result.filter(({ valid }) => !valid);
+// Do something with the information
 ```
 
 If you want to get an ID for a feature and create that outside Terra Draw to do something with it later, you can use the `getFeatureId` method on the Terra Draw instance, like so:

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -370,7 +370,7 @@ It is possible to select and deselect a feature via the draw instance, which use
   draw.start();
 
   // Add feature programmatically
-  draw.addFeatures([
+  const result = draw.addFeatures([
     {
       id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
       type: "Feature",
@@ -383,6 +383,11 @@ It is possible to select and deselect a feature via the draw instance, which use
       },
     },
   ]);
+
+  // Log out if the feature passed validation or not
+  if (!result[0].valid) {
+    throw new Error(result.reason ? result.reason : 'Feature f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8 was invalid')
+  }
 
   // Select a given feature
   draw.selectFeature("f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8");

--- a/src/common.ts
+++ b/src/common.ts
@@ -103,7 +103,10 @@ type ValidationContext = Pick<
 export type Validation = (
 	feature: GeoJSONStoreFeatures,
 	context: ValidationContext,
-) => boolean;
+) => {
+	valid: boolean;
+	reason?: string;
+};
 
 export type TerraDrawModeState =
 	| "unregistered"

--- a/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
+++ b/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
@@ -119,7 +119,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 			store = new GeoJSONStore();
 			angledRectangleMode = new TerraDrawAngledRectangleMode({
 				validation: () => {
-					return true;
+					return { valid: true };
 				},
 			});
 			const mockConfig = MockModeConfig(angledRectangleMode.mode);
@@ -190,7 +190,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 		describe("with successful validation", () => {
 			beforeEach(() => {
 				angledRectangleMode = new TerraDrawAngledRectangleMode({
-					validation: () => true,
+					validation: () => ({ valid: true }),
 				});
 				const mockConfig = MockModeConfig(angledRectangleMode.mode);
 
@@ -224,7 +224,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 		describe("with unsuccessful validation", () => {
 			beforeEach(() => {
 				angledRectangleMode = new TerraDrawAngledRectangleMode({
-					validation: () => false,
+					validation: () => ({ valid: false, reason: "Test" }),
 				});
 				const mockConfig = MockModeConfig(angledRectangleMode.mode);
 
@@ -380,7 +380,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 	describe("validateFeature", () => {
 		it("returns true for valid rectangle feature with validation that returns true", () => {
 			const rectangleMode = new TerraDrawAngledRectangleMode({
-				validation: () => true,
+				validation: () => ({ valid: true }),
 			});
 			rectangleMode.register(MockModeConfig("angled-rectangle"));
 
@@ -405,14 +405,14 @@ describe("TerraDrawAngledRectangleMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid rectangle feature but with validation that returns false", () => {
 			const rectangleMode = new TerraDrawAngledRectangleMode({
-				validation: () => {
-					return false;
-				},
+				validation: () => ({ valid: false, reason: "Test" }),
 			});
 			rectangleMode.register(MockModeConfig("angled-rectangle"));
 
@@ -437,7 +437,10 @@ describe("TerraDrawAngledRectangleMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				reason: "Test",
+				valid: false,
+			});
 		});
 	});
 

--- a/src/modes/circle/circle.mode.spec.ts
+++ b/src/modes/circle/circle.mode.spec.ts
@@ -219,7 +219,7 @@ describe("TerraDrawCircleMode", () => {
 
 				beforeEach(() => {
 					circleMode = new TerraDrawCircleMode({
-						validation: () => valid,
+						validation: () => ({ valid }),
 					});
 					const mockConfig = MockModeConfig(circleMode.mode);
 
@@ -570,7 +570,10 @@ describe("TerraDrawCircleMode", () => {
 						updatedAt: 1685568435434,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				reason: "Feature is not a valid simple Polygon feature",
+				valid: false,
+			});
 		});
 
 		it("returns true for valid circle feature", () => {
@@ -666,13 +669,15 @@ describe("TerraDrawCircleMode", () => {
 						updatedAt: 1685568435434,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid circle feature but with validation that returns false", () => {
 			const circleMode = new TerraDrawCircleMode({
 				validation: () => {
-					return false;
+					return { valid: false };
 				},
 				styles: {
 					fillColor: "#ffffff",
@@ -765,7 +770,9 @@ describe("TerraDrawCircleMode", () => {
 						updatedAt: 1685568435434,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+			});
 		});
 	});
 });

--- a/src/modes/freehand/freehand.mode.spec.ts
+++ b/src/modes/freehand/freehand.mode.spec.ts
@@ -175,7 +175,7 @@ describe("TerraDrawFreehandMode", () => {
 			beforeEach(() => {
 				freehandMode = new TerraDrawFreehandMode({
 					validation: () => {
-						return valid;
+						return { valid };
 					},
 				});
 				store = new GeoJSONStore();
@@ -738,7 +738,10 @@ describe("TerraDrawFreehandMode", () => {
 						updatedAt: 1685568435434,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+				reason: "Feature mode property does not match the mode being added to",
+			});
 		});
 
 		it("returns true for valid freehand feature", () => {
@@ -781,13 +784,15 @@ describe("TerraDrawFreehandMode", () => {
 						updatedAt: 1685569593386,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid freehand feature but the validate function returns false", () => {
 			const freehandMode = new TerraDrawFreehandMode({
 				validation: () => {
-					return false;
+					return { valid: false };
 				},
 				styles: {
 					closingPointColor: "#ffffff",
@@ -827,7 +832,9 @@ describe("TerraDrawFreehandMode", () => {
 						updatedAt: 1685569593386,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+			});
 		});
 	});
 });

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -16,7 +16,11 @@ import {
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { getDefaultStyling } from "../../util/styling";
-import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
+import {
+	FeatureId,
+	GeoJSONStoreFeatures,
+	StoreValidation,
+} from "../../store/store";
 import { cartesianDistance } from "../../geometry/measure/pixel-distance";
 import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 
@@ -133,7 +137,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				},
 			);
 
-			if (!valid) {
+			if (!valid.valid) {
 				return;
 			}
 		}
@@ -254,7 +258,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				},
 			);
 
-			if (!valid) {
+			if (!valid.valid) {
 				return;
 			}
 		}
@@ -428,14 +432,12 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 		return styles;
 	}
 
-	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
-		if (super.validateFeature(feature)) {
-			return (
-				feature.properties.mode === this.mode &&
-				ValidatePolygonFeature(feature, this.coordinatePrecision)
-			);
-		} else {
-			return false;
-		}
+	validateFeature(feature: unknown): StoreValidation {
+		return this.validateModeFeature(
+			feature,
+			(baseValidatedFeature) =>
+				ValidatePolygonFeature(baseValidatedFeature, this.coordinatePrecision),
+			"Feature is not a valid Polygon feature",
+		);
 	}
 }

--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -311,9 +311,9 @@ describe("TerraDrawLineStringMode", () => {
 				lineStringMode = new TerraDrawLineStringMode({
 					validation: (feature, { updateType }) => {
 						if (updateType === "finish" || updateType === "commit") {
-							return ValidateNotSelfIntersecting(feature);
+							return { valid: ValidateNotSelfIntersecting(feature) };
 						}
-						return true;
+						return { valid: true };
 					},
 				});
 
@@ -385,9 +385,9 @@ describe("TerraDrawLineStringMode", () => {
 				lineStringMode = new TerraDrawLineStringMode({
 					validation: (feature, { updateType }) => {
 						if (updateType === "finish" || updateType === "commit") {
-							return ValidateNotSelfIntersecting(feature);
+							return { valid: ValidateNotSelfIntersecting(feature) };
 						}
-						return true;
+						return { valid: true };
 					},
 				});
 
@@ -827,7 +827,10 @@ describe("TerraDrawLineStringMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				reason: "Feature is not a valid LineString feature",
+				valid: false,
+			});
 		});
 
 		it("returns true for valid linestring feature", () => {
@@ -855,13 +858,15 @@ describe("TerraDrawLineStringMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid linestring feature with validate function that returns false", () => {
 			const lineStringMode = new TerraDrawLineStringMode({
 				validation: () => {
-					return false;
+					return { valid: false };
 				},
 				styles: {
 					lineStringColor: "#ffffff",
@@ -886,7 +891,9 @@ describe("TerraDrawLineStringMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+			});
 		});
 	});
 });

--- a/src/modes/point/point.mode.spec.ts
+++ b/src/modes/point/point.mode.spec.ts
@@ -120,7 +120,7 @@ describe("TerraDrawPointMode", () => {
 			it("does not create the point if validation returns false", () => {
 				const pointMode = new TerraDrawPointMode({
 					validation: (feature) => {
-						return (feature.geometry as Point).coordinates[0] > 45;
+						return { valid: (feature.geometry as Point).coordinates[0] > 45 };
 					},
 				});
 
@@ -140,7 +140,7 @@ describe("TerraDrawPointMode", () => {
 			it("does create the point if validation returns true", () => {
 				const pointMode = new TerraDrawPointMode({
 					validation: (feature) => {
-						return (feature.geometry as Point).coordinates[0] > 45;
+						return { valid: (feature.geometry as Point).coordinates[0] > 45 };
 					},
 				});
 
@@ -325,7 +325,10 @@ describe("TerraDrawPointMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				reason: "Feature mode property does not match the mode being added to",
+				valid: false,
+			});
 		});
 
 		it("returns true for valid point feature", () => {
@@ -351,12 +354,14 @@ describe("TerraDrawPointMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid point feature but validate function returns false", () => {
 			const pointMode = new TerraDrawPointMode({
-				validation: () => false,
+				validation: () => ({ valid: false }),
 				styles: {
 					pointColor: "#ffffff",
 				},
@@ -378,7 +383,9 @@ describe("TerraDrawPointMode", () => {
 						updatedAt: 1685654950609,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+			});
 		});
 	});
 });

--- a/src/modes/point/point.mode.ts
+++ b/src/modes/point/point.mode.ts
@@ -6,11 +6,12 @@ import {
 	Cursor,
 	UpdateTypes,
 } from "../../common";
-import { GeoJSONStoreFeatures } from "../../store/store";
+import { GeoJSONStoreFeatures, StoreValidation } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeMismatchValidationFailure,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidatePointFeature } from "../../validations/point.validation";
@@ -91,7 +92,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 				},
 			);
 
-			if (!valid) {
+			if (!valid.valid) {
 				return;
 			}
 		}
@@ -162,14 +163,12 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		return styles;
 	}
 
-	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
-		if (super.validateFeature(feature)) {
-			return (
-				feature.properties.mode === this.mode &&
-				ValidatePointFeature(feature, this.coordinatePrecision)
-			);
-		} else {
-			return false;
-		}
+	validateFeature(feature: unknown): StoreValidation {
+		return this.validateModeFeature(
+			feature,
+			(baseValidatedFeature) =>
+				ValidatePointFeature(baseValidatedFeature, this.coordinatePrecision),
+			"Feature is not a valid Point feature",
+		);
 	}
 }

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -229,9 +229,13 @@ describe("TerraDrawPolygonMode", () => {
 
 		const validation: Validation = (feature, { updateType }) => {
 			if (updateType === "finish" || updateType === "commit") {
-				return ValidateNotSelfIntersecting(feature);
+				const validation = ValidateNotSelfIntersecting(feature);
+				return {
+					valid: validation,
+					reason: validation ? undefined : "Self intersecting",
+				};
 			}
-			return true;
+			return { valid: true };
 		};
 
 		beforeEach(() => {
@@ -540,9 +544,13 @@ describe("TerraDrawPolygonMode", () => {
 				polygonMode = new TerraDrawPolygonMode({
 					validation: (feature, { updateType }) => {
 						if (updateType === "finish" || updateType === "commit") {
-							return ValidateNotSelfIntersecting(feature);
+							const validation = ValidateNotSelfIntersecting(feature);
+							return {
+								valid: validation,
+								reason: validation ? undefined : "Self intersecting",
+							};
 						}
-						return true;
+						return { valid: true };
 					},
 				});
 				const mockConfig = MockModeConfig(polygonMode.mode);
@@ -914,7 +922,10 @@ describe("validateFeature", () => {
 					updatedAt: 1685568435434,
 				},
 			}),
-		).toBe(false);
+		).toEqual({
+			valid: false,
+			reason: "Feature mode property does not match the mode being added to",
+		});
 	});
 
 	it("returns true for valid polygon feature", () => {
@@ -950,12 +961,15 @@ describe("validateFeature", () => {
 					updatedAt: 1685655518118,
 				},
 			}),
-		).toBe(true);
+		).toEqual({
+			reason: undefined,
+			valid: true,
+		});
 	});
 
 	it("returns false for valid polygon feature but validate function returns false", () => {
 		const polygonMode = new TerraDrawPolygonMode({
-			validation: () => false,
+			validation: () => ({ valid: false }),
 		});
 		polygonMode.register(MockModeConfig("polygon"));
 
@@ -981,6 +995,9 @@ describe("validateFeature", () => {
 					updatedAt: 1685655518118,
 				},
 			}),
-		).toBe(false);
+		).toEqual({
+			reason: undefined,
+			valid: false,
+		});
 	});
 });

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -12,6 +12,7 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
+	ModeMismatchValidationFailure,
 } from "../base.mode";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
@@ -21,7 +22,11 @@ import { SnappingBehavior } from "../snapping.behavior";
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { ClosingPointsBehavior } from "./behaviors/closing-points.behavior";
 import { getDefaultStyling } from "../../util/styling";
-import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
+import {
+	FeatureId,
+	GeoJSONStoreFeatures,
+	StoreValidation,
+} from "../../store/store";
 import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 
 type TerraDrawPolygonModeKeyEvents = {
@@ -255,7 +260,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				},
 			);
 
-			if (!valid) {
+			if (!valid.valid) {
 				return false;
 			}
 		}
@@ -561,14 +566,12 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		return styles;
 	}
 
-	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
-		if (super.validateFeature(feature)) {
-			return (
-				feature.properties.mode === this.mode &&
-				ValidatePolygonFeature(feature, this.coordinatePrecision)
-			);
-		} else {
-			return false;
-		}
+	validateFeature(feature: unknown): StoreValidation {
+		return this.validateModeFeature(
+			feature,
+			(baseValidatedFeature) =>
+				ValidatePolygonFeature(baseValidatedFeature, this.coordinatePrecision),
+			"Feature is not a valid Polygon feature",
+		);
 	}
 }

--- a/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/src/modes/rectangle/rectangle.mode.spec.ts
@@ -447,7 +447,10 @@ describe("TerraDrawRectangleMode", () => {
 						updatedAt: 1685568435434,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				reason: "Feature mode property does not match the mode being added to",
+				valid: false,
+			});
 		});
 
 		it("returns false for self intersecting polygon feature", () => {
@@ -482,13 +485,16 @@ describe("TerraDrawRectangleMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+				reason: "Feature is not a valid simple Polygon feature",
+			});
 		});
 
 		it("returns true for valid rectangle feature with validation that returns true", () => {
 			const rectangleMode = new TerraDrawRectangleMode({
 				validation: () => {
-					return true;
+					return { valid: true };
 				},
 			});
 			rectangleMode.register(MockModeConfig("rectangle"));
@@ -514,13 +520,15 @@ describe("TerraDrawRectangleMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid rectangle feature but with validation that returns false", () => {
 			const rectangleMode = new TerraDrawRectangleMode({
 				validation: () => {
-					return false;
+					return { valid: false };
 				},
 			});
 			rectangleMode.register(MockModeConfig("rectangle"));
@@ -546,7 +554,9 @@ describe("TerraDrawRectangleMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+			});
 		});
 	});
 });

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -8,11 +8,16 @@ import {
 	Cursor,
 	UpdateTypes,
 } from "../../common";
-import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
+import {
+	FeatureId,
+	GeoJSONStoreFeatures,
+	StoreValidation,
+} from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeMismatchValidationFailure,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
@@ -108,7 +113,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 					},
 				);
 
-				if (!valid) {
+				if (!valid.valid) {
 					return;
 				}
 			}
@@ -266,14 +271,15 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 		return styles;
 	}
 
-	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
-		if (super.validateFeature(feature)) {
-			return (
-				feature.properties.mode === this.mode &&
-				ValidateNonIntersectingPolygonFeature(feature, this.coordinatePrecision)
-			);
-		} else {
-			return false;
-		}
+	validateFeature(feature: unknown): StoreValidation {
+		return this.validateModeFeature(
+			feature,
+			(baseValidatedFeature) =>
+				ValidateNonIntersectingPolygonFeature(
+					baseValidatedFeature,
+					this.coordinatePrecision,
+				),
+			"Feature is not a valid simple Polygon feature",
+		);
 	}
 }

--- a/src/modes/render/render.mode.spec.ts
+++ b/src/modes/render/render.mode.spec.ts
@@ -240,21 +240,25 @@ describe("TerraDrawRenderMode", () => {
 			const renderMode = new TerraDrawRenderMode(options);
 			renderMode.register(MockModeConfig("arbitary"));
 
-			expect(renderMode.validateFeature(MockPoint())).toBe(true);
+			expect(renderMode.validateFeature(MockPoint())).toEqual({ valid: true });
 		});
 
 		it("validates linestrings", () => {
 			const renderMode = new TerraDrawRenderMode(options);
 			renderMode.register(MockModeConfig("arbitary"));
 
-			expect(renderMode.validateFeature(MockLineString())).toBe(true);
+			expect(renderMode.validateFeature(MockLineString())).toEqual({
+				valid: true,
+			});
 		});
 
 		it("validates polygons", () => {
 			const renderMode = new TerraDrawRenderMode(options);
 			renderMode.register(MockModeConfig("arbitary"));
 
-			expect(renderMode.validateFeature(MockPolygonSquare())).toBe(true);
+			expect(renderMode.validateFeature(MockPolygonSquare())).toEqual({
+				valid: true,
+			});
 		});
 	});
 });

--- a/src/modes/render/render.mode.ts
+++ b/src/modes/render/render.mode.ts
@@ -15,6 +15,7 @@ import { GeoJSONStoreFeatures } from "../../terra-draw";
 import { ValidatePointFeature } from "../../validations/point.validation";
 import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 import { ValidateLineStringFeature } from "../../validations/linestring.validation";
+import { StoreValidation } from "../../store/store";
 
 type RenderModeStyling = {
 	pointColor: HexColorStyling;
@@ -152,12 +153,24 @@ export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling
 		};
 	}
 
-	validateFeature(feature: unknown): feature is GeoJSONStoreFeatures {
-		return (
-			super.validateFeature(feature) &&
-			(ValidatePointFeature(feature, this.coordinatePrecision) ||
-				ValidatePolygonFeature(feature, this.coordinatePrecision) ||
-				ValidateLineStringFeature(feature, this.coordinatePrecision))
-		);
+	validateFeature(feature: unknown): StoreValidation {
+		const validationResult = super.validateFeature(feature);
+		if (validationResult.valid) {
+			const validatedFeature = feature as GeoJSONStoreFeatures;
+
+			const featureValidation =
+				ValidatePointFeature(validatedFeature, this.coordinatePrecision) ||
+				ValidatePolygonFeature(validatedFeature, this.coordinatePrecision) ||
+				ValidateLineStringFeature(validatedFeature, this.coordinatePrecision);
+
+			return {
+				valid: featureValidation,
+				reason: featureValidation
+					? undefined
+					: "Feature is not a valid Point, Polygon or LineString feature",
+			};
+		}
+
+		return validationResult;
 	}
 }

--- a/src/modes/sector/sector.mode.spec.ts
+++ b/src/modes/sector/sector.mode.spec.ts
@@ -121,7 +121,7 @@ describe("TerraDrawSectorMode", () => {
 			store = new GeoJSONStore();
 			sectorMode = new TerraDrawSectorMode({
 				validation: () => {
-					return true;
+					return { valid: true };
 				},
 			});
 			const mockConfig = MockModeConfig(sectorMode.mode);
@@ -205,7 +205,9 @@ describe("TerraDrawSectorMode", () => {
 		describe("with successful validation", () => {
 			beforeEach(() => {
 				sectorMode = new TerraDrawSectorMode({
-					validation: () => true,
+					validation: () => {
+						return { valid: true };
+					},
 				});
 				const mockConfig = MockModeConfig(sectorMode.mode);
 
@@ -239,7 +241,9 @@ describe("TerraDrawSectorMode", () => {
 		describe("with unsuccessful validation", () => {
 			beforeEach(() => {
 				sectorMode = new TerraDrawSectorMode({
-					validation: () => false,
+					validation: () => {
+						return { valid: false };
+					},
 				});
 				const mockConfig = MockModeConfig(sectorMode.mode);
 
@@ -379,53 +383,8 @@ describe("TerraDrawSectorMode", () => {
 	describe("validateFeature", () => {
 		it("returns true for valid sector feature with validation that returns true", () => {
 			const sectorMode = new TerraDrawSectorMode({
-				validation: () => true,
-			});
-			sectorMode.register(MockModeConfig("sector"));
-
-			expect(
-				sectorMode.validateFeature({
-					id: "5c582a42-c3a7-4bfc-b686-6036f311df3c",
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[-0.096802636, 51.500464739],
-								[-0.109590068, 51.510206381],
-								[-0.109590068, 51.510206381],
-								[-0.11416909, 51.50689961],
-								[-0.116656509, 51.502817579],
-								[-0.116752741, 51.498451789],
-								[-0.114446197, 51.494328048],
-								[-0.110014675, 51.490943142],
-								[-0.103991904, 51.48870495],
-								[-0.097103263, 51.487883219],
-								[-0.090178415, 51.488576994],
-								[-0.084051383, 51.490702652],
-								[-0.079460103, 51.494004006],
-								[-0.076957545, 51.498083239],
-								[-0.076845116, 51.502448914],
-								[-0.079136357, 51.506575225],
-								[-0.083555311, 51.509965331],
-								[-0.089569764, 51.512211129],
-								[-0.096455339, 51.513042321],
-								[-0.096802636, 51.500464739],
-							],
-						],
-					},
-					properties: {
-						mode: "sector",
-						createdAt: 1685655516297,
-						updatedAt: 1685655518118,
-					},
-				}),
-			).toBe(true);
-		});
-
-		it("returns false for valid sector feature but with validation that returns false", () => {
-			const sectorMode = new TerraDrawSectorMode({
 				validation: () => {
-					return false;
+					return { valid: true };
 				},
 			});
 			sectorMode.register(MockModeConfig("sector"));
@@ -466,7 +425,58 @@ describe("TerraDrawSectorMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: true,
+			});
+		});
+
+		it("returns false for valid sector feature but with validation that returns false", () => {
+			const sectorMode = new TerraDrawSectorMode({
+				validation: () => {
+					return { valid: true };
+				},
+			});
+			sectorMode.register(MockModeConfig("sector"));
+
+			expect(
+				sectorMode.validateFeature({
+					id: "5c582a42-c3a7-4bfc-b686-6036f311df3c",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[-0.096802636, 51.500464739],
+								[-0.109590068, 51.510206381],
+								[-0.109590068, 51.510206381],
+								[-0.11416909, 51.50689961],
+								[-0.116656509, 51.502817579],
+								[-0.116752741, 51.498451789],
+								[-0.114446197, 51.494328048],
+								[-0.110014675, 51.490943142],
+								[-0.103991904, 51.48870495],
+								[-0.097103263, 51.487883219],
+								[-0.090178415, 51.488576994],
+								[-0.084051383, 51.490702652],
+								[-0.079460103, 51.494004006],
+								[-0.076957545, 51.498083239],
+								[-0.076845116, 51.502448914],
+								[-0.079136357, 51.506575225],
+								[-0.083555311, 51.509965331],
+								[-0.089569764, 51.512211129],
+								[-0.096455339, 51.513042321],
+								[-0.096802636, 51.500464739],
+							],
+						],
+					},
+					properties: {
+						mode: "sector",
+						createdAt: 1685655516297,
+						updatedAt: 1685655518118,
+					},
+				}),
+			).toEqual({
+				valid: true,
+			});
 		});
 	});
 

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -150,7 +150,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						MockCursorEvent({ lng: 0, lat: 0 }),
 						"center",
 						() => {
-							return false;
+							return { valid: false };
 						},
 					);
 

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -732,7 +732,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 					updateType: UpdateTypes.Provisional,
 				},
 			);
-			if (!valid) {
+			if (!valid.valid) {
 				return false;
 			}
 		}

--- a/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -144,13 +144,13 @@ describe("DragCoordinateBehavior", () => {
 				dragCoordinateBehavior.drag(
 					MockCursorEvent({ lng: 0, lat: 0 }),
 					true,
-					() => false,
+					() => ({ valid: false }),
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
 
-			it("validation returning false means updates are not called", () => {
+			it("validation returning true means updates are called", () => {
 				const id = createStorePolygon(config);
 
 				dragCoordinateBehavior.startDragging(id, 0);
@@ -160,7 +160,7 @@ describe("DragCoordinateBehavior", () => {
 				dragCoordinateBehavior.drag(
 					MockCursorEvent({ lng: 0, lat: 0 }),
 					true,
-					() => true,
+					() => ({ valid: true }),
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);

--- a/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -170,7 +170,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 				},
 			);
 
-			if (!valid) {
+			if (!valid.valid) {
 				return false;
 			}
 		}

--- a/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -140,10 +140,9 @@ describe("DragFeatureBehavior", () => {
 				jest.spyOn(config.store, "updateGeometry");
 				jest.spyOn(config.store, "getGeometryCopy");
 
-				dragFeatureBehavior.drag(
-					MockCursorEvent({ lng: 0, lat: 0 }),
-					() => false,
-				);
+				dragFeatureBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), () => ({
+					valid: false,
+				}));
 
 				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -158,10 +157,9 @@ describe("DragFeatureBehavior", () => {
 				jest.spyOn(config.store, "updateGeometry");
 				jest.spyOn(config.store, "getGeometryCopy");
 
-				dragFeatureBehavior.drag(
-					MockCursorEvent({ lng: 0, lat: 0 }),
-					() => true,
-				);
+				dragFeatureBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), () => ({
+					valid: true,
+				}));
 
 				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);

--- a/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -174,7 +174,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 					},
 				);
 
-				if (!valid) {
+				if (!valid.valid) {
 					return false;
 				}
 			}

--- a/src/modes/select/select.mode.ts
+++ b/src/modes/select/select.mode.ts
@@ -180,9 +180,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			for (const mode in options.flags) {
 				const feature = options.flags[mode].feature;
 				if (feature && feature.validation) {
-					this.validations[mode] = feature.validation as (
-						feature: GeoJSONStoreFeatures,
-					) => boolean;
+					this.validations[mode] = feature.validation;
 				}
 			}
 		}
@@ -383,7 +381,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					updateType: UpdateTypes.Commit,
 				},
 			);
-			if (!valid) {
+			if (!valid.valid) {
 				return;
 			}
 		}

--- a/src/modes/sensor/sensor.mode.spec.ts
+++ b/src/modes/sensor/sensor.mode.spec.ts
@@ -120,7 +120,7 @@ describe("TerraDrawSensorMode", () => {
 			store = new GeoJSONStore();
 			sensorMode = new TerraDrawSensorMode({
 				validation: () => {
-					return true;
+					return { valid: true };
 				},
 			});
 			const mockConfig = MockModeConfig(sensorMode.mode);
@@ -181,7 +181,7 @@ describe("TerraDrawSensorMode", () => {
 		describe("with successful validation", () => {
 			beforeEach(() => {
 				sensorMode = new TerraDrawSensorMode({
-					validation: () => true,
+					validation: () => ({ valid: true }),
 				});
 				const mockConfig = MockModeConfig(sensorMode.mode);
 
@@ -257,7 +257,7 @@ describe("TerraDrawSensorMode", () => {
 		describe("with non successful validation", () => {
 			beforeEach(() => {
 				sensorMode = new TerraDrawSensorMode({
-					validation: () => false,
+					validation: () => ({ valid: false }),
 				});
 				const mockConfig = MockModeConfig(sensorMode.mode);
 
@@ -398,7 +398,7 @@ describe("TerraDrawSensorMode", () => {
 	describe("validateFeature", () => {
 		it("returns true for valid rectangle feature with validation that returns true", () => {
 			const sensorMode = new TerraDrawSensorMode({
-				validation: () => true,
+				validation: () => ({ valid: true }),
 			});
 			sensorMode.register(MockModeConfig("sensor"));
 
@@ -438,13 +438,15 @@ describe("TerraDrawSensorMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(true);
+			).toEqual({
+				valid: true,
+			});
 		});
 
 		it("returns false for valid rectangle feature but with validation that returns false", () => {
 			const sensorMode = new TerraDrawSensorMode({
 				validation: () => {
-					return false;
+					return { valid: false, reason: "Test" };
 				},
 			});
 			sensorMode.register(MockModeConfig("sensor"));
@@ -485,7 +487,10 @@ describe("TerraDrawSensorMode", () => {
 						updatedAt: 1685655518118,
 					},
 				}),
-			).toBe(false);
+			).toEqual({
+				valid: false,
+				reason: "Test",
+			});
 		});
 	});
 

--- a/src/store/store-feature-validation.ts
+++ b/src/store/store-feature-validation.ts
@@ -25,6 +25,19 @@ function isObject(
 	);
 }
 
+export function hasModeProperty(
+	feature: unknown,
+): feature is { properties: { mode: string } } {
+	return Boolean(
+		feature &&
+			typeof feature === "object" &&
+			"properties" in feature &&
+			typeof feature.properties === "object" &&
+			feature.properties !== null &&
+			"mode" in feature.properties,
+	);
+}
+
 function dateIsValid(timestamp: unknown): boolean {
 	return (
 		typeof timestamp === "number" &&
@@ -34,7 +47,7 @@ function dateIsValid(timestamp: unknown): boolean {
 
 export function isValidTimestamp(timestamp: unknown): boolean {
 	if (!dateIsValid(timestamp)) {
-		throw new Error(StoreValidationErrors.InvalidTrackedProperties);
+		return false;
 	}
 
 	return true;
@@ -43,7 +56,10 @@ export function isValidTimestamp(timestamp: unknown): boolean {
 export function isValidStoreFeature(
 	feature: unknown,
 	isValidId: IdStrategy<FeatureId>["isValidId"],
-): feature is GeoJSONStoreFeatures {
+): {
+	valid: boolean;
+	reason?: string;
+} {
 	let error;
 	if (!isObject(feature)) {
 		error = StoreValidationErrors.FeatureIsNotObject;
@@ -68,12 +84,12 @@ export function isValidStoreFeature(
 		!feature.properties.mode ||
 		typeof feature.properties.mode !== "string"
 	) {
-		throw new Error(StoreValidationErrors.InvalidModeProperty);
+		return { valid: false, reason: StoreValidationErrors.InvalidModeProperty };
 	}
 
 	if (error) {
-		throw new Error(error);
+		return { valid: false, reason: error };
 	}
 
-	return true;
+	return { valid: true };
 }

--- a/src/store/store-validation.spec.ts
+++ b/src/store/store-validation.spec.ts
@@ -8,59 +8,71 @@ import {
 describe("isValidStoreFeature", () => {
 	const isValidId = defaultIdStrategy.isValidId;
 
-	it("throws on data with non object feature", () => {
-		expect(() => isValidStoreFeature(undefined, isValidId)).toThrow(
-			StoreValidationErrors.FeatureIsNotObject,
-		);
-		expect(() => isValidStoreFeature(null, isValidId)).toThrow(
-			StoreValidationErrors.FeatureIsNotObject,
-		);
+	it("returns valid false with reason on data with non object feature", () => {
+		expect(isValidStoreFeature(undefined, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureIsNotObject,
+			valid: false,
+		});
+		expect(isValidStoreFeature(null, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureIsNotObject,
+			valid: false,
+		});
 	});
 
-	it("throws on data with no id", () => {
-		expect(() => isValidStoreFeature({ id: undefined }, isValidId)).toThrow(
-			StoreValidationErrors.FeatureHasNoId,
-		);
-		expect(() => isValidStoreFeature({ id: null }, isValidId)).toThrow(
-			StoreValidationErrors.FeatureHasNoId,
-		);
+	it("returns valid false with reason on data with no id", () => {
+		expect(isValidStoreFeature({ id: undefined }, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureHasNoId,
+			valid: false,
+		});
+		expect(isValidStoreFeature({ id: null }, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureHasNoId,
+			valid: false,
+		});
 	});
 
-	it("throws on data with non string id", () => {
-		expect(() => isValidStoreFeature({ id: 1 }, isValidId)).toThrow(
-			StoreValidationErrors.FeatureIdIsNotValid,
-		);
+	it("returns valid false with reason on data with non string id", () => {
+		expect(isValidStoreFeature({ id: 1 }, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureIdIsNotValid,
+			valid: false,
+		});
 	});
 
-	it("throws on data with non uuid4 id", () => {
-		expect(() => isValidStoreFeature({ id: "1" }, isValidId)).toThrow(
-			StoreValidationErrors.FeatureIdIsNotValid,
-		);
+	it("returns valid false with reason on data with non uuid4 id", () => {
+		expect(isValidStoreFeature({ id: "1" }, isValidId)).toEqual({
+			reason: StoreValidationErrors.FeatureIdIsNotValid,
+			valid: false,
+		});
 	});
 
-	it("throws on data with no geometry", () => {
-		expect(() =>
+	it("returns valid false with reason on data with no geometry", () => {
+		expect(
 			isValidStoreFeature(
 				{ id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284" },
 				isValidId,
 			),
-		).toThrow(StoreValidationErrors.FeatureHasNoGeometry);
+		).toEqual({
+			reason: StoreValidationErrors.FeatureHasNoGeometry,
+			valid: false,
+		});
 	});
 
-	it("throws on data with no properties", () => {
-		expect(() => {
+	it("returns valid false with reason on data with no properties", () => {
+		expect(
 			isValidStoreFeature(
 				{
 					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
 					geometry: {},
-				} as any,
+				} as unknown,
 				isValidId,
-			);
-		}).toThrow(StoreValidationErrors.FeatureHasNoProperties);
+			),
+		).toEqual({
+			reason: StoreValidationErrors.FeatureHasNoProperties,
+			valid: false,
+		});
 	});
 
-	it("throws on data with non Point, LineString, Polygon geometry type", () => {
-		expect(() => {
+	it("returns valid false with reason on data with non Point, LineString, Polygon geometry type", () => {
+		expect(
 			isValidStoreFeature(
 				{
 					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
@@ -68,14 +80,17 @@ describe("isValidStoreFeature", () => {
 						type: "MultiLineString",
 					},
 					properties: {},
-				} as any,
+				} as unknown,
 				isValidId,
-			);
-		}).toThrow(StoreValidationErrors.FeatureGeometryNotSupported);
+			),
+		).toEqual({
+			reason: StoreValidationErrors.FeatureGeometryNotSupported,
+			valid: false,
+		});
 	});
 
-	it("throws on data with supported geometry with non array coordinate property", () => {
-		expect(() => {
+	it("returns valid false with reason on data with supported geometry with non array coordinate property", () => {
+		expect(
 			isValidStoreFeature(
 				{
 					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
@@ -84,14 +99,17 @@ describe("isValidStoreFeature", () => {
 						coordinates: "[]",
 					},
 					properties: {},
-				},
+				} as unknown,
 				isValidId,
-			);
-		}).toThrow(StoreValidationErrors.FeatureCoordinatesNotAnArray);
+			),
+		).toEqual({
+			reason: StoreValidationErrors.FeatureCoordinatesNotAnArray,
+			valid: false,
+		});
 	});
 
-	it("throws if mode is not provided as a string", () => {
-		expect(() =>
+	it("returns valid false with reason if mode is not provided as a string", () => {
+		expect(
 			isValidStoreFeature(
 				{
 					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
@@ -103,11 +121,14 @@ describe("isValidStoreFeature", () => {
 				},
 				isValidId,
 			),
-		).toThrow(StoreValidationErrors.InvalidModeProperty);
+		).toEqual({
+			reason: StoreValidationErrors.InvalidModeProperty,
+			valid: false,
+		});
 	});
 
 	it("does not throw if mode is provide as a string", () => {
-		expect(() =>
+		expect(
 			isValidStoreFeature(
 				{
 					id: "e3ccd3b9-afb1-4f0b-91d8-22a768d5f284",
@@ -119,16 +140,16 @@ describe("isValidStoreFeature", () => {
 				},
 				isValidId,
 			),
-		).not.toThrow();
+		).toEqual({
+			valid: true,
+		});
 	});
 
-	it("throws if tracked is explicitly true and tracked properties are not provided", () => {
-		expect(() => isValidTimestamp(undefined)).toThrow(
-			StoreValidationErrors.InvalidTrackedProperties,
-		);
+	it("returns valid false with reason if tracked is explicitly true and tracked properties are not provided", () => {
+		expect(isValidTimestamp(undefined)).toEqual(false);
 	});
 
 	it("does not throw if tracked is true and tracked properties are provided", () => {
-		expect(() => isValidTimestamp(+new Date())).not.toThrow();
+		expect(isValidTimestamp(+new Date())).toEqual(true);
 	});
 });

--- a/src/store/store.spec.ts
+++ b/src/store/store.spec.ts
@@ -383,60 +383,79 @@ describe("GeoJSONStore", () => {
 		it("errors if feature does not pass validation", () => {
 			const store = new GeoJSONStore({ tracked: false });
 
-			expect(() => {
-				store.load(
-					[
-						{
-							type: "Feature",
-							properties: {},
-							geometry: { type: "Point", coordinates: [0, 0] },
-						},
-					],
-					(feature) => {
-						return Boolean(
-							feature &&
-								typeof feature === "object" &&
-								"type" in feature &&
-								feature.type === "Polygon",
-						);
+			const result = store.load(
+				[
+					{
+						type: "Feature",
+						properties: {},
+						geometry: { type: "Point", coordinates: [0, 0] },
 					},
-				);
-			}).toThrow();
+				],
+				(feature) => ({
+					valid: Boolean(
+						feature &&
+							typeof feature === "object" &&
+							"type" in feature &&
+							feature.type === "Polygon",
+					),
+					reason: "Test",
+				}),
+			);
+
+			expect(result).toStrictEqual([
+				{
+					id: expect.any(String),
+					reason: expect.any(String),
+					valid: false,
+				},
+			]);
 		});
 
 		it("errors if feature createdAt is not valid numeric timestamps", () => {
 			const store = new GeoJSONStore({ tracked: true });
 
-			expect(() => {
-				store.load([
-					{
-						type: "Feature",
-						properties: {
-							mode: "point",
-							createdAt: new Date().toISOString(),
-						},
-						geometry: { type: "Point", coordinates: [0, 0] },
+			const result = store.load([
+				{
+					type: "Feature",
+					properties: {
+						mode: "point",
+						createdAt: new Date().toISOString(),
 					},
-				]);
-			}).toThrow(StoreValidationErrors.InvalidTrackedProperties);
+					geometry: { type: "Point", coordinates: [0, 0] },
+				},
+			]);
+
+			return expect(result).toStrictEqual([
+				{
+					id: expect.any(String),
+					reason: "createdAt is not a valid numeric timestamp",
+					valid: false,
+				},
+			]);
 		});
 
 		it("errors if feature createdAt is not valid numeric timestamps", () => {
 			const store = new GeoJSONStore({ tracked: true });
 
-			expect(() => {
-				store.load([
-					{
-						type: "Feature",
-						properties: {
-							mode: "point",
-							createdAt: +new Date(),
-							updatedAt: new Date().toISOString(),
-						},
-						geometry: { type: "Point", coordinates: [0, 0] },
+			const result = store.load([
+				{
+					type: "Feature",
+					properties: {
+						mode: "point",
+						createdAt: +new Date(),
+						updatedAt: new Date().toISOString(),
 					},
-				]);
-			}).toThrow(StoreValidationErrors.InvalidTrackedProperties);
+					geometry: { type: "Point", coordinates: [0, 0] },
+				},
+			]);
+
+			expect(result).toStrictEqual([
+				{
+					id: expect.any(String),
+					reason: "updatedAt is not a valid numeric timestamp",
+					valid: false,
+				},
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

Now returns an array with information about each feature valid, including it's `id` if it was `valid` and if it wasn't valid the `reason` it was not valid. This is a **breaking change** as invalid features no longer error, they just return an invalid entry in the returned array.

This allows more flexibility to allow developers to handle the invalid features as they want and also makes it easier to get the ids if they are already assigned.

## Link to Issue

#379 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 