### PR TITLE
feat: expose the validation failure reasons for developers to check against

### DIFF
--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -88,8 +88,21 @@ console.log(result)
 `addFeatures` returns an array of objects providing information about the added features such as the id and the feature was valid. Only valid features are added to the store. This allows developers to handle failure cases how they see fit:
 
 ```typescript
+// Create a list of features that did not pass validation
 const invalidFeatures = result.filter(({ valid }) => !valid);
+
 // Do something with the information
+invalidFeatures.forEach(({ reason }) => {
+  // ValidationReasonFeatureHasHoles is exposed in the Terra Draw library under ValidationReasons
+  if (reason === ValidationReasonFeatureHasHoles) {
+
+    // sentAnalytics is a fake function that illustrates reacting to a invalid feature
+    sentAnalytics({ 
+      type: 'error', 
+      info: 'Feature that is being added to Terra Draw has holes when it should not'
+    })
+  }
+});
 ```
 
 If you want to get an ID for a feature and create that outside Terra Draw to do something with it later, you can use the `getFeatureId` method on the Terra Draw instance, like so:

--- a/src/modes/base.mode.ts
+++ b/src/modes/base.mode.ts
@@ -18,6 +18,7 @@ import {
 	StoreChangeHandler,
 } from "../store/store";
 import { isValidStoreFeature } from "../store/store-feature-validation";
+import { ValidationReasonModeMismatch } from "../validations/common-validations";
 
 export type CustomStyling = Record<
 	string,
@@ -39,11 +40,6 @@ export type BaseModeOptions<T extends CustomStyling> = {
 	pointerDistance?: number;
 	validation?: Validation;
 	projection?: Projection;
-};
-
-export const ModeMismatchValidationFailure = {
-	valid: false,
-	reason: "Feature mode property does not match the mode being added to",
 };
 
 export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
@@ -201,7 +197,10 @@ export abstract class TerraDrawBaseDrawMode<T extends CustomStyling> {
 			const validatedFeature = feature as GeoJSONStoreFeatures;
 			const matches = validatedFeature.properties.mode === this.mode;
 			if (!matches) {
-				return ModeMismatchValidationFailure;
+				return {
+					valid: false,
+					reason: ValidationReasonModeMismatch,
+				};
 			}
 			const modeValidation = modeValidationFn(validatedFeature);
 			return modeValidation;

--- a/src/modes/polygon/polygon.mode.ts
+++ b/src/modes/polygon/polygon.mode.ts
@@ -12,7 +12,6 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
-	ModeMismatchValidationFailure,
 } from "../base.mode";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";

--- a/src/modes/rectangle/rectangle.mode.ts
+++ b/src/modes/rectangle/rectangle.mode.ts
@@ -17,7 +17,6 @@ import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
-	ModeMismatchValidationFailure,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";

--- a/src/modes/sector/sector.mode.ts
+++ b/src/modes/sector/sector.mode.ts
@@ -12,7 +12,6 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
-	ModeMismatchValidationFailure,
 } from "../base.mode";
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { getDefaultStyling } from "../../util/styling";

--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -56,6 +56,7 @@ import { TerraDrawSectorMode } from "./modes/sector/sector.mode";
 import { TerraDrawSensorMode } from "./modes/sensor/sensor.mode";
 import * as TerraDrawExtend from "./extend";
 import { hasModeProperty } from "./store/store-feature-validation";
+import { ValidationReasons } from "./validation-reasons";
 
 type FinishListener = (id: FeatureId, context: OnFinishContext) => void;
 type ChangeListener = (ids: FeatureId[], type: string) => void;
@@ -834,4 +835,5 @@ export {
 	ValidateMinAreaSquareMeters,
 	ValidateMaxAreaSquareMeters,
 	ValidateNotSelfIntersecting,
+	ValidationReasons,
 };

--- a/src/validation-reasons.ts
+++ b/src/validation-reasons.ts
@@ -1,0 +1,33 @@
+import {
+	ValidationReasonModeMismatch,
+	ValidationReasonFeatureNotPolygon,
+} from "./validations/common-validations";
+import { ValidationReasonFeatureLessThanMinSize } from "./validations/min-size.validation";
+import {
+	ValidationReasonFeatureNotPolygonOrLineString,
+	ValidationReasonFeatureSelfIntersects,
+} from "./validations/not-self-intersecting.validation";
+import {
+	ValidationReasonFeatureInvalidCoordinates,
+	ValidationReasonFeatureNotPoint,
+} from "./validations/point.validation";
+import {
+	ValidationReasonFeatureHasHoles,
+	ValidationReasonFeatureLessThanFourCoordinates,
+	ValidationReasonFeatureHasInvalidCoordinates,
+	ValidationReasonFeatureCoordinatesNotClosed,
+} from "./validations/polygon.validation";
+
+export const ValidationReasons = {
+	ValidationReasonFeatureNotPoint,
+	ValidationReasonFeatureInvalidCoordinates,
+	ValidationReasonFeatureNotPolygon,
+	ValidationReasonFeatureHasHoles,
+	ValidationReasonFeatureLessThanFourCoordinates,
+	ValidationReasonFeatureHasInvalidCoordinates,
+	ValidationReasonFeatureCoordinatesNotClosed,
+	ValidationReasonFeatureNotPolygonOrLineString,
+	ValidationReasonFeatureSelfIntersects,
+	ValidationReasonFeatureLessThanMinSize,
+	ValidationReasonModeMismatch,
+};

--- a/src/validations/common-validations.ts
+++ b/src/validations/common-validations.ts
@@ -1,0 +1,3 @@
+export const ValidationReasonFeatureNotPolygon = "Feature is not a Polygon";
+export const ValidationReasonModeMismatch =
+	"Feature mode property does not match the mode being added to";

--- a/src/validations/linestring.validation.ts
+++ b/src/validations/linestring.validation.ts
@@ -2,6 +2,11 @@ import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
 import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 
+export const ValidationReasonFeatureIsNotALineString =
+	"Feature is not a LineString";
+export const ValidationReasonFeatureHasLessThanTwoCoordinates =
+	"Feature has less than 2 coordinates";
+
 export function ValidateLineStringFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
@@ -9,14 +14,14 @@ export function ValidateLineStringFeature(
 	if (feature.geometry.type !== "LineString") {
 		return {
 			valid: false,
-			reason: "Feature is not a LineString",
+			reason: ValidationReasonFeatureIsNotALineString,
 		};
 	}
 
 	if (feature.geometry.coordinates.length < 2) {
 		return {
 			valid: false,
-			reason: "Feature has less than 2 coordinates",
+			reason: ValidationReasonFeatureHasLessThanTwoCoordinates,
 		};
 	}
 

--- a/src/validations/max-size.validation.ts
+++ b/src/validations/max-size.validation.ts
@@ -1,6 +1,10 @@
 import { Validation } from "../common";
 import { polygonAreaSquareMeters } from "../geometry/measure/area";
 import { GeoJSONStoreFeatures } from "../terra-draw";
+import { ValidationReasonFeatureNotPolygon } from "./common-validations";
+
+export const ValidationMaxAreaSquareMetersReason =
+	"Feature is larger than the maximum area";
 
 export const ValidateMaxAreaSquareMeters = (
 	feature: GeoJSONStoreFeatures,
@@ -9,7 +13,7 @@ export const ValidateMaxAreaSquareMeters = (
 	if (feature.geometry.type !== "Polygon") {
 		return {
 			valid: false,
-			reason: "Feature is not a Polygon",
+			reason: ValidationReasonFeatureNotPolygon,
 		};
 	}
 
@@ -18,7 +22,7 @@ export const ValidateMaxAreaSquareMeters = (
 	if (size > maxSize) {
 		return {
 			valid: false,
-			reason: "Feature is larger than the maximum area",
+			reason: ValidationMaxAreaSquareMetersReason,
 		};
 	}
 

--- a/src/validations/min-size.validation.ts
+++ b/src/validations/min-size.validation.ts
@@ -1,6 +1,10 @@
 import { Validation } from "../common";
 import { polygonAreaSquareMeters } from "../geometry/measure/area";
 import { GeoJSONStoreFeatures } from "../terra-draw";
+import { ValidationReasonFeatureNotPolygon } from "./common-validations";
+
+export const ValidationReasonFeatureLessThanMinSize =
+	"Feature is smaller than the minimum area";
 
 export const ValidateMinAreaSquareMeters = (
 	feature: GeoJSONStoreFeatures,
@@ -9,14 +13,14 @@ export const ValidateMinAreaSquareMeters = (
 	if (feature.geometry.type !== "Polygon") {
 		return {
 			valid: false,
-			reason: "Feature is not a Polygon",
+			reason: ValidationReasonFeatureNotPolygon,
 		};
 	}
 
 	if (polygonAreaSquareMeters(feature.geometry) < minSize) {
 		return {
 			valid: false,
-			reason: "Feature is smaller than the minimum area",
+			reason: ValidationReasonFeatureLessThanMinSize,
 		};
 	}
 

--- a/src/validations/not-self-intersecting.validation.ts
+++ b/src/validations/not-self-intersecting.validation.ts
@@ -3,6 +3,11 @@ import { selfIntersects } from "../geometry/boolean/self-intersects";
 import { GeoJSONStoreFeatures } from "../terra-draw";
 import { Validation } from "../common";
 
+export const ValidationReasonFeatureNotPolygonOrLineString =
+	"Feature is not a Polygon or LineString";
+export const ValidationReasonFeatureSelfIntersects =
+	"Feature intersects itself";
+
 export const ValidateNotSelfIntersecting = (
 	feature: GeoJSONStoreFeatures,
 ): ReturnType<Validation> => {
@@ -12,7 +17,7 @@ export const ValidateNotSelfIntersecting = (
 	) {
 		return {
 			valid: false,
-			reason: "Feature is not a Polygon or LineString",
+			reason: ValidationReasonFeatureNotPolygonOrLineString,
 		};
 	}
 
@@ -23,7 +28,7 @@ export const ValidateNotSelfIntersecting = (
 	if (hasSelfIntersections) {
 		return {
 			valid: false,
-			reason: "Feature intersects itself",
+			reason: ValidationReasonFeatureSelfIntersects,
 		};
 	}
 

--- a/src/validations/point.validation.ts
+++ b/src/validations/point.validation.ts
@@ -2,6 +2,10 @@ import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
 import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 
+export const ValidationReasonFeatureNotPoint = "Feature is not a Point";
+export const ValidationReasonFeatureInvalidCoordinates =
+	"Feature has invalid coordinates";
+
 export function ValidatePointFeature(
 	feature: GeoJSONStoreFeatures,
 	coordinatePrecision: number,
@@ -9,14 +13,14 @@ export function ValidatePointFeature(
 	if (feature.geometry.type !== "Point") {
 		return {
 			valid: false,
-			reason: "Feature is not a Point",
+			reason: ValidationReasonFeatureNotPoint,
 		};
 	}
 
 	if (!coordinateIsValid(feature.geometry.coordinates, coordinatePrecision)) {
 		return {
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason: ValidationReasonFeatureInvalidCoordinates,
 		};
 	}
 

--- a/src/validations/polygon.validation.ts
+++ b/src/validations/polygon.validation.ts
@@ -4,12 +4,14 @@ import { selfIntersects } from "../geometry/boolean/self-intersects";
 import { coordinateIsValid } from "./../geometry/boolean/is-valid-coordinate";
 import { Validation } from "../common";
 
-function coordinatesMatch(coordinateOne: Position, coordinateTwo: Position) {
-	return (
-		coordinateOne[0] === coordinateTwo[0] &&
-		coordinateOne[1] === coordinateTwo[1]
-	);
-}
+export const ValidationReasonFeatureNotPolygon = "Feature is not a Polygon";
+export const ValidationReasonFeatureHasHoles = "Feature has holes";
+export const ValidationReasonFeatureLessThanFourCoordinates =
+	"Feature has less than 4 coordinates";
+export const ValidationReasonFeatureHasInvalidCoordinates =
+	"Feature has invalid coordinates";
+export const ValidationReasonFeatureCoordinatesNotClosed =
+	"Feature coordinates are not closed";
 
 export function ValidatePolygonFeature(
 	feature: GeoJSONStoreFeatures,
@@ -18,21 +20,21 @@ export function ValidatePolygonFeature(
 	if (feature.geometry.type !== "Polygon") {
 		return {
 			valid: false,
-			reason: "Feature is not a Polygon",
+			reason: ValidationReasonFeatureNotPolygon,
 		};
 	}
 
 	if (feature.geometry.coordinates.length !== 1) {
 		return {
 			valid: false,
-			reason: "Feature has holes",
+			reason: ValidationReasonFeatureHasHoles,
 		};
 	}
 
 	if (feature.geometry.coordinates[0].length < 4) {
 		return {
 			valid: false,
-			reason: "Feature has less than 4 coordinates",
+			reason: ValidationReasonFeatureLessThanFourCoordinates,
 		};
 	}
 
@@ -43,7 +45,7 @@ export function ValidatePolygonFeature(
 	) {
 		return {
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason: ValidationReasonFeatureHasInvalidCoordinates,
 		};
 	}
 
@@ -57,7 +59,7 @@ export function ValidatePolygonFeature(
 	) {
 		return {
 			valid: false,
-			reason: "Feature coordinates are not closed",
+			reason: ValidationReasonFeatureCoordinatesNotClosed,
 		};
 	}
 
@@ -85,4 +87,17 @@ export function ValidateNonIntersectingPolygonFeature(
 	}
 
 	return { valid: true };
+}
+
+/**
+ * Check if two coordinates are identical
+ * @param coordinateOne - coordinate to compare
+ * @param coordinateTwo - coordinate to compare with
+ * @returns boolean
+ */
+function coordinatesMatch(coordinateOne: Position, coordinateTwo: Position) {
+	return (
+		coordinateOne[0] === coordinateTwo[0] &&
+		coordinateOne[1] === coordinateTwo[1]
+	);
 }


### PR DESCRIPTION
## Description of Changes

This PR exposes all the internal validation failure reasons to make it easier for developers using Terra Draw to have branching logic depending on the failure reason, even if the wording of the error was to change in the future (for example due to a typo or clarification change).

```typescript
import { ValidationReasons } from 'terra-draw';

const { ValidationReasonFeatureHasHoles } = ValidationReasons

console.log(ValidationReasonFeatureHasHoles)
```

## Link to Issue

#380 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 