### PR TITLE
feat: provide snapping to line as well as feature coordinates for polygon mode

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -169,13 +169,19 @@ const getModes = () => {
 		}),
 		new TerraDrawPointMode(),
 		new TerraDrawLineStringMode({
-			insertCoordinates: {
-				strategy: "amount",
-				value: 10,
+			snapping: {
+				toCoordinate: true,
 			},
+			// insertCoordinates: {
+			// 	strategy: "amount",
+			// 	value: 10,
+			// },
 		}),
 		new TerraDrawPolygonMode({
-			snapping: true,
+			snapping: {
+				toLine: true,
+				toCoordinate: true,
+			},
 			validation: (feature, { updateType }) => {
 				if (updateType === "finish" || updateType === "commit") {
 					return ValidateNotSelfIntersecting(feature);

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -137,6 +137,24 @@ You'll notice there are two arguments to the `validation` function, the first be
 
 Using these can help you write more customised behaviours, for example you may only want to run the validation when the update is a `finish` or `commit` type, ensuring that validation is not prematurely preventing user interactions to update the feature.
 
+#### Snapping
+
+Some specific modes support snapping, currently polygon and linestring mode. As of writing you can snap between features in the same mode. Currently polygon mode supports snapping to a the coordinates or line segments of existing features via the `toCoordinate` and/or `toLine` properties respectively:
+
+```typescript
+  new TerraDrawPolygonMode({
+    snapping: {
+      toLine: true,
+      toCoordinate: true,
+    },
+    validation: (feature, { updateType }) => {
+      if (updateType === "finish" || updateType === "commit") {
+        return ValidateNotSelfIntersecting(feature);
+      }
+      return { valid: true };
+    },
+  })
+```
 
 #### Projections in Drawing Modes
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -29,6 +29,8 @@ export interface TerraDrawAdapterStyling {
 	zIndex: number;
 }
 
+export type CartesianPoint = { x: number; y: number };
+
 // Neither buttons nor touch/pen contact changed since last event	-1
 // Mouse move with no buttons pressed, Pen moved while hovering with no buttons pressed	—
 // Left Mouse, Touch Contact, Pen contact	0
@@ -62,7 +64,7 @@ export type SetCursor = (
 		| "move",
 ) => void;
 
-export type Project = (lng: number, lat: number) => { x: number; y: number };
+export type Project = (lng: number, lat: number) => CartesianPoint;
 export type Unproject = (x: number, y: number) => { lat: number; lng: number };
 export type GetLngLatFromEvent = (event: PointerEvent | MouseEvent) => {
 	lng: number;

--- a/src/geometry/calculate-relative-angle.ts
+++ b/src/geometry/calculate-relative-angle.ts
@@ -1,3 +1,4 @@
+import { CartesianPoint } from "../common";
 import { webMercatorBearing } from "./measure/bearing";
 
 /**
@@ -8,9 +9,9 @@ import { webMercatorBearing } from "./measure/bearing";
  * @returns The relative angle between the two lines
  */
 export function calculateRelativeAngle(
-	A: { x: number; y: number },
-	B: { x: number; y: number },
-	C: { x: number; y: number },
+	A: CartesianPoint,
+	B: CartesianPoint,
+	C: CartesianPoint,
 ): number {
 	const bearingAB = webMercatorBearing(A, B); // Bearing from A to B
 	const bearingBC = webMercatorBearing(B, C); // Bearing from B to C

--- a/src/geometry/clockwise.ts
+++ b/src/geometry/clockwise.ts
@@ -1,7 +1,9 @@
+import { CartesianPoint } from "../common";
+
 export function isClockwiseWebMercator(
-	center: { x: number; y: number },
-	secondCoord: { x: number; y: number },
-	thirdCoord: { x: number; y: number },
+	center: CartesianPoint,
+	secondCoord: CartesianPoint,
+	thirdCoord: CartesianPoint,
 ): boolean {
 	// Calculate the vectors
 	const vector1 = { x: secondCoord.x - center.x, y: secondCoord.y - center.y };

--- a/src/geometry/determine-halfplane.ts
+++ b/src/geometry/determine-halfplane.ts
@@ -1,8 +1,10 @@
+import { CartesianPoint } from "../common";
+
 // Function to determine the relative position of a point to a line segment
 export function determineHalfPlane(
-	point: { x: number; y: number },
-	lineStart: { x: number; y: number },
-	lineEnd: { x: number; y: number },
+	point: CartesianPoint,
+	lineStart: CartesianPoint,
+	lineEnd: CartesianPoint,
 ): string {
 	// Calculate the vectors
 	const vectorLine = { x: lineEnd.x - lineStart.x, y: lineEnd.y - lineStart.y };

--- a/src/geometry/measure/bearing.ts
+++ b/src/geometry/measure/bearing.ts
@@ -1,5 +1,6 @@
 import { Position } from "geojson";
 import { degreesToRadians, radiansToDegrees } from "../helpers";
+import { CartesianPoint } from "../../common";
 
 // Adapted from the @turf/bearing module which is MIT Licensed
 // https://github.com/Turfjs/turf/tree/master/packages/turf-bearing
@@ -18,8 +19,8 @@ export function bearing(start: Position, end: Position): number {
 }
 
 export function webMercatorBearing(
-	{ x: x1, y: y1 }: { x: number; y: number },
-	{ x: x2, y: y2 }: { x: number; y: number },
+	{ x: x1, y: y1 }: CartesianPoint,
+	{ x: x2, y: y2 }: CartesianPoint,
 ): number {
 	const deltaX = x2 - x1;
 	const deltaY = y2 - y1;

--- a/src/geometry/measure/destination.ts
+++ b/src/geometry/measure/destination.ts
@@ -4,6 +4,7 @@ import {
 	lengthToRadians,
 	radiansToDegrees,
 } from "../helpers";
+import { CartesianPoint } from "../../common";
 
 // Adapted from @turf/destination module which is MIT Licensed
 // https://github.com/Turfjs/turf/blob/master/packages/turf-desination/index.ts
@@ -36,10 +37,10 @@ export function destination(
 
 // Function to create a destination point in Web Mercator projection
 export function webMercatorDestination(
-	{ x, y }: { x: number; y: number },
+	{ x, y }: CartesianPoint,
 	distance: number,
 	bearing: number,
-): { x: number; y: number } {
+): CartesianPoint {
 	// Convert origin to Web Mercator
 	const bearingRad = degreesToRadians(bearing);
 

--- a/src/geometry/measure/pixel-distance-to-line.ts
+++ b/src/geometry/measure/pixel-distance-to-line.ts
@@ -1,18 +1,20 @@
+import { CartesianPoint } from "../../common";
+
 export const pixelDistanceToLine = (
-	point: { x: number; y: number },
-	linePointOne: { x: number; y: number },
-	linePointTwo: { x: number; y: number },
+	point: CartesianPoint,
+	linePointOne: CartesianPoint,
+	linePointTwo: CartesianPoint,
 ) => {
 	const square = (x: number) => {
 		return x * x;
 	};
-	const dist2 = (v: { x: number; y: number }, w: { x: number; y: number }) => {
+	const dist2 = (v: CartesianPoint, w: CartesianPoint) => {
 		return square(v.x - w.x) + square(v.y - w.y);
 	};
 	const distToSegmentSquared = (
-		p: { x: number; y: number },
-		v: { x: number; y: number },
-		w: { x: number; y: number },
+		p: CartesianPoint,
+		v: CartesianPoint,
+		w: CartesianPoint,
 	) => {
 		const l2 = dist2(v, w);
 

--- a/src/geometry/measure/pixel-distance.ts
+++ b/src/geometry/measure/pixel-distance.ts
@@ -1,6 +1,8 @@
+import { CartesianPoint } from "../../common";
+
 export const cartesianDistance = (
-	pointOne: { x: number; y: number },
-	pointTwo: { x: number; y: number },
+	pointOne: CartesianPoint,
+	pointTwo: CartesianPoint,
 ) => {
 	const { x: x1, y: y1 } = pointOne;
 	const { x: x2, y: y2 } = pointTwo;

--- a/src/geometry/point-on-line.spec.ts
+++ b/src/geometry/point-on-line.spec.ts
@@ -1,0 +1,59 @@
+import { nearestPointOnLine } from "./point-on-line";
+
+describe("nearestPointOnLine", () => {
+	it("returns exact feature coordinate if source coordinate is that coordinate", () => {
+		const result = nearestPointOnLine(
+			[0, 1],
+			[
+				[
+					[0, 0],
+					[0, 1],
+				],
+				[
+					[0, 1],
+					[1, 1],
+				],
+				[
+					[1, 1],
+					[1, 0],
+				],
+				[
+					[1, 0],
+					[0, 0],
+				],
+			],
+		);
+
+		expect(result?.coordinate).toEqual([0, 1]);
+		expect(result?.distance).toEqual(0);
+	});
+
+	it("returns coordinate on line", () => {
+		const result = nearestPointOnLine(
+			[0, 2],
+			[
+				[
+					[0, 0],
+					[0, 1],
+				],
+				[
+					[0, 1],
+					[1, 1],
+				],
+				[
+					[1, 1],
+					[1, 0],
+				],
+				[
+					[1, 0],
+					[0, 0],
+				],
+			],
+		);
+
+		expect(result?.coordinate[0]).toBeCloseTo(0);
+		expect(result?.coordinate[1]).toBeCloseTo(1);
+
+		expect(result?.distance).toBeCloseTo(111.19492664455873);
+	});
+});

--- a/src/geometry/point-on-line.ts
+++ b/src/geometry/point-on-line.ts
@@ -1,0 +1,185 @@
+import { Feature, Point, Position, LineString } from "geojson";
+import { degreesToRadians, radiansToDegrees } from "./helpers";
+import { haversineDistanceKilometers } from "./measure/haversine-distance";
+
+// nearestPointOnLine is adapted from the @turf/midpoint which is MIT Licensed
+// https://github.com/Turfjs/turf/tree/master/packages/turf-nearest-point-on-line
+
+export function nearestPointOnLine(
+	inputCoordinate: Position,
+	lines: [Position, Position][],
+):
+	| {
+			coordinate: Position;
+			distance: number;
+	  }
+	| undefined {
+	let closestPoint: Position = [Infinity, Infinity];
+	let closestDistance = Infinity;
+
+	for (let line of lines) {
+		const startPosition: Position = line[0];
+		const stopPosition: Position = line[1];
+
+		// sectionLength
+		let intersectPosition: Position;
+		let intersectDistance: number = Infinity;
+
+		// Short circuit if snap point is start or end position of the line segment.
+		if (
+			startPosition[0] === inputCoordinate[0] &&
+			startPosition[1] === inputCoordinate[1]
+		) {
+			intersectPosition = startPosition;
+		} else if (
+			stopPosition[0] === inputCoordinate[0] &&
+			stopPosition[1] === inputCoordinate[1]
+		) {
+			intersectPosition = stopPosition;
+		} else {
+			// Otherwise, find the nearest point the hard way.
+			[intersectPosition] = nearestPointOnSegment(
+				startPosition,
+				stopPosition,
+				inputCoordinate,
+			);
+		}
+
+		if (intersectPosition) {
+			intersectDistance = haversineDistanceKilometers(
+				inputCoordinate,
+				intersectPosition,
+			);
+
+			if (intersectDistance < closestDistance) {
+				closestPoint = intersectPosition;
+				closestDistance = intersectDistance;
+			}
+		}
+	}
+
+	return closestDistance === Infinity
+		? undefined
+		: { coordinate: closestPoint, distance: closestDistance };
+}
+
+/*
+ * Plan is to externalise these vector functions to a simple third party
+ * library.
+ * Possible candidate is @amandaghassaei/vector-math though having some import
+ * issues.
+ */
+type Vector = [number, number, number];
+
+function dot(v1: Vector, v2: Vector): number {
+	const [v1x, v1y, v1z] = v1;
+	const [v2x, v2y, v2z] = v2;
+	return v1x * v2x + v1y * v2y + v1z * v2z;
+}
+
+// https://en.wikipedia.org/wiki/Cross_product
+function cross(v1: Vector, v2: Vector): Vector {
+	const [v1x, v1y, v1z] = v1;
+	const [v2x, v2y, v2z] = v2;
+	return [v1y * v2z - v1z * v2y, v1z * v2x - v1x * v2z, v1x * v2y - v1y * v2x];
+}
+
+function magnitude(v: Vector) {
+	return Math.sqrt(Math.pow(v[0], 2) + Math.pow(v[1], 2) + Math.pow(v[2], 2));
+}
+
+function angle(v1: Vector, v2: Vector): number {
+	const theta = dot(v1, v2) / (magnitude(v1) * magnitude(v2));
+	return Math.acos(Math.min(Math.max(theta, -1), 1));
+}
+
+function lngLatToVector(a: Position): Vector {
+	const lat = degreesToRadians(a[1]);
+	const lng = degreesToRadians(a[0]);
+	return [
+		Math.cos(lat) * Math.cos(lng),
+		Math.cos(lat) * Math.sin(lng),
+		Math.sin(lat),
+	];
+}
+
+function vectorToLngLat(v: Vector): Position {
+	const [x, y, z] = v;
+	const lat = radiansToDegrees(Math.asin(z));
+	const lng = radiansToDegrees(Math.atan2(y, x));
+
+	return [lng, lat];
+}
+
+function nearestPointOnSegment(
+	posA: Position, // start point of segment to measure to
+	posB: Position, // end point of segment to measure to
+	posC: Position, // point to measure from
+): [Position, boolean, boolean] {
+	// Based heavily on this article on finding cross track distance to an arc:
+	// https://gis.stackexchange.com/questions/209540/projecting-cross-track-distance-on-great-circle
+
+	// Convert spherical (lng, lat) to cartesian vector coords (x, y, z)
+	// In the below https://tikz.net/spherical_1/ we convert lng (𝜙) and lat (𝜃)
+	// into vectors with x, y, and z components with a length (r) of 1.
+	const A = lngLatToVector(posA); // the vector from 0,0,0 to posA
+	const B = lngLatToVector(posB); // ... to posB
+	const C = lngLatToVector(posC); // ... to posC
+
+	// Components of target point.
+	const [Cx, Cy, Cz] = C;
+
+	// Calculate coefficients.
+	const [D, E, F] = cross(A, B);
+	const a = E * Cz - F * Cy;
+	const b = F * Cx - D * Cz;
+	const c = D * Cy - E * Cx;
+
+	const f = c * E - b * F;
+	const g = a * F - c * D;
+	const h = b * D - a * E;
+
+	const t = 1 / Math.sqrt(Math.pow(f, 2) + Math.pow(g, 2) + Math.pow(h, 2));
+
+	// Vectors to the two points these great circles intersect.
+	const I1: Vector = [f * t, g * t, h * t];
+	const I2: Vector = [-1 * f * t, -1 * g * t, -1 * h * t];
+
+	// Figure out which is the closest intersection to this segment of the great
+	// circle.
+	const angleAB = angle(A, B);
+	const angleAI1 = angle(A, I1);
+	const angleBI1 = angle(B, I1);
+	const angleAI2 = angle(A, I2);
+	const angleBI2 = angle(B, I2);
+
+	let I: Vector;
+
+	if (
+		(angleAI1 < angleAI2 && angleAI1 < angleBI2) ||
+		(angleBI1 < angleAI2 && angleBI1 < angleBI2)
+	) {
+		I = I1;
+	} else {
+		I = I2;
+	}
+
+	// I is the closest intersection to the segment, though might not actually be
+	// ON the segment.
+
+	// If angle AI or BI is greater than angleAB, I lies on the circle *beyond* A
+	// and B so use the closest of A or B as the intersection
+	if (angle(A, I) > angleAB || angle(B, I) > angleAB) {
+		if (
+			haversineDistanceKilometers(vectorToLngLat(I), vectorToLngLat(A)) <=
+			haversineDistanceKilometers(vectorToLngLat(I), vectorToLngLat(B))
+		) {
+			return [vectorToLngLat(A), true, false];
+		} else {
+			return [vectorToLngLat(B), false, true];
+		}
+	}
+
+	// As angleAI nor angleBI don't exceed angleAB, I is on the segment
+	return [vectorToLngLat(I), false, false];
+}

--- a/src/geometry/project/web-mercator.ts
+++ b/src/geometry/project/web-mercator.ts
@@ -1,3 +1,5 @@
+import { CartesianPoint } from "../../common";
+
 const RADIANS_TO_DEGREES = 57.29577951308232 as const; // 180 / Math.PI
 const DEGREES_TO_RADIANS = 0.017453292519943295 as const; // Math.PI / 180
 const R = 6378137 as const;
@@ -11,7 +13,7 @@ const R = 6378137 as const;
 export const lngLatToWebMercatorXY = (
 	lng: number,
 	lat: number,
-): { x: number; y: number } => ({
+): CartesianPoint => ({
 	x: lng === 0 ? 0 : lng * DEGREES_TO_RADIANS * R,
 	y:
 		lat === 0

--- a/src/geometry/transform/rotate.ts
+++ b/src/geometry/transform/rotate.ts
@@ -7,6 +7,7 @@ import {
 	lngLatToWebMercatorXY,
 	webMercatorXYToLngLat,
 } from "../project/web-mercator";
+import { CartesianPoint } from "../../common";
 
 // Adapted on @turf/transform-rotate module which is MIT licensed
 // https://github.com/Turfjs/turf/tree/master/packages/turf-transform-rotate
@@ -69,7 +70,7 @@ export const transformRotateWebMercator = (
 
 	// Find centroid of the polygon in Web Mercator
 	const centroid = webMercatorCoords.reduce(
-		(acc: { x: number; y: number }, coord: { x: number; y: number }) => ({
+		(acc: CartesianPoint, coord: CartesianPoint) => ({
 			x: acc.x + coord.x,
 			y: acc.y + coord.y,
 		}),

--- a/src/geometry/web-mercator-centroid.ts
+++ b/src/geometry/web-mercator-centroid.ts
@@ -1,5 +1,6 @@
 import { Feature, LineString, Polygon, Position } from "geojson";
 import { lngLatToWebMercatorXY } from "./project/web-mercator";
+import { CartesianPoint } from "../common";
 
 /**
  * Calculates the centroid of a GeoJSON Polygon or LineString in Web Mercator
@@ -25,10 +26,9 @@ export function webMercatorCentroid(feature: Feature<Polygon | LineString>) {
 	}
 }
 
-function calculatePolygonCentroid(webMercatorCoordinates: Position[]): {
-	x: number;
-	y: number;
-} {
+function calculatePolygonCentroid(
+	webMercatorCoordinates: Position[],
+): CartesianPoint {
 	let area = 0;
 	let centroidX = 0;
 	let centroidY = 0;
@@ -52,10 +52,7 @@ function calculatePolygonCentroid(webMercatorCoordinates: Position[]): {
 	return { x: centroidX, y: centroidY };
 }
 
-function calculateLineStringMidpoint(lineString: Position[]): {
-	x: number;
-	y: number;
-} {
+function calculateLineStringMidpoint(lineString: Position[]): CartesianPoint {
 	const n = lineString.length;
 	let totalX = 0;
 	let totalY = 0;

--- a/src/geometry/web-mercator-point-on-line.spec.ts
+++ b/src/geometry/web-mercator-point-on-line.spec.ts
@@ -1,0 +1,59 @@
+import { webMercatorNearestPointOnLine } from "./web-mercator-point-on-line";
+
+describe("webMercatorNearestPointOnLine", () => {
+	it("returns exact feature coordinate if source coordinate is that coordinate", () => {
+		const result = webMercatorNearestPointOnLine(
+			[0, 1],
+			[
+				[
+					[0, 0],
+					[0, 1],
+				],
+				[
+					[0, 1],
+					[1, 1],
+				],
+				[
+					[1, 1],
+					[1, 0],
+				],
+				[
+					[1, 0],
+					[0, 0],
+				],
+			],
+		);
+
+		expect(result?.coordinate).toEqual([0, 1]);
+		expect(result?.distance).toEqual(0);
+	});
+
+	it("returns coordinate on line", () => {
+		const result = webMercatorNearestPointOnLine(
+			[0, 2],
+			[
+				[
+					[0, 0],
+					[0, 1],
+				],
+				[
+					[0, 1],
+					[1, 1],
+				],
+				[
+					[1, 1],
+					[1, 0],
+				],
+				[
+					[1, 0],
+					[0, 0],
+				],
+			],
+		);
+
+		expect(result?.coordinate[0]).toBeCloseTo(0);
+		expect(result?.coordinate[1]).toBeCloseTo(1);
+
+		expect(result?.distance).toBeCloseTo(111359.06563915969);
+	});
+});

--- a/src/geometry/web-mercator-point-on-line.ts
+++ b/src/geometry/web-mercator-point-on-line.ts
@@ -1,0 +1,124 @@
+import { Position } from "geojson";
+import {
+	lngLatToWebMercatorXY,
+	webMercatorXYToLngLat,
+} from "./project/web-mercator";
+import { cartesianDistance } from "./measure/pixel-distance";
+import { CartesianPoint } from "../common";
+
+// nearestPointOnLine is adapted from the @turf/midpoint which is MIT Licensed
+// https://github.com/Turfjs/turf/tree/master/packages/turf-nearest-point-on-line
+
+/**
+ * Takes two points and finds the closest point on the line between them to a third point.
+ * @param lines
+ * @param inputCoordinate
+ * @returns
+ */
+export function webMercatorNearestPointOnLine(
+	inputCoordinate: Position,
+	lines: [Position, Position][],
+):
+	| {
+			coordinate: Position;
+			distance: number;
+	  }
+	| undefined {
+	let closestPoint: Position = [Infinity, Infinity];
+	let closestDistance = Infinity;
+
+	for (let line of lines) {
+		const startPosition: Position = line[0];
+		const stopPosition: Position = line[1];
+
+		// sectionLength
+		let intersectPosition: Position;
+		let intersectDistance: number = Infinity;
+
+		const start = lngLatToWebMercatorXY(startPosition[0], startPosition[1]);
+		const stop = lngLatToWebMercatorXY(stopPosition[0], stopPosition[1]);
+		const source = lngLatToWebMercatorXY(
+			inputCoordinate[0],
+			inputCoordinate[1],
+		);
+
+		// Short circuit if snap point is start or end position of the line segment.
+		if (
+			startPosition[0] === inputCoordinate[0] &&
+			startPosition[1] === inputCoordinate[1]
+		) {
+			intersectPosition = startPosition;
+		} else if (
+			stopPosition[0] === inputCoordinate[0] &&
+			stopPosition[1] === inputCoordinate[1]
+		) {
+			intersectPosition = stopPosition;
+		} else {
+			// Otherwise, find the nearest point the hard way.
+			const { x, y } = findNearestPointOnLine(start, stop, source);
+
+			const { lng, lat } = webMercatorXYToLngLat(x, y);
+			intersectPosition = [lng, lat];
+		}
+
+		if (intersectPosition) {
+			intersectDistance = cartesianDistance(
+				source,
+				lngLatToWebMercatorXY(intersectPosition[0], intersectPosition[1]),
+			);
+
+			if (intersectDistance < closestDistance) {
+				closestPoint = intersectPosition;
+				closestDistance = intersectDistance;
+			}
+		}
+	}
+
+	return closestDistance === Infinity
+		? undefined
+		: { coordinate: closestPoint, distance: closestDistance };
+}
+
+/**
+ * Finds the nearest Web Mercator coordinate on a line to a given coordinate.
+ * @param pointA - The first point of the line (Web Mercator coordinate).
+ * @param pointB - The second point of the line (Web Mercator coordinate).
+ * @param target - The target point to which the nearest point on the line is calculated.
+ * @returns The nearest Web Mercator coordinate on the line to the target.
+ */
+function findNearestPointOnLine(
+	pointA: CartesianPoint,
+	pointB: CartesianPoint,
+	target: CartesianPoint,
+): CartesianPoint {
+	// Vector from pointA to pointB
+	const lineVector = {
+		x: pointB.x - pointA.x,
+		y: pointB.y - pointA.y,
+	};
+
+	// Vector from pointA to the target point
+	const targetVector = {
+		x: target.x - pointA.x,
+		y: target.y - pointA.y,
+	};
+
+	// Compute the dot product of the target vector with the line vector
+	const dotProduct =
+		targetVector.x * lineVector.x + targetVector.y * lineVector.y;
+
+	// Compute the length squared of the line vector
+	const lineLengthSquared =
+		lineVector.x * lineVector.x + lineVector.y * lineVector.y;
+
+	// Find the projection of the target vector onto the line vector
+	const t = Math.max(0, Math.min(1, dotProduct / lineLengthSquared));
+
+	// Compute the nearest point on the line
+	const nearestPoint = {
+		x: pointA.x + t * lineVector.x,
+		y: pointA.y + t * lineVector.y,
+	};
+
+	return nearestPoint;
+}

--- a/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -52,7 +52,6 @@ interface Cursors {
 
 interface TerraDrawPolygonModeOptions<T extends CustomStyling>
 	extends BaseModeOptions<T> {
-	snapping?: boolean;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
 	cursors?: Cursors;

--- a/src/modes/coordinate-snapping.behavior.spec.ts
+++ b/src/modes/coordinate-snapping.behavior.spec.ts
@@ -4,13 +4,13 @@ import { MockCursorEvent } from "../test/mock-cursor-event";
 import { BehaviorConfig } from "./base.behavior";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
-import { SnappingBehavior } from "./snapping.behavior";
+import { CoordinateSnappingBehavior } from "./coordinate-snapping.behavior";
 
-describe("SnappingBehavior", () => {
+describe("CoordinateSnappingBehavior", () => {
 	describe("constructor", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
-			new SnappingBehavior(
+			new CoordinateSnappingBehavior(
 				config,
 				new PixelDistanceBehavior(config),
 				new ClickBoundingBoxBehavior(config),
@@ -20,20 +20,20 @@ describe("SnappingBehavior", () => {
 
 	describe("api", () => {
 		let config: BehaviorConfig;
-		let snappingBehavior: SnappingBehavior;
+		let coordinateSnappingBehavior: CoordinateSnappingBehavior;
 
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
-			snappingBehavior = new SnappingBehavior(
+			coordinateSnappingBehavior = new CoordinateSnappingBehavior(
 				config,
 				new PixelDistanceBehavior(config),
 				new ClickBoundingBoxBehavior(config),
 			);
 		});
 
-		describe("getSnappablePolygonCoord", () => {
+		describe("getSnappableCoordinate", () => {
 			it("returns undefined if not snappable", () => {
-				const snappedCoord = snappingBehavior.getSnappableCoordinate(
+				const snappedCoord = coordinateSnappingBehavior.getSnappableCoordinate(
 					MockCursorEvent({ lng: 0, lat: 0 }),
 					"mockId",
 				);
@@ -46,7 +46,7 @@ describe("SnappingBehavior", () => {
 				// creating an existing polygon
 				createStorePolygon(config);
 
-				const snappedCoord = snappingBehavior.getSnappableCoordinate(
+				const snappedCoord = coordinateSnappingBehavior.getSnappableCoordinate(
 					MockCursorEvent({ lng: 0, lat: 0 }),
 					"currentId",
 				);

--- a/src/modes/coordinate-snapping.behavior.ts
+++ b/src/modes/coordinate-snapping.behavior.ts
@@ -1,0 +1,73 @@
+import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
+import { TerraDrawMouseEvent } from "../common";
+import { Feature, Position } from "geojson";
+import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
+import { BBoxPolygon, FeatureId } from "../store/store";
+import { PixelDistanceBehavior } from "./pixel-distance.behavior";
+
+export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
+	constructor(
+		readonly config: BehaviorConfig,
+		private readonly pixelDistance: PixelDistanceBehavior,
+		private readonly clickBoundingBox: ClickBoundingBoxBehavior,
+	) {
+		super(config);
+	}
+
+	/** Returns the nearest snappable coordinate - on first click there is no currentId so no need to provide */
+	public getSnappableCoordinateFirstClick = (event: TerraDrawMouseEvent) => {
+		return this.getSnappable(event, (feature) => {
+			return Boolean(
+				feature.properties && feature.properties.mode === this.mode,
+			);
+		});
+	};
+
+	public getSnappableCoordinate = (
+		event: TerraDrawMouseEvent,
+		currentFeatureId: FeatureId,
+	) => {
+		return this.getSnappable(event, (feature) => {
+			return Boolean(
+				feature.properties &&
+					feature.properties.mode === this.mode &&
+					feature.id !== currentFeatureId,
+			);
+		});
+	};
+
+	private getSnappable(
+		event: TerraDrawMouseEvent,
+		filter: (feature: Feature) => boolean,
+	) {
+		const bbox = this.clickBoundingBox.create(event) as BBoxPolygon;
+
+		const features = this.store.search(bbox, filter);
+
+		const closest: { coord: undefined | Position; minDist: number } = {
+			coord: undefined,
+			minDist: Infinity,
+		};
+
+		features.forEach((feature) => {
+			let coordinates: Position[];
+			if (feature.geometry.type === "Polygon") {
+				coordinates = feature.geometry.coordinates[0];
+			} else if (feature.geometry.type === "LineString") {
+				coordinates = feature.geometry.coordinates;
+			} else {
+				return;
+			}
+
+			coordinates.forEach((coord) => {
+				const dist = this.pixelDistance.measure(event, coord);
+				if (dist < closest.minDist && dist < this.pointerDistance) {
+					closest.coord = coord;
+					closest.minDist = dist;
+				}
+			});
+		});
+
+		return closest.coord;
+	}
+}

--- a/src/modes/line-snapping.behavior.spec.ts
+++ b/src/modes/line-snapping.behavior.spec.ts
@@ -1,0 +1,79 @@
+import { createStorePolygon } from "../test/create-store-features";
+import { MockBehaviorConfig } from "../test/mock-behavior-config";
+import { MockCursorEvent } from "../test/mock-cursor-event";
+import { BehaviorConfig } from "./base.behavior";
+import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
+import { PixelDistanceBehavior } from "./pixel-distance.behavior";
+import { LineSnappingBehavior } from "./line-snapping.behavior";
+
+describe("LineSnappingBehavior", () => {
+	describe("constructor", () => {
+		it("constructs", () => {
+			const config = MockBehaviorConfig("test");
+			new LineSnappingBehavior(
+				config,
+				new PixelDistanceBehavior(config),
+				new ClickBoundingBoxBehavior(config),
+			);
+		});
+	});
+
+	describe("api", () => {
+		let config: BehaviorConfig;
+		let lineSnappingBehavior: LineSnappingBehavior;
+
+		describe.each(["globe", "web-mercator"] as const)(
+			"getSnappableCoordinateFirstClick (%s)",
+			(projection) => {
+				beforeEach(() => {
+					config = MockBehaviorConfig("test", projection);
+					lineSnappingBehavior = new LineSnappingBehavior(
+						config,
+						new PixelDistanceBehavior(config),
+						new ClickBoundingBoxBehavior(config),
+					);
+				});
+
+				describe("getSnappableCoordinate", () => {
+					it("returns undefined if not snappable", () => {
+						const snappedCoord = lineSnappingBehavior.getSnappableCoordinate(
+							MockCursorEvent({ lng: 0, lat: 0 }),
+							"mockId",
+						);
+
+						expect(snappedCoord).toBe(undefined);
+					});
+
+					it("returns a snappable coordinate if one exists", () => {
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snappedCoord = lineSnappingBehavior.getSnappableCoordinate(
+							MockCursorEvent({ lng: 0, lat: 0 }),
+							"currentId",
+						);
+
+						expect(snappedCoord).toStrictEqual([0, 0]);
+					});
+
+					it("returns a snappable coordinate if one exists", () => {
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snappedCoord = lineSnappingBehavior.getSnappableCoordinate(
+							MockCursorEvent({ lng: -0.5, lat: 0.5 }),
+							"currentId",
+						);
+
+						expect(snappedCoord && snappedCoord[0]).toBeCloseTo(0);
+						expect(snappedCoord && snappedCoord[1]).toBeCloseTo(
+							0.5000190382262164,
+						);
+					});
+				});
+			},
+		);
+	});
+});

--- a/src/modes/line-snapping.behavior.ts
+++ b/src/modes/line-snapping.behavior.ts
@@ -4,8 +4,10 @@ import { Feature, Position } from "geojson";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
 import { BBoxPolygon, FeatureId } from "../store/store";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
+import { nearestPointOnLine } from "../geometry/point-on-line";
+import { webMercatorNearestPointOnLine } from "../geometry/web-mercator-point-on-line";
 
-export class SnappingBehavior extends TerraDrawModeBehavior {
+export class LineSnappingBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
 		private readonly pixelDistance: PixelDistanceBehavior,
@@ -40,13 +42,11 @@ export class SnappingBehavior extends TerraDrawModeBehavior {
 		event: TerraDrawMouseEvent,
 		filter: (feature: Feature) => boolean,
 	) {
-		const bbox = this.clickBoundingBox.create(event) as BBoxPolygon;
-
-		const features = this.store.search(bbox, filter);
-
-		const closest: { coord: undefined | Position; minDist: number } = {
+		const boundingBox = this.clickBoundingBox.create(event) as BBoxPolygon;
+		const features = this.store.search(boundingBox, filter);
+		const closest: { coord: undefined | Position; minDistance: number } = {
 			coord: undefined,
-			minDist: Infinity,
+			minDistance: Infinity,
 		};
 
 		features.forEach((feature) => {
@@ -59,13 +59,36 @@ export class SnappingBehavior extends TerraDrawModeBehavior {
 				return;
 			}
 
-			coordinates.forEach((coord) => {
-				const dist = this.pixelDistance.measure(event, coord);
-				if (dist < closest.minDist && dist < this.pointerDistance) {
-					closest.coord = coord;
-					closest.minDist = dist;
-				}
-			});
+			const lines: [Position, Position][] = [];
+
+			for (let i = 0; i < coordinates.length - 1; i++) {
+				lines.push([coordinates[i], coordinates[i + 1]]);
+			}
+
+			let nearest:
+				| {
+						coordinate: Position;
+						distance: number;
+				  }
+				| undefined;
+
+			const lngLat: Position = [event.lng, event.lat];
+
+			if (this.config.projection === "web-mercator") {
+				nearest = webMercatorNearestPointOnLine(lngLat, lines);
+			} else if (this.config.projection === "globe") {
+				nearest = nearestPointOnLine(lngLat, lines);
+			}
+
+			if (!nearest) {
+				return;
+			}
+
+			const distance = this.pixelDistance.measure(event, nearest.coordinate);
+			if (distance < closest.minDistance && distance < this.pointerDistance) {
+				closest.coord = nearest.coordinate;
+				closest.minDistance = distance;
+			}
 		});
 
 		return closest.coord;

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -271,7 +271,11 @@ describe("TerraDrawPolygonMode", () => {
 		});
 
 		it("can create a polygon with snapping enabled", () => {
-			polygonMode = new TerraDrawPolygonMode({ snapping: true });
+			polygonMode = new TerraDrawPolygonMode({
+				snapping: {
+					toCoordinate: true,
+				},
+			});
 			const mockConfig = MockModeConfig(polygonMode.mode);
 			store = mockConfig.store;
 			polygonMode.register(mockConfig);

--- a/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -1,4 +1,9 @@
-import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
+import {
+	CartesianPoint,
+	TerraDrawMouseEvent,
+	UpdateTypes,
+	Validation,
+} from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { LineString, Polygon, Position, Point, Feature } from "geojson";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
@@ -278,9 +283,9 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	}: {
 		closestBBoxIndex: BoundingBoxIndex;
 		updatedCoords: Position[];
-		webMercatorCursor: { x: number; y: number };
-		webMercatorSelected: { x: number; y: number };
-		webMercatorOrigin: { x: number; y: number };
+		webMercatorCursor: CartesianPoint;
+		webMercatorSelected: CartesianPoint;
+		webMercatorOrigin: CartesianPoint;
 	}) {
 		const cursorDistanceX = webMercatorOrigin.x - webMercatorCursor.x;
 		const cursorDistanceY = webMercatorOrigin.y - webMercatorCursor.y;
@@ -393,9 +398,9 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	}: {
 		closestBBoxIndex: BoundingBoxIndex;
 		updatedCoords: Position[];
-		webMercatorCursor: { x: number; y: number };
-		webMercatorSelected: { x: number; y: number };
-		webMercatorOrigin: { x: number; y: number };
+		webMercatorCursor: CartesianPoint;
+		webMercatorSelected: CartesianPoint;
+		webMercatorOrigin: CartesianPoint;
 	}) {
 		const cursorDistanceX = webMercatorOrigin.x - webMercatorCursor.x;
 		const cursorDistanceY = webMercatorOrigin.y - webMercatorCursor.y;
@@ -574,7 +579,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 
 	private getIndexesWebMercator(
 		boundingBox: BoundingBox,
-		selectedXY: { x: number; y: number },
+		selectedXY: CartesianPoint,
 	) {
 		let closestIndex: BoundingBoxIndex | undefined;
 		let closestDistance = Infinity;


### PR DESCRIPTION
## Description of Changes

This PR sets up some breaking API changes for snapping, which paves the way for allowing snapping to lines as well as coordinates for the existing polygon mode features. Line and coordinate snapping can be enabled/disabled individually.

* Change polygon mode snapping property from optional boolean to optional object of type `{ toLine?: boolean;  toCoordinate?: boolean; }`
* Provides toLine which allows snapping to the line segments of polygon mode features
* Change linestring mode snapping property from optional boolean to optional object of type `{ toCoordinate?: boolean; }`
* Fixes bug with initial snapping of linestrings on the first coordinate click
* Add the `CartesianPoint` type to standardised x, y coordinates across the codebase

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/307

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 