### PR TITLE
feat: visualise snapping point and allow it to be styled

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -178,6 +178,7 @@ const getModes = () => {
 			// },
 		}),
 		new TerraDrawPolygonMode({
+			pointerDistance: 20,
 			snapping: {
 				toLine: true,
 				toCoordinate: true,
@@ -187,6 +188,9 @@ const getModes = () => {
 					return ValidateNotSelfIntersecting(feature);
 				}
 				return { valid: true };
+			},
+			styles: {
+				snappingPointColor: "#3fc8e0",
 			},
 		}),
 		new TerraDrawRectangleMode(),

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -128,8 +128,11 @@ const example = {
 					},
 				}),
 				new TerraDrawPointMode(),
-				new TerraDrawLineStringMode(
-					this.config?.includes("insertCoordinates")
+				new TerraDrawLineStringMode({
+					snapping: {
+						toCoordinate: this.config?.includes("snappingCoordinate"),
+					},
+					...(this.config?.includes("insertCoordinates")
 						? {
 								insertCoordinates: {
 									strategy: "amount",
@@ -144,8 +147,8 @@ const example = {
 									value: 10,
 								},
 						  }
-						: undefined,
-				),
+						: undefined),
+				}),
 				new TerraDrawPolygonMode({
 					validation:
 						this.config?.includes("validationSuccess") ||
@@ -159,6 +162,9 @@ const example = {
 									);
 							  }
 							: undefined,
+					snapping: {
+						toCoordinate: this.config?.includes("snappingCoordinate"),
+					},
 				}),
 				new TerraDrawRectangleMode(),
 				new TerraDrawCircleMode({

--- a/e2e/tests/setup.ts
+++ b/e2e/tests/setup.ts
@@ -8,7 +8,8 @@ export type TestConfigOptions =
 	| "insertCoordinates"
 	| "insertCoordinatesGlobe"
 	| "globeCircle"
-	| "globeSelect";
+	| "globeSelect"
+	| "snappingCoordinate";
 
 export const setupMap = async ({
 	page,

--- a/src/common.ts
+++ b/src/common.ts
@@ -171,6 +171,7 @@ export const SELECT_PROPERTIES = {
 	SELECTION_POINT: "selectionPoint",
 } as const;
 
-export const POLYGON_PROPERTIES = {
+export const COMMON_PROPERTIES = {
 	CLOSING_POINT: "closingPoint",
+	SNAPPING_POINT: "snappingPoint",
 };

--- a/src/modes/freehand/freehand.mode.ts
+++ b/src/modes/freehand/freehand.mode.ts
@@ -6,7 +6,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
-	POLYGON_PROPERTIES,
+	COMMON_PROPERTIES,
 } from "../../common";
 import { Polygon } from "geojson";
 
@@ -300,7 +300,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 					},
 					properties: {
 						mode: this.mode,
-						[POLYGON_PROPERTIES.CLOSING_POINT]: true,
+						[COMMON_PROPERTIES.CLOSING_POINT]: true,
 					},
 				},
 			]);

--- a/src/modes/polygon/behaviors/closing-points.behavior.ts
+++ b/src/modes/polygon/behaviors/closing-points.behavior.ts
@@ -1,6 +1,6 @@
 import { Point, Position } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
-import { POLYGON_PROPERTIES, TerraDrawMouseEvent } from "../../../common";
+import { COMMON_PROPERTIES, TerraDrawMouseEvent } from "../../../common";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
 
 export class ClosingPointsBehavior extends TerraDrawModeBehavior {
@@ -38,7 +38,7 @@ export class ClosingPointsBehavior extends TerraDrawModeBehavior {
 					} as Point,
 					properties: {
 						mode,
-						[POLYGON_PROPERTIES.CLOSING_POINT]: true,
+						[COMMON_PROPERTIES.CLOSING_POINT]: true,
 					},
 				},
 				// Final coordinate
@@ -49,7 +49,7 @@ export class ClosingPointsBehavior extends TerraDrawModeBehavior {
 					} as Point,
 					properties: {
 						mode,
-						[POLYGON_PROPERTIES.CLOSING_POINT]: true,
+						[COMMON_PROPERTIES.CLOSING_POINT]: true,
 					},
 				},
 			],

--- a/src/modes/polygon/polygon.mode.spec.ts
+++ b/src/modes/polygon/polygon.mode.spec.ts
@@ -863,7 +863,7 @@ describe("styleFeature", () => {
 		});
 	});
 
-	it("returns the correct styles for point", () => {
+	it("returns the correct styles for closing point", () => {
 		const polygonMode = new TerraDrawPolygonMode({
 			styles: {
 				fillColor: "#ffffff",
@@ -881,7 +881,35 @@ describe("styleFeature", () => {
 			polygonMode.styleFeature({
 				type: "Feature",
 				geometry: { type: "Point", coordinates: [] },
-				properties: { mode: "polygon" },
+				properties: { mode: "polygon", closingPoint: true },
+			}),
+		).toMatchObject({
+			pointWidth: 2,
+			pointColor: "#dddddd",
+			pointOutlineColor: "#222222",
+			pointOutlineWidth: 1,
+		});
+	});
+
+	it("returns the correct styles for snapping point", () => {
+		const polygonMode = new TerraDrawPolygonMode({
+			styles: {
+				fillColor: "#ffffff",
+				outlineColor: "#111111",
+				outlineWidth: 2,
+				fillOpacity: 0.5,
+				snappingPointWidth: 2,
+				snappingPointColor: "#dddddd",
+				snappingPointOutlineWidth: 1,
+				snappingPointOutlineColor: "#222222",
+			},
+		});
+
+		expect(
+			polygonMode.styleFeature({
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [] },
+				properties: { mode: "polygon", snappingPoint: true },
 			}),
 		).toMatchObject({
 			pointWidth: 2,


### PR DESCRIPTION
## Description of Changes

Provides visual feedback in the form of a point when snapping to line to make it clearer what is happening to the end user. The new behaviour looks like this:

<img width="642" alt="Screenshot 2024-12-23 at 12 37 51" src="https://github.com/user-attachments/assets/b383c7cc-a806-46d6-8fbb-0817ad264b32" />

## Link to Issue

#384 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 