### PR TITLE
feat: allow snapping to custom positions with toCustom snapping option

### DIFF
--- a/development/src/index.ts
+++ b/development/src/index.ts
@@ -180,8 +180,8 @@ const getModes = () => {
 		new TerraDrawPolygonMode({
 			pointerDistance: 20,
 			snapping: {
-				toLine: true,
-				toCoordinate: true,
+				toLine: false,
+				toCoordinate: false,
 			},
 			validation: (feature, { updateType }) => {
 				if (updateType === "finish" || updateType === "commit") {

--- a/e2e/tests/leaflet.spec.ts
+++ b/e2e/tests/leaflet.spec.ts
@@ -193,11 +193,13 @@ test.describe("linestring mode", () => {
 		test(`mode can set with snapping enabled used to create multiple linestrings${name}`, async ({
 			page,
 		}) => {
+			const configQueryParam: TestConfigOptions[] = config
+				? [...config, "snappingCoordinate"]
+				: ["snappingCoordinate"];
+
 			const mapDiv = await setupMap({
 				page,
-				configQueryParam: config
-					? [...config, "snappingCoordinate"]
-					: undefined,
+				configQueryParam,
 			});
 			await changeMode({ page, mode });
 

--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -156,6 +156,19 @@ Some specific modes support snapping, currently polygon and linestring mode. As 
   })
 ```
 
+We can also provide a `toCustom` function which allows snapping to some arbitrary position. This could be other features in the store, or some external data you have access too synchronously:
+
+```typescript
+  new TerraDrawPolygonMode({
+    snapping: {
+      toCustom: () => {
+        // You can return whatever position you want here, determined in any way you see fit!
+        return [0, 0] 
+      }
+    }
+  })
+```
+
 #### Projections in Drawing Modes
 
 As we move forward Terra Draw will work on supporting Web Mercator maps out the box with the ability to support Globes (i.e. 3D spherical representations of the earth with no projection) as a secondary option. This is made slightly more complicated by the fact we know sometimes users want to draw geodesic geometries on a web mercator map, for example a geodesic circle or a great circle line. In future we will better align by assuming developers want web mercator first behaviours, with secondary support for globes via the `projection` property for built in modes.
@@ -228,7 +241,7 @@ const selectMode = new TerraDrawSelectMode({
               // to geographic space and vice versa
 
               // ValidateMinAreaSquareMeters can be imported from Terra Draw
-					    return feature.geometry.type !== "Polygon" && ValidateMinAreaSquareMeters(feature.geometry, 1000);
+					    return ValidateMinAreaSquareMeters(feature.geometry, 1000);
           }
         },
       },

--- a/src/modes/linestring/linestring.mode.spec.ts
+++ b/src/modes/linestring/linestring.mode.spec.ts
@@ -338,6 +338,54 @@ describe("TerraDrawLineStringMode", () => {
 			expect(features[1].geometry.coordinates).toStrictEqual([2, 2]);
 		});
 
+		it("can snap from existing line once finished with snapping toCustom enabled", () => {
+			const coordinates = [
+				[5, 5],
+				[5, 5],
+				[5, 10],
+				[5, 10],
+				[10, 10],
+			];
+
+			lineStringMode = new TerraDrawLineStringMode({
+				snapping: {
+					toCustom: () => {
+						return coordinates.shift();
+					},
+				},
+			});
+
+			const mockConfig = MockModeConfig(lineStringMode.mode);
+			onChange = mockConfig.onChange;
+			onFinish = mockConfig.onFinish;
+			store = mockConfig.store;
+
+			lineStringMode.register(mockConfig);
+			lineStringMode.start();
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 0 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			expect(onFinish).toHaveBeenCalledTimes(1);
+			const features = store.copyAll();
+
+			expect(features.length).toBe(1);
+
+			expect(features[0].geometry.coordinates).toStrictEqual([
+				[5, 5],
+				[5, 10],
+				[10, 10],
+			]);
+		});
+
 		describe("validations", () => {
 			it("does create a line if it has intersections and no validation provided", () => {
 				lineStringMode = new TerraDrawLineStringMode();


### PR DESCRIPTION
## Description of Changes

This PR allows users to snap to some arbitrary position for Polygon and LineString modes. This can be useful in making it possible to snap to your own custom positions based on external data or some other criteria.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 