### PR TITLE
fix: export BaseAdapterConfig type from TerraDraw

### DIFF
--- a/src/terra-draw.ts
+++ b/src/terra-draw.ts
@@ -57,6 +57,7 @@ import { TerraDrawSensorMode } from "./modes/sensor/sensor.mode";
 import * as TerraDrawExtend from "./extend";
 import { hasModeProperty } from "./store/store-feature-validation";
 import { ValidationReasons } from "./validation-reasons";
+import type { BaseAdapterConfig } from "./adapters/common/base.adapter";
 
 type FinishListener = (id: FeatureId, context: OnFinishContext) => void;
 type ChangeListener = (ids: FeatureId[], type: string) => void;
@@ -830,6 +831,7 @@ export {
 	Unproject,
 	SetCursor,
 	GetLngLatFromEvent,
+	type BaseAdapterConfig,
 
 	// Validations
 	ValidateMinAreaSquareMeters,


### PR DESCRIPTION
## Description of Changes

I exported BaseAdapterConfig since I want to use this type for maplibre-gl-terradraw

## Link to Issue

fixes #392

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 