### PR TITLE
chore(terra-draw): add a dry run release script for terra-draw

### DIFF
--- a/.github/workflows/dry-run-release-terra-draw.yml
+++ b/.github/workflows/dry-run-release-terra-draw.yml
@@ -1,0 +1,40 @@
+name: Dry-run release terra-draw
+
+permissions:
+  contents: write
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TERRA_DRAW_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: npm ci
+
+      - name: Update Docs
+        run: npm run docs
+
+      - name: Run build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
+      - name: Set git credentials
+        run: |
+          git config --global user.email "terradraw@githubactions.com"
+          git config --global user.name "James Milner"
+
+      - name: Release
+        working-directory: ./packages/terra-draw
+        run: npm run release:dryrun


### PR DESCRIPTION
## Description of Changes

Adds a script that allows a dry-run release for the `terra-draw` package so we can see what changes will occur

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 