### PR TITLE
chore(terra-draw): ensure release script for terra-draw is named correctly

### DIFF
--- a/.github/workflows/release-terra-draw.yml
+++ b/.github/workflows/release-terra-draw.yml
@@ -1,4 +1,4 @@
-name: Dry-run release terra-draw
+name: Run release terra-draw
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description of Changes

Ensures the script is named correctly for releasing terra-draw package

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 