### PR TITLE
feat(terra-draw-maplibre-gl-adapter)!: breaking change commit to allow adapter to v1.0.0

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/package.json
+++ b/packages/terra-draw-maplibre-gl-adapter/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-beta.12",
 	"description": "Terra Draw Adapter for Maplibre GL JS",
 	"peerDependencies": {
-		"terra-draw": "^1.0.0-beta.12",
+		"terra-draw": "^1.0.0",
 		"maplibre-gl": ">=4"
 	},
 	"scripts": {


### PR DESCRIPTION
## Description of Changes

This PR will allow conventional commits to bump terra-draw-maplibre-gl-adapter to v1

## Link to Issue

#259 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 