### PR TITLE
chore(terra-draw): ensure terra-draw is built before trying to build adapters in releases

### DIFF
--- a/.github/workflows/terra-draw-arcgis-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-dry-run-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-arcgis-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-arcgis-adapter-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-arcgis-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
@@ -25,6 +25,10 @@ jobs:
 
       - name: Update Docs
         run: npm run docs
+      
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
 
       - name: Run build
         working-directory: ./packages/terra-draw-leaflet-adapter

--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -26,9 +26,15 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run build
+      
+
 
       - name: Set git credentials
         run: |

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-mapbox-gl-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-mapbox-gl-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-maplibre-gl-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-maplibre-gl-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-openlayers-adapter
         run: npm run build

--- a/.github/workflows/terra-draw-openlayers-adapter-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Update Docs
         run: npm run docs
 
+      - name: Run terra-draw build
+        working-directory: ./packages/terra-draw
+        run: npm run build
+
       - name: Run build
         working-directory: ./packages/terra-draw-openlayers-adapter
         run: npm run build


### PR DESCRIPTION
## Description of Changes

We need to ensure terra-draw is built before trying to build the terra-draw adapters in releases

## Link to Issue

#259 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 