### PR TITLE
chore(terra-draw): add a step to update package-lock.json for Leaflet

### DIFF
--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -34,8 +34,6 @@ jobs:
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run build
       
-
-
       - name: Set git credentials
         run: |
           git config --global user.email "terradraw@githubactions.com"
@@ -44,6 +42,19 @@ jobs:
       - name: Release
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run release
+
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
 
       - name: Push upstream
         run: git push origin main

--- a/package-lock.json
+++ b/package-lock.json
@@ -21912,7 +21912,7 @@
 			"license": "MIT"
 		},
 		"packages/terra-draw-arcgis-adapter": {
-			"version": "1.0.0-beta.12",
+			"version": "1.0.0",
 			"license": "MIT",
 			"peerDependencies": {
 				"@arcgis/core": "^4.31.6",
@@ -21920,7 +21920,7 @@
 			}
 		},
 		"packages/terra-draw-google-maps-adapter": {
-			"version": "1.0.0-beta.12",
+			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/google.maps": "^3.49.2"


### PR DESCRIPTION
## Description of Changes

This PR aims to make it so we can update the root package-lock.json as part of the release to avoid CI failures on the main branch after the merge

## Link to Issue

#259 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 