### PR TITLE
chore(terra-draw): remove package-lock.json update as part of release for now

### DIFF
--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -43,19 +43,6 @@ jobs:
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run release
 
-      - name: Check if package-lock.json changed
-        run: |
-          npm install
-
-          # Check if package-lock.json changed
-          if ! git diff --exit-code --quiet package-lock.json; then
-            echo "package-lock.json has changed"
-            git add package-lock.json
-            git commit -m "chore(terra-draw): update package-lock.json during CI release"
-          else
-            echo "No changes to package-lock.json"
-          fi
-
       - name: Push upstream
         run: git push origin main
 


### PR DESCRIPTION
## Description of Changes

I think this causes issues because the package isn't initially published yet. Will remove for now.

## Link to Issue

#259 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 