### PR TITLE
chore(terra-draw): fix leaflet adapter package version that does not exist for e2e package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21665,7 +21665,7 @@
 			"dependencies": {
 				"leaflet": "1.9.4",
 				"terra-draw": "1.0.0",
-				"terra-draw-leaflet-adapter": "1.0.0-beta.12"
+				"terra-draw-leaflet-adapter": "1.0.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.49.1",
@@ -21931,7 +21931,7 @@
 			}
 		},
 		"packages/terra-draw-leaflet-adapter": {
-			"version": "1.0.0-beta.12",
+			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/leaflet": "^1.9.15"

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"leaflet": "1.9.4",
 		"terra-draw": "1.0.0",
-		"terra-draw-leaflet-adapter": "1.0.0-beta.12"
+		"terra-draw-leaflet-adapter": "1.0.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.1",


### PR DESCRIPTION
## Description of Changes

Fixes the e2e tests package.json to reference correct version. We should look at automatically updating this on publish of the leaflet package.

## Link to Issue

#259 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 