### PR TITLE
chore(terra-draw): fix the getting started guides Leaflet adapter import

### DIFF
--- a/guides/1.GETTING_STARTED.md
+++ b/guides/1.GETTING_STARTED.md
@@ -48,7 +48,7 @@ And then in your code you would import it like so:
 
 ```javascript
 
-import TerraDrawLeafletAdapter from 'terra-draw-leaflet-adapter';
+import { TerraDrawLeafletAdapter } from 'terra-draw-leaflet-adapter';
 
 // Create an Adapter for Leaflet
 const adapter = new TerraDrawLeafletAdapter({ map, lib });


### PR DESCRIPTION
## Description of Changes

Resolves an issue in the docs where the example adapter is default imported

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 