### PR TITLE
fix(terra-draw-openlayers-adapter): ensure the README has correct links on npm

### DIFF
--- a/packages/terra-draw-openlayers-adapter/README.md
+++ b/packages/terra-draw-openlayers-adapter/README.md
@@ -1,7 +1,26 @@
 # TerraDrawOpenLayersAdapter
 
-This package is for the Terra Draw OpenLayers Adapter. You can find out more about what adapters are and how to use them in [the adapters guide](./../../guides/3.ADAPTERS.md). For a broader introduction to Terra Draw, check out the main [README](../../README.md) and the [getting started guide](../../guides/1.GETTING_STARTED.md).
+This package is for the [Terra Draw](https://www.github.com/JamesLMilner/terra-draw) OpenLayers JS Adapter. The package is designed be used in conjunction with the [`ol` package](https://www.npmjs.com/package/ol).
+
+## Getting Started
+
+For full getting started instructions for Terra Draw please read the [getting started guide in the GitHub repository](https://github.com/JamesLMilner/terra-draw/blob/main/guides/1.GETTING_STARTED.md). To get started with the OpenLayers adapter, please see the detailed [guide on adapters in the GitHub repository](https://github.com/JamesLMilner/terra-draw/blob/main/guides/3.ADAPTERS.md) to understand which are supported and how to get started with them. The guide has a specific section on the [TerraDrawOpenLayersAdapter](https://github.com/JamesLMilner/terra-draw/blob/main/guides/3.ADAPTERS.md#openlayers).
+
+
+#### Installation
+
+Installing the core package and this adapter can be done like so:
+
+```shell
+npm install terra-draw terra-draw-openlayers-adapter
+```
+
+#### Quick Links
+
+* [TerraDrawOpenLayersAdapter API Docs](https://jameslmilner.github.io/terra-draw/classes/terra_draw_openlayers_adapter.TerraDrawOpenLayersAdapter.html)
+* [GitHub Repository](https://www.github.com/JamesLMilner/terra-draw)
+* [Website](https://terradraw.io)
 
 ## License 
 
-[MIT](../../LICENSE)
+[MIT](https://github.com/JamesLMilner/terra-draw/blob/main/LICENSE)


### PR DESCRIPTION
## Description of Changes

PR aims to add a better documented README to the terra-draw-openlayers-adapter npm package.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 