### PR TITLE
chore(terra-draw): automatically update root package-lock.json on release by actions

### DIFF
--- a/.github/workflows/terra-draw-arcgis-adapter-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-release.yml
@@ -43,6 +43,18 @@ jobs:
         working-directory: ./packages/terra-draw-arcgis-adapter
         run: npm run release
 
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): automated update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
+
       - name: Push upstream
         run: git push origin main
 

--- a/.github/workflows/terra-draw-google-maps-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-google-maps-adapter-dry-run-release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw-google-maps-adapter
         run: npm run release:dryrun
  

--- a/.github/workflows/terra-draw-google-maps-adapter-release.yml
+++ b/.github/workflows/terra-draw-google-maps-adapter-release.yml
@@ -43,6 +43,18 @@ jobs:
         working-directory: ./packages/terra-draw-google-maps-adapter
         run: npm run release
 
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): automated update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
+
       - name: Push upstream
         run: git push origin main
 

--- a/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run release:dryrun
  

--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -43,6 +43,18 @@ jobs:
         working-directory: ./packages/terra-draw-leaflet-adapter
         run: npm run release
 
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): automated update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
+
       - name: Push upstream
         run: git push origin main
 

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw-mapbox-gl-adapter
         run: npm run release:dryrun
  

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
@@ -43,6 +43,18 @@ jobs:
         working-directory: ./packages/terra-draw-mapbox-gl-adapter
         run: npm run release
 
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): automated update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
+
       - name: Push upstream
         run: git push origin main
 

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw-maplibre-gl-adapter
         run: npm run release:dryrun
  

--- a/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw-openlayers-adapter
         run: npm run release:dryrun
  

--- a/.github/workflows/terra-draw-openlayers-adapter-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-release.yml
@@ -43,6 +43,18 @@ jobs:
         working-directory: ./packages/terra-draw-openlayers-adapter
         run: npm run release
 
+      - name: Check if package-lock.json changed
+        run: |
+          npm install
+          # Check if package-lock.json changed
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "package-lock.json has changed"
+            git add package-lock.json
+            git commit -m "chore(terra-draw): automated update package-lock.json during CI release"
+          else
+            echo "No changes to package-lock.json"
+          fi
+
       - name: Push upstream
         run: git push origin main
 

--- a/.github/workflows/terra-draw-release-dry-run.yml
+++ b/.github/workflows/terra-draw-release-dry-run.yml
@@ -35,6 +35,6 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Dry Run Release
         working-directory: ./packages/terra-draw
         run: npm run release:dryrun


### PR DESCRIPTION
## Description of Changes

Ensure that the root package-lock.json file is updated when a new package is released

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 