### PR TITLE
fix(terra-draw): resolve issue where coordinates cannot be draggable if feature id is 0

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -90,7 +90,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		allowSelfIntersection: boolean,
 		validateFeature?: Validation,
 	): boolean {
-		if (!this.draggedCoordinate.id) {
+		if (this.draggedCoordinate.id == null) {
 			return false;
 		}
 		const index = this.draggedCoordinate.index;

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -90,7 +90,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		allowSelfIntersection: boolean,
 		validateFeature?: Validation,
 	): boolean {
-		if (this.draggedCoordinate.id == null) {
+		if (this.draggedCoordinate.id === null) {
 			return false;
 		}
 		const index = this.draggedCoordinate.index;


### PR DESCRIPTION
## Description of Changes

fix coordinates cannot be draggable if feature id is 0

<!--- Please provide a summary of the changes you have made -->

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/422

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 