### PR TITLE
chore(terra-draw): ensure the actions/checkout action is used in the commit-lint-prs.yml action

### DIFF
--- a/.github/workflows/commit-lint-prs.yml
+++ b/.github/workflows/commit-lint-prs.yml
@@ -11,6 +11,11 @@ jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
       - name: PR Conventional Commit Validation Against Commit Lint Config
         env:
             TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Description of Changes

Without the checkout action we don't actually get the repository code. This PR fixes that and ensures the branch is actually checked out correctly.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 