### PR TITLE
chore(terra-draw): ensure that local version of commit lint is used for commit-lint-prs.yml

### DIFF
--- a/.github/workflows/commit-lint-prs.yml
+++ b/.github/workflows/commit-lint-prs.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22.x"
+      - name: Install packages
+        run: npm ci
       - name: PR Conventional Commit Validation Against Commit Lint Config
         env:
             TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Description of Changes

The current version of commit-lint-prs.yml does not install the packages, which I believe is causing it to use the latest version of commit-lint. This appears to be failing for a reason I haven't investigated, but as this works locally I assume it because two major versions different between what's installed and what is the latest version of commit-lint. This PR adds a `npm ci` to install the current versions.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 