### PR TITLE
feat(terra-draw): add editable option for point mode to allow moving points whilst drawing

### DIFF
--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -131,7 +131,9 @@ const example = {
 						},
 					},
 				}),
-				new TerraDrawPointMode(),
+				new TerraDrawPointMode({
+					editable: this.config?.includes("pointEditable"),
+				}),
 				new TerraDrawLineStringMode({
 					snapping: {
 						toCoordinate: this.config?.includes("snappingCoordinate"),

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -71,6 +71,28 @@ test.describe("point mode", () => {
 
 		await expectPaths({ page, count: 3 });
 	});
+
+	test("mode can set with editable set to true and points can be moved", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["pointEditable"],
+		});
+		await changeMode({ page, mode });
+
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+		await expectGroupPosition({ page, x: 633, y: 353 });
+
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 2);
+		await page.mouse.down();
+		await page.mouse.move(mapDiv.width / 3, mapDiv.height / 3);
+		await page.mouse.up();
+
+		await expectPaths({ page, count: 1 });
+
+		await expectGroupPosition({ page, x: 419, y: 233 });
+	});
 });
 
 test.describe("linestring mode", () => {

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -3,6 +3,7 @@ import { Page, expect } from "@playwright/test";
 export const pageUrl = "http://localhost:3000/";
 
 export type TestConfigOptions =
+	| "pointEditable"
 	| "validationSuccess"
 	| "validationFailure"
 	| "insertCoordinates"

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -172,6 +172,7 @@ export const SELECT_PROPERTIES = {
 } as const;
 
 export const COMMON_PROPERTIES = {
+	EDITED: "edited",
 	CLOSING_POINT: "closingPoint",
 	SNAPPING_POINT: "snappingPoint",
 };

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -5,8 +5,14 @@ import {
 	HexColorStyling,
 	Cursor,
 	UpdateTypes,
+	COMMON_PROPERTIES,
 } from "../../common";
-import { GeoJSONStoreFeatures, StoreValidation } from "../../store/store";
+import {
+	BBoxPolygon,
+	FeatureId,
+	GeoJSONStoreFeatures,
+	StoreValidation,
+} from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
@@ -14,39 +20,63 @@ import {
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidatePointFeature } from "../../validations/point.validation";
-import { Point } from "geojson";
+import { Point, Position } from "geojson";
+import { BehaviorConfig } from "../base.behavior";
+import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
+import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 
 type PointModeStyling = {
 	pointWidth: NumericStyling;
 	pointColor: HexColorStyling;
 	pointOutlineColor: HexColorStyling;
 	pointOutlineWidth: NumericStyling;
+	editedPointColor: HexColorStyling;
+	editedPointWidth: NumericStyling;
+	editedPointOutlineColor: HexColorStyling;
+	editedPointOutlineWidth: NumericStyling;
 };
 
 interface Cursors {
 	create?: Cursor;
+	dragStart?: Cursor;
+	dragEnd?: Cursor;
 }
 
 interface TerraDrawPointModeOptions<T extends CustomStyling>
 	extends BaseModeOptions<T> {
 	cursors?: Cursors;
+	editable?: boolean;
 }
 
 export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> {
 	mode = "point";
 
 	private cursors: Required<Cursors>;
+	private editable: boolean;
+	private editedFeatureId: FeatureId | undefined;
+
+	// Behaviors
+	private pixelDistance!: PixelDistanceBehavior;
+	private clickBoundingBox!: ClickBoundingBoxBehavior;
 
 	constructor(options?: TerraDrawPointModeOptions<PointModeStyling>) {
 		super(options);
 		const defaultCursors = {
 			create: "crosshair",
+			dragStart: "grabbing",
+			dragEnd: "crosshair",
 		} as Required<Cursors>;
 
 		if (options && options.cursors) {
 			this.cursors = { ...defaultCursors, ...options.cursors };
 		} else {
 			this.cursors = defaultCursors;
+		}
+
+		if (options && options.editable) {
+			this.editable = options.editable;
+		} else {
+			this.editable = false;
 		}
 	}
 
@@ -112,16 +142,147 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 	onKeyUp() {}
 
 	/** @internal */
-	cleanUp() {}
+	cleanUp() {
+		this.editedFeatureId = undefined;
+	}
+
+	onDragStart(
+		event: TerraDrawMouseEvent,
+		setMapDraggability: (enabled: boolean) => void,
+	) {
+		if (this.editable) {
+			const bbox = this.clickBoundingBox.create(event) as BBoxPolygon;
+			const features = this.store.search(bbox);
+
+			let distance = Infinity;
+			let clickedFeature: GeoJSONStoreFeatures | undefined = undefined;
+
+			for (let i = 0; i < features.length; i++) {
+				const feature = features[i];
+				const isPoint =
+					feature.geometry.type === "Point" &&
+					feature.properties.mode === this.mode;
+
+				if (!isPoint) {
+					continue;
+				}
+
+				const position = feature.geometry.coordinates as Position;
+				const distanceToFeature = this.pixelDistance.measure(event, position);
+
+				if (
+					distanceToFeature > distance ||
+					distanceToFeature > this.pointerDistance
+				) {
+					continue;
+				}
+
+				distance = distanceToFeature;
+				clickedFeature = feature;
+			}
+
+			if (clickedFeature) {
+				this.editedFeatureId = clickedFeature.id;
+			}
+		}
+
+		// We only need to stop the map dragging if
+		// we actually have something selected
+		if (!this.editedFeatureId) {
+			return;
+		}
+
+		// Drag Feature
+		this.setCursor(this.cursors.dragStart);
+
+		setMapDraggability(false);
+	}
 
 	/** @internal */
-	onDragStart() {}
+	onDrag(
+		event: TerraDrawMouseEvent,
+		setMapDraggability: (enabled: boolean) => void,
+	) {
+		if (this.editedFeatureId === undefined) {
+			return;
+		}
+
+		const newGeometry = {
+			type: "Point",
+			coordinates: [event.lng, event.lat],
+		};
+
+		if (this.validate) {
+			const validationResult = this.validate(
+				{
+					type: "Feature",
+					geometry: newGeometry,
+					properties: this.store.getPropertiesCopy(this.editedFeatureId),
+				} as GeoJSONStoreFeatures,
+				{
+					project: this.project,
+					unproject: this.unproject,
+					coordinatePrecision: this.coordinatePrecision,
+					updateType: UpdateTypes.Finish,
+				},
+			);
+
+			if (!validationResult.valid) {
+				return;
+			}
+		}
+
+		// For cursor points we can simply move it
+		// to the dragged position
+		this.store.updateGeometry([
+			{
+				id: this.editedFeatureId,
+				geometry: {
+					type: "Point",
+					coordinates: [event.lng, event.lat],
+				},
+			},
+		]);
+
+		this.store.updateProperty([
+			{
+				id: this.editedFeatureId,
+				property: COMMON_PROPERTIES.EDITED,
+				value: true,
+			},
+		]);
+
+		setMapDraggability(true);
+	}
 
 	/** @internal */
-	onDrag() {}
+	onDragEnd(
+		_: TerraDrawMouseEvent,
+		setMapDraggability: (enabled: boolean) => void,
+	) {
+		if (this.editedFeatureId === undefined) {
+			return;
+		}
 
-	/** @internal */
-	onDragEnd() {}
+		this.onFinish(this.editedFeatureId, { mode: this.mode, action: "edit" });
+
+		this.setCursor(this.cursors.dragEnd);
+
+		this.store.updateProperty([
+			{
+				id: this.editedFeatureId,
+				property: COMMON_PROPERTIES.EDITED,
+				value: false,
+			},
+		]);
+		this.editedFeatureId = undefined;
+		setMapDraggability(true);
+	}
+
+	registerBehaviors(config: BehaviorConfig) {
+		this.pixelDistance = new PixelDistanceBehavior(config);
+		this.clickBoundingBox = new ClickBoundingBoxBehavior(config);
+	}
 
 	/** @internal */
 	styleFeature(feature: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
@@ -132,26 +293,34 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			feature.geometry.type === "Point" &&
 			feature.properties.mode === this.mode
 		) {
+			const isEdited = Boolean(
+				feature.id && this.editedFeatureId === feature.id,
+			);
+
 			styles.pointWidth = this.getNumericStylingValue(
-				this.styles.pointWidth,
+				isEdited ? this.styles.editedPointWidth : this.styles.pointWidth,
 				styles.pointWidth,
 				feature,
 			);
 
 			styles.pointColor = this.getHexColorStylingValue(
-				this.styles.pointColor,
+				isEdited ? this.styles.editedPointColor : this.styles.pointColor,
 				styles.pointColor,
 				feature,
 			);
 
 			styles.pointOutlineColor = this.getHexColorStylingValue(
-				this.styles.pointOutlineColor,
+				isEdited
+					? this.styles.editedPointOutlineColor
+					: this.styles.pointOutlineColor,
 				styles.pointOutlineColor,
 				feature,
 			);
 
 			styles.pointOutlineWidth = this.getNumericStylingValue(
-				this.styles.pointOutlineWidth,
+				isEdited
+					? this.styles.editedPointOutlineWidth
+					: this.styles.pointOutlineWidth,
 				2,
 				feature,
 			);


### PR DESCRIPTION
## Description of Changes

Gives an `editable` option to the `TerraDrawPointMode` which allows the points to me moved whilst still drawing. This allows for a closer experience to what OpenLayers offers out the box.

## Link to Issue

#433 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 