### PR TITLE
feat(terra-draw): add editable option for polygon mode to allow moving polygons whilst drawing

### DIFF
--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -168,6 +168,7 @@ const example = {
 									);
 								}
 							: undefined,
+					editable: this.config?.includes("polygonEditable"),
 					snapping: {
 						toCoordinate: this.config?.includes("snappingCoordinate"),
 					},

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -422,6 +422,116 @@ test.describe("polygon mode", () => {
 
 		await expectPaths({ page, count: 3 });
 	});
+
+	test("can use editable setting to edit drawn polygon by dragging one of it's coordinates", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["polygonEditable"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
+
+		await page.mouse.move(topLeft.x, topLeft.y);
+		await page.mouse.down();
+		await page.mouse.move(topLeft.x - 100, topLeft.y - 10, { steps: 30 });
+
+		// Check to see the editable point has appeared
+		await expectPaths({ page, count: 2 });
+
+		// Stop editing (dragging)
+		await page.mouse.up();
+
+		// Check to see the editable point has disappeared
+		await expectPaths({ page, count: 1 });
+
+		// Check to see the dimensions have changed due to the edit
+		await expectPathDimensions({ page, width: 204, height: 114 });
+	});
+
+	test("can use editable setting to edit drawn polygon by dragging on one of it's lines", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["polygonEditable"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topMiddle = { x: centerX, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
+
+		const offset = 20;
+		await page.mouse.move(topMiddle.x, topMiddle.y);
+		await page.mouse.down();
+		await page.mouse.move(topMiddle.x, topLeft.y - offset, { steps: 30 });
+
+		// Check to see the editable point has appeared
+		await expectPaths({ page, count: 2 });
+
+		// Stop editing (dragging)
+		await page.mouse.up();
+
+		// Check to see the editable point has disappeared
+		await expectPaths({ page, count: 1 });
+
+		// Check to see the dimensions have changed due to the edit
+		await expectPathDimensions({ page, width: 104, height: 104 + offset });
+	});
 });
 
 test.describe("rectangle mode", () => {

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -3,6 +3,7 @@ import { Page, expect } from "@playwright/test";
 export const pageUrl = "http://localhost:3000/";
 
 export type TestConfigOptions =
+	| "polygonEditable"
 	| "pointEditable"
 	| "validationSuccess"
 	| "validationFailure"

--- a/packages/terra-draw/src/geometry/point-on-line.ts
+++ b/packages/terra-draw/src/geometry/point-on-line.ts
@@ -12,10 +12,12 @@ export function nearestPointOnLine(
 	| {
 			coordinate: Position;
 			distance: number;
+			lineIndex: number;
 	  }
 	| undefined {
 	let closestPoint: Position = [Infinity, Infinity];
 	let closestDistance = Infinity;
+	let lineIndex = 0;
 
 	for (let line of lines) {
 		const startPosition: Position = line[0];
@@ -54,13 +56,14 @@ export function nearestPointOnLine(
 			if (intersectDistance < closestDistance) {
 				closestPoint = intersectPosition;
 				closestDistance = intersectDistance;
+				lineIndex = lines.indexOf(line);
 			}
 		}
 	}
 
 	return closestDistance === Infinity
 		? undefined
-		: { coordinate: closestPoint, distance: closestDistance };
+		: { coordinate: closestPoint, distance: closestDistance, lineIndex };
 }
 
 /*

--- a/packages/terra-draw/src/geometry/web-mercator-point-on-line.ts
+++ b/packages/terra-draw/src/geometry/web-mercator-point-on-line.ts
@@ -21,11 +21,13 @@ export function webMercatorNearestPointOnLine(
 ):
 	| {
 			coordinate: Position;
+			lineIndex: number;
 			distance: number;
 	  }
 	| undefined {
 	let closestPoint: Position = [Infinity, Infinity];
 	let closestDistance = Infinity;
+	let lineIndex = 0;
 
 	for (let line of lines) {
 		const startPosition: Position = line[0];
@@ -70,13 +72,18 @@ export function webMercatorNearestPointOnLine(
 			if (intersectDistance < closestDistance) {
 				closestPoint = intersectPosition;
 				closestDistance = intersectDistance;
+				lineIndex = lines.indexOf(line);
 			}
 		}
 	}
 
 	return closestDistance === Infinity
 		? undefined
-		: { coordinate: closestPoint, distance: closestDistance };
+		: {
+				coordinate: closestPoint,
+				lineIndex: lineIndex,
+				distance: closestDistance,
+			};
 }
 
 /**


### PR DESCRIPTION
## Description of Changes

Gives an editable option to the TerraDrawPolygonMode which allows the polygons to be edited whilst still drawing. This allows for a closer experience to what OpenLayers offers out the box.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/433

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 