### PR TITLE
chore(terra-draw): add default title for the documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation improvement
 about: Suggest an improvement to the project documentation
-title: ''
+title: '[Documentation]'
 labels: documentation
 assignees: ''
 


### PR DESCRIPTION
## Description of Changes

Ensure a default title is provided for Documentation GitHub issue template

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 