### PR TITLE
fix(terra-draw): fix issue deleting line string coordinate points in select mode

### DIFF
--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -340,7 +340,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			coordinates = geometry.coordinates;
 
 			// Prevent creating an invalid linestring
-			if (coordinates.length <= 3) {
+			if (coordinates.length <= 2) {
 				return;
 			}
 		}
@@ -350,10 +350,11 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			return;
 		}
 
-		if (
-			(geometry.type === "Polygon" && coordinateIndex === 0) ||
-			coordinateIndex === coordinates.length - 1
-		) {
+		const isFinalPolygonCoordinate =
+			geometry.type === "Polygon" &&
+			(coordinateIndex === 0 || coordinateIndex === coordinates.length - 1);
+
+		if (isFinalPolygonCoordinate) {
 			// Deleting the final coordinate in a polygon breaks it
 			// because GeoJSON expects a duplicate, so we need to fix
 			// it by adding the new first coordinate to the end


### PR DESCRIPTION
## Description of Changes

Fixes an issue where a right click to delete code branch meant for polygons was getting hit for linestrings if the last coordinate was deleted.

## Link to Issue

#437

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 