### PR TITLE
fix(terra-draw): ensure getFeaturesAtPointerEvent has optional options properties

### DIFF
--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -605,6 +605,53 @@ describe("Terra Draw", () => {
 
 			expect(features).toHaveLength(1);
 		});
+
+		it("gets features at a given longitude and latitude within a given pointer distance", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [new TerraDrawPointMode()],
+			});
+
+			draw.start();
+
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [0, 0],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+				{
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [50, 50],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			adapter.getLngLatFromEvent = jest.fn(() => ({ lng: 50, lat: 50 }));
+
+			const features = draw.getFeaturesAtPointerEvent(
+				{
+					clientX: 50,
+					clientY: 50,
+				} as PointerEvent,
+				{
+					pointerDistance: 10,
+				},
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.coordinates).toEqual([50, 50]);
+		});
 	});
 
 	describe("start and stop", () => {

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -324,7 +324,7 @@ class TerraDraw {
 			lng: number;
 			lat: number;
 		},
-		options?: { pointerDistance: number; ignoreSelectFeatures: boolean },
+		options?: { pointerDistance?: number; ignoreSelectFeatures?: boolean },
 	) {
 		const pointerDistance =
 			options && options.pointerDistance !== undefined
@@ -682,13 +682,12 @@ class TerraDraw {
 	}
 
 	/**
-	 * Takes a given pointer event and
-	 * Will return point and linestrings that are a given pixel distance
-	 * away from the lng/lat and any polygons which contain it.
+	 * Takes a given pointer event and will return point and linestrings that are
+	 * a given pixel distance away from the longitude/latitude, and any polygons which contain it.
 	 */
 	getFeaturesAtPointerEvent(
 		event: PointerEvent | MouseEvent,
-		options?: { pointerDistance: number; ignoreSelectFeatures: boolean },
+		options?: { pointerDistance?: number; ignoreSelectFeatures?: boolean },
 	) {
 		const getLngLatFromEvent = this._adapter.getLngLatFromEvent.bind(
 			this._adapter,


### PR DESCRIPTION
## Description of Changes

Ensures `getFeaturesAtPointerEvent` can be passed with partial options, as defaults are provided  in `featuresAtLocation`

## Link to Issue

#435 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 