### PR TITLE
chore(terra-draw): improve local development experience by using package src files rather than dist

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -174,7 +174,7 @@ We can also provide a `toCustom` function which allows snapping to some arbitrar
 As we move forward Terra Draw will work on supporting Web Mercator maps out the box with the ability to support Globes (i.e., 3D spherical representations of the earth with no projection) as a secondary option. This is made slightly more complicated by the fact we know sometimes users want to draw geodesic geometries on a web mercator map, for example a geodesic circle or a great circle line. In future we will better align by assuming developers want web mercator first behaviours, with secondary support for globes via the `projection` property for built in modes.
 
 * Circle mode currently supports both web mercator and geodesic circles, using the `projection` property, which can be `globe` or `web-mercator` (default is `web-mercator`)
-* Select mode currently supports both web mercator and geodesic editing (scaling, rotating), although resizeable property currently only supports `web-mercator` as `projection` (default is `web-mercator`)
+* Select mode currently supports both web mercator and geodesic editing (scaling, rotating), although `resizable` property currently only supports `web-mercator` as `projection` (default is `web-mercator`)
 
 Note: If you want to draw great circle lines on a web mercator map, this is possible. Historically there was a specific mode called 'TerraGreatCircleMode' however this was deprecated in favour of supporting it directly in `TerraDrawLineStringMode`. You can achieve the same effect, by using the `projection` property and setting it to `globe` and using the `insertCoordinates` property in conjunction with it, like so: 
 
@@ -229,7 +229,7 @@ const selectMode = new TerraDrawSelectMode({
           // center will allow resizing of the aspect ratio from the center
           // and opposite allows resizing from the opposite corner of the 
           // bounding box of the geometry. 
-          resizeable: 'center', // can also be 'opposite', 'center-fixed', 'opposite-fixed'
+          resizable: 'center', // can also be 'opposite', 'center-fixed', 'opposite-fixed'
 
           // Can be deleted
           deletable: true,

--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -51,7 +51,7 @@ This will increment the major version on release, i.e. v1.0.0 -> v2.0.0. `feat` 
 - Webpack - used for bundling locally in development (`development` and `docs` folders)
 - esno - for running tests quickly without type checking
 
-## Building the Project
+## Building the Terra Draw Packages
 
 To build the project, you will need to install the dependencies from the project root:
 
@@ -59,32 +59,29 @@ To build the project, you will need to install the dependencies from the project
 npm install
 ```
 
+You will also need to then install in the package you are interested in building. Let's go to the folder and then install in there too:
 
-You may also need to change directory to e2e and install dependencies in there too.
+```shell
+cd packages/terra-draw
+npm install
+```
 
-You can then build the project using:
+Then we can run the following to build that specific package:
 
 ```shell
 npm run build
 ```
 
-## Creating a watching build
+## Developing Locally
 
-You can also create a watching build that detects changes and rebuilds the project automatically. This can help when developing locally.
-To create a watching build, first from the root level of the project go into the `e2e` folder and install the dependencies for the tests.
-
-```shell
-cd e2e/
-npm install
-```
-After that, from the root level go into the `development` folder and install the dependencies.
+One of the simplest way to start developing locally is in the `packages/development` folder. This project is designed to allow quick and efficient testing of changes on the fly. It is designed to respond in real time to changes when you are developing the Terra Draw packages locally. First thing is to go into the development folder and install:
 
 ```shell
 cd development/
 npm install
 ```
 
-If you don't have the API keys for GoogleAPI and Mapbox, comment out the corresponding libraries inside `development\src\config.ts`.
+The demo application that development builds shows all mapping libraries simultaneously side by side. You can control which mapping libraries get rendered via the `development\src\config.ts` file. If you don't have the API keys for Google Maps API and Mapbox, comment out the corresponding libraries inside `development\src\config.ts`.
 
 ```typescript
 export const Config = {
@@ -98,9 +95,25 @@ export const Config = {
 	] as const,
 };
 ```
+
 If you do have the API keys, refer to the `README.md` file inside the `development` folder to see how to set up the `.env` file with the APIs keys.
 
-After that, you can run the following command to start the watching build, inside the `development` folder.
+If you just wanted to run one mapping library in the demo app, say for example MapLibre, you can do that like so:
+
+```typescript
+export const Config = {
+	libraries: [
+		// Libraries.Leaflet,
+		Libraries.MapLibre,
+		// Libraries.Mapbox,
+		// Libraries.Google,
+		// Libraries.OpenLayers,
+		// Libraries.ArcGIS,
+	] as const,
+};
+```
+
+After that, you can run the following command to start the watching build, inside the `packages/development` folder.
 
 ```shell
 npm run serve

--- a/packages/development/src/index.ts
+++ b/packages/development/src/index.ts
@@ -13,20 +13,20 @@ import {
 	TerraDrawSectorMode,
 	ValidateMinAreaSquareMeters,
 	ValidateNotSelfIntersecting,
-} from "terra-draw";
+} from "../../terra-draw/src/terra-draw";
 
-import { TerraDrawMapboxGLAdapter } from "terra-draw-mapbox-gl-adapter";
-import { TerraDrawLeafletAdapter } from "terra-draw-leaflet-adapter";
-import { TerraDrawGoogleMapsAdapter } from "terra-draw-google-maps-adapter";
-import { TerraDrawMapLibreGLAdapter } from "terra-draw-maplibre-gl-adapter";
-import { TerraDrawArcGISMapsSDKAdapter } from "terra-draw-arcgis-adapter";
-import { TerraDrawOpenLayersAdapter } from "terra-draw-openlayers-adapter";
+import { TerraDrawMapboxGLAdapter } from "../../terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter";
+import { TerraDrawLeafletAdapter } from "../../terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter";
+import { TerraDrawGoogleMapsAdapter } from "../../terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter";
+import { TerraDrawMapLibreGLAdapter } from "../../terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter";
+import { TerraDrawArcGISMapsSDKAdapter } from "../../terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter";
+import { TerraDrawOpenLayersAdapter } from "../../terra-draw-openlayers-adapter/src/terra-draw-openlayers-adapter";
 
 // Mapbox
 import mapboxgl from "mapbox-gl";
 
 // MapLibre
-import maplibregl from "maplibre-gl";
+import maplibregl, { StyleSpecification } from "maplibre-gl";
 
 // Leaflet
 import * as L from "leaflet";
@@ -372,7 +372,7 @@ const example = {
 
 		const map = new maplibregl.Map({
 			container: this.generateId(Libraries.MapLibre),
-			style: OSMStyle as maplibregl.StyleSpecification,
+			style: OSMStyle as StyleSpecification,
 			center: [lng, lat],
 			zoom: zoom,
 		});

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -1736,7 +1736,7 @@ describe("TerraDrawSelectMode", () => {
 			});
 		});
 
-		it("fires onFinish for resizeable if it is currently being dragged", () => {
+		it("fires onFinish for resizable if it is currently being dragged", () => {
 			setSelectMode({
 				flags: {
 					polygon: {

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -638,7 +638,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		) {
 			this.setCursor(this.cursors.dragStart);
 
-			// With resizeable
+			// With resizable
 			if (modeFlags.feature.coordinates.resizable) {
 				this.dragCoordinateResizeFeature.startDragging(
 					selectedId,


### PR DESCRIPTION
## Description of Changes

* Use src rather than `dist` when referencing other packages from `development`
* Improve `7.DEVELOPMENT.md` to reflect changes 
* Small fixes to documentation around misspelt `resizeable` in docs

## Link to Issue

#448

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 