### PR TITLE
chore(terra-draw): use --release-as with custom bumper as scopes are not being respected

### DIFF
--- a/bump.mjs
+++ b/bump.mjs
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import { Bumper } from 'conventional-recommended-bump';
+import { readFileSync } from "fs";
+
+const gitPath = path.resolve('./');
+const bumper = new Bumper(gitPath);
+const packageName = JSON.parse(readFileSync('./package.json', 'utf8')).name;
+await getBumpType(bumper, packageName);
+
+async function getBumpType(bumper, packageName) {
+    await bumper.loadPreset('conventionalcommits')
+
+    const recommendation = await bumper.bump(
+        (commits) => {
+            let recommendation = 0;
+            for (let commit of commits.slice(0, -1)) {
+                if (commit.scope === packageName) {
+                    if (recommendation < 2 && commit.type === 'feat') {
+                        recommendation = 1;
+                    }
+
+                    if (commit.notes.some((note) => note.title === 'BREAKING CHANGE')) {
+                        recommendation = 2;
+                    }
+                }
+            }
+
+            return {
+                level: recommendation,
+                reason: 'Based on conventional commits',
+                releaseType: ['patch', 'minor', 'major'][recommendation]
+            }
+        }
+
+    )
+
+    console.log(recommendation.releaseType)
+    process.exit(0)
+}

--- a/bump.mjs
+++ b/bump.mjs
@@ -1,3 +1,10 @@
+/**
+ * We have to manually figure out how to bump the package version based on the commits
+ * as commit-and-tag-version doesn't seem to work with monorepos where scopes are used to
+ * differentiate packages. We build on the conventional-recommended-bump package to determine
+ * the bump type based on the commits since the last release for the current package.
+ */
+
 import * as path from 'path';
 import { Bumper } from 'conventional-recommended-bump';
 import { readFileSync } from "fs";
@@ -7,20 +14,31 @@ const bumper = new Bumper(gitPath);
 const packageName = JSON.parse(readFileSync('./package.json', 'utf8')).name;
 await getBumpType(bumper, packageName);
 
+
 async function getBumpType(bumper, packageName) {
+
+    const PATCH = 0;
+    const MINOR = 1;
+    const MAJOR = 2;
+
     await bumper.loadPreset('conventionalcommits')
 
     const recommendation = await bumper.bump(
         (commits) => {
-            let recommendation = 0;
-            for (let commit of commits.slice(0, -1)) {
+            let recommendation = PATCH;
+
+            // The last commit is the one that bumped the version for the current package
+            // It appears it is included in the list of commits, so we need to exclude it
+            const allCommitsAfterLastRelease = commits.slice(0, -1)
+
+            for (let commit of allCommitsAfterLastRelease) {
                 if (commit.scope === packageName) {
-                    if (recommendation < 2 && commit.type === 'feat') {
-                        recommendation = 1;
+                    if (recommendation < MAJOR && commit.type === 'feat') {
+                        recommendation = MINOR;
                     }
 
                     if (commit.notes.some((note) => note.title === 'BREAKING CHANGE')) {
-                        recommendation = 2;
+                        recommendation = MAJOR;
                     }
                 }
             }
@@ -35,5 +53,7 @@ async function getBumpType(bumper, packageName) {
     )
 
     console.log(recommendation.releaseType)
+
+    // TODO: Process doesn't seem to exit - probably something async still running
     process.exit(0)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@typescript-eslint/eslint-plugin": "8.17.0",
 				"@typescript-eslint/parser": "8.17.0",
 				"commit-and-tag-version": "^12.5.0",
+				"conventional-recommended-bump": "^10.0.0",
 				"eslint": "9.17.0",
 				"eslint-config-prettier": "9.1.0",
 				"eslint-plugin-prettier": "5.2.1",
@@ -4971,6 +4972,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
 		"node_modules/@types/send": {
 			"version": "0.17.4",
 			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -7341,6 +7348,27 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/commit-and-tag-version/node_modules/conventional-recommended-bump": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-7.0.1.tgz",
+			"integrity": "sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA==",
+			"dev": true,
+			"dependencies": {
+				"concat-stream": "^2.0.0",
+				"conventional-changelog-preset-loader": "^3.0.0",
+				"conventional-commits-filter": "^3.0.0",
+				"conventional-commits-parser": "^4.0.0",
+				"git-raw-commits": "^3.0.0",
+				"git-semver-tags": "^5.0.0",
+				"meow": "^8.1.2"
+			},
+			"bin": {
+				"conventional-recommended-bump": "cli.js"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/commit-and-tag-version/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -7349,6 +7377,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/commit-and-tag-version/node_modules/git-raw-commits": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
+			"integrity": "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==",
+			"dev": true,
+			"dependencies": {
+				"dargs": "^7.0.0",
+				"meow": "^8.1.2",
+				"split2": "^3.2.2"
+			},
+			"bin": {
+				"git-raw-commits": "cli.js"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/commit-and-tag-version/node_modules/has-flag": {
@@ -7485,7 +7530,6 @@
 			"engines": [
 				"node >= 6.0"
 			],
-			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -7784,43 +7828,92 @@
 			}
 		},
 		"node_modules/conventional-recommended-bump": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-7.0.1.tgz",
-			"integrity": "sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-10.0.0.tgz",
+			"integrity": "sha512-RK/fUnc2btot0oEVtrj3p2doImDSs7iiz/bftFCDzels0Qs1mxLghp+DFHMaOC0qiCI6sWzlTDyBFSYuot6pRA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"concat-stream": "^2.0.0",
-				"conventional-changelog-preset-loader": "^3.0.0",
-				"conventional-commits-filter": "^3.0.0",
-				"conventional-commits-parser": "^4.0.0",
-				"git-raw-commits": "^3.0.0",
-				"git-semver-tags": "^5.0.0",
-				"meow": "^8.1.2"
+				"@conventional-changelog/git-client": "^1.0.0",
+				"conventional-changelog-preset-loader": "^5.0.0",
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.0.0",
+				"meow": "^13.0.0"
 			},
 			"bin": {
-				"conventional-recommended-bump": "cli.js"
+				"conventional-recommended-bump": "dist/cli/index.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
-		"node_modules/conventional-recommended-bump/node_modules/git-raw-commits": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
-			"integrity": "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==",
+		"node_modules/conventional-recommended-bump/node_modules/@conventional-changelog/git-client": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
+			"integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"dargs": "^7.0.0",
-				"meow": "^8.1.2",
-				"split2": "^3.2.2"
-			},
-			"bin": {
-				"git-raw-commits": "cli.js"
+				"@types/semver": "^7.5.5",
+				"semver": "^7.5.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.0.0"
+			},
+			"peerDependenciesMeta": {
+				"conventional-commits-filter": {
+					"optional": true
+				},
+				"conventional-commits-parser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/conventional-recommended-bump/node_modules/conventional-changelog-preset-loader": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+			"integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-recommended-bump/node_modules/conventional-commits-filter": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+			"integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+			"dev": true,
+			"dependencies": {
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-recommended-bump/node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -20007,8 +20100,7 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/typedoc": {
 			"version": "0.26.11",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@typescript-eslint/eslint-plugin": "8.17.0",
 		"@typescript-eslint/parser": "8.17.0",
 		"commit-and-tag-version": "^12.5.0",
+		"conventional-recommended-bump": "^10.0.0",
 		"eslint": "9.17.0",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-plugin-prettier": "5.2.1",

--- a/packages/terra-draw-arcgis-adapter/package.json
+++ b/packages/terra-draw-arcgis-adapter/package.json
@@ -7,8 +7,8 @@
 		"@arcgis/core": "^4.31.6"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw-google-maps-adapter/package.json
+++ b/packages/terra-draw-google-maps-adapter/package.json
@@ -10,8 +10,8 @@
 		"@types/google.maps": "^3.49.2"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw-leaflet-adapter/package.json
+++ b/packages/terra-draw-leaflet-adapter/package.json
@@ -7,8 +7,8 @@
 		"leaflet": "^1.9.4"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw-mapbox-gl-adapter/package.json
+++ b/packages/terra-draw-mapbox-gl-adapter/package.json
@@ -7,8 +7,8 @@
 		"mapbox-gl": "^3.9.2"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw-maplibre-gl-adapter/package.json
+++ b/packages/terra-draw-maplibre-gl-adapter/package.json
@@ -7,8 +7,8 @@
 		"maplibre-gl": ">=4"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw-openlayers-adapter/package.json
+++ b/packages/terra-draw-openlayers-adapter/package.json
@@ -7,8 +7,8 @@
 		"ol": "^10.3.1"
 	},
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -5,7 +5,6 @@
 	"scripts": {
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --dry-run --release-as $TYPE",
-		"release:help": "commit-and-tag-version --help",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -3,8 +3,9 @@
 	"version": "1.0.0",
 	"description": "Frictionless map drawing across mapping provider",
 	"scripts": {
-		"release": "commit-and-tag-version .versionrc.cjs -t terra-draw@",
-		"release:dryrun": "commit-and-tag-version .versionrc.cjs -t terra-draw@ --dry-run",
+		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --release-as $TYPE",
+		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --dry-run --release-as $TYPE",
+		"release:help": "commit-and-tag-version --help",
 		"build": "microbundle",
 		"watch": "microbundle --watch --format modern",
 		"unused": "knip",


### PR DESCRIPTION
## Description of Changes

This is a work around for https://github.com/absolute-version/commit-and-tag-version/issues/210, where we pass the release type (patch, minor, major) to `--release-as` explicitly, as we can't seem to be able to filter out commits from other scopes in any other way. At the moment the change log filters out other commits from other scopes (packages) with the `transform` function. No similar function seems to exist for the bumping of the packages, so it sees all the breaking changes from the other packages since the last release.

## Link to Issue

<!--- Please provide a link to the issue for reference. If you have not created an issue, please do so before raising a PR so that it is possible to discuss the changes in advance -->

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 