### PR TITLE
chore(terra-draw): use source files for e2e testing for simplicty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,7 @@ jobs:
       with:
         node-version: "22.x"
     - name: Install parent directory
-      run: npm ci
-    - name: Build terra-draw
-      run: cd packages/terra-draw && npm run build
-    - name: Build terra-draw-leaflet-adapter
-      run: cd packages/terra-draw-leaflet-adapter && npm run build
+      run: npm install    
     - name: Get installed Playwright version
       id: playwright-version
       working-directory: ./packages/e2e
@@ -107,11 +103,19 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
     - name: Install e2e test
       working-directory: ./packages/e2e
-      run: npm ci --ignore-scripts
-    - run: npx playwright install --with-deps
+      run: npm install    
+    - name: Install terra-draw
+      working-directory: ./packages/terra-draw
+      run: npm install
+    - name: Install terra-draw-leaflet-adapter
+      working-directory: ./packages/terra-draw-leaflet-adapter
+      run: npm install
+    - name: Install playwright
+      run: npx playwright install --with-deps
       working-directory: ./packages/e2e
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - run: npx playwright install-deps
+    - name: Install playwright dependencies
+      run: npx playwright install-deps
       working-directory: ./packages/e2e
       if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: Run Playwright tests

--- a/docs/media/1.GETTING_STARTED.md
+++ b/docs/media/1.GETTING_STARTED.md
@@ -95,7 +95,7 @@ npm install terra-draw
 It is strongly advised to pin your installation to a specific version i.e. not using carat, asterix or tilde for versions but giving a version explicitly in your `package.json`.
 
 ```json
-"terra-draw": "1.0.0-beta.0"
+"terra-draw": "1.1.0"
 ```
 
 Once Terra Draw is out of beta this suggestion will be removed as we will aim to move to semantic versioning.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import prettierConfig from "eslint-config-prettier";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 
-const ignores = ["**/node_modules", "**/dist", "**/docs", ".github", ".husky", ".vscode", "**/public", "**/coverage", "packages/e2e/playwright-report"];
+const ignores = ["**/node_modules", "**/dist", "**/docs", ".github", ".husky", ".vscode", "**/public", "**/coverage", "packages/e2e/playwright-report", "packages/e2e/test-results"];
 
 export default [
 	{

--- a/package-lock.json
+++ b/package-lock.json
@@ -21401,8 +21401,7 @@
 				"leaflet": "1.9.4",
 				"mapbox-gl": "3.9.2",
 				"maplibre-gl": "3.6.2",
-				"ol": "10.3.1",
-				"terra-draw": "1.0.0"
+				"ol": "10.3.1"
 			},
 			"devDependencies": {
 				"dotenv-webpack": "8.0.0",
@@ -21664,11 +21663,6 @@
 			"version": "2.0.0",
 			"license": "ISC"
 		},
-		"packages/development/node_modules/terra-draw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.0.0.tgz",
-			"integrity": "sha512-LMD5wLHHSfkXOX0eGjhUV/Pnxedn5MvsKBvGOP6txCY1D1LAIVnIx1g+trTXfBHUjogDJj/vmswsGMD/5LtNKQ=="
-		},
 		"packages/development/node_modules/tinyqueue": {
 			"version": "2.0.3",
 			"license": "ISC"
@@ -21734,9 +21728,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"leaflet": "1.9.4",
-				"terra-draw": "1.0.0",
-				"terra-draw-leaflet-adapter": "1.0.0"
+				"leaflet": "1.9.4"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.49.1",
@@ -21924,11 +21916,6 @@
 			"engines": {
 				"node": ">=4.0"
 			}
-		},
-		"packages/e2e/node_modules/terra-draw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.0.0.tgz",
-			"integrity": "sha512-LMD5wLHHSfkXOX0eGjhUV/Pnxedn5MvsKBvGOP6txCY1D1LAIVnIx1g+trTXfBHUjogDJj/vmswsGMD/5LtNKQ=="
 		},
 		"packages/e2e/node_modules/undici-types": {
 			"version": "5.26.5",

--- a/packages/development/package.json
+++ b/packages/development/package.json
@@ -11,7 +11,6 @@
 	"author": "James Milner",
 	"license": "MIT",
 	"dependencies": {
-		"terra-draw": "1.0.0",
 		"leaflet": "1.9.4",
 		"maplibre-gl": "3.6.2",
 		"@arcgis/core": "4.31.6",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -14,9 +14,7 @@
 	"author": "James Milner",
 	"license": "MIT",
 	"dependencies": {
-		"leaflet": "1.9.4",
-		"terra-draw": "1.0.0",
-		"terra-draw-leaflet-adapter": "1.0.0"
+		"leaflet": "1.9.4"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.1",

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -1,6 +1,6 @@
 import L from "leaflet";
 
-import { TerraDrawLeafletAdapter } from "terra-draw-leaflet-adapter";
+import { TerraDrawLeafletAdapter } from "../../terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter";
 
 import {
 	TerraDraw,
@@ -16,7 +16,7 @@ import {
 	TerraDrawRenderMode,
 	TerraDrawSelectMode,
 	ValidateMaxAreaSquareMeters,
-} from "terra-draw";
+} from "../../terra-draw/src/terra-draw";
 
 const example = {
 	lng: -0.118092,


### PR DESCRIPTION
## Description of Changes

We now do E2E tests using the source files for simplicity. 

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 