### PR TITLE
feat(terra-draw): add editable option for linestring mode to allow moving polygons whilst drawing

### DIFF
--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -135,6 +135,7 @@ const example = {
 					editable: this.config?.includes("pointEditable"),
 				}),
 				new TerraDrawLineStringMode({
+					editable: this.config?.includes("lineStringEditable"),
 					snapping: {
 						toCoordinate: this.config?.includes("snappingCoordinate"),
 					},

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -253,6 +253,35 @@ test.describe("linestring mode", () => {
 			await expectPaths({ page, count: 2 });
 		});
 	}
+
+	test(`mode can set with editable set to true and points can be moved`, async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["lineStringEditable"],
+		});
+		await changeMode({ page, mode });
+
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 2, { steps: 30 });
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+		await page.mouse.move(mapDiv.width / 3, mapDiv.height / 3, { steps: 30 });
+		await page.mouse.click(mapDiv.width / 3, mapDiv.height / 3);
+
+		// Close
+		await page.mouse.click(mapDiv.width / 3, mapDiv.height / 3);
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 217, height: 124 });
+
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 2, { steps: 30 });
+		await page.mouse.down();
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 4, { steps: 30 });
+		await page.mouse.up();
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 217, height: 64 });
+	});
 });
 
 test.describe("polygon mode", () => {

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -5,6 +5,7 @@ export const pageUrl = "http://localhost:3000/";
 export type TestConfigOptions =
 	| "polygonEditable"
 	| "pointEditable"
+	| "lineStringEditable"
 	| "validationSuccess"
 	| "validationFailure"
 	| "insertCoordinates"

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -22,7 +22,6 @@ import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { ClosingPointsBehavior } from "./behaviors/closing-points.behavior";
 import { getDefaultStyling } from "../../util/styling";
 import {
-	BBoxPolygon,
 	FeatureId,
 	GeoJSONStoreFeatures,
 	StoreValidation,
@@ -83,10 +82,15 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private currentCoordinate = 0;
 	private currentId: FeatureId | undefined;
 	private keyEvents: TerraDrawPolygonModeKeyEvents;
-	private snapping: Snapping | undefined;
-	private editable: boolean;
+	private cursors: Required<Cursors>;
+	private mouseMove = false;
 
+	// Snapping
+	private snapping: Snapping | undefined;
 	private snappedPointId: FeatureId | undefined;
+
+	// Editable
+	private editable: boolean;
 	private editedFeatureId: FeatureId | undefined;
 	private editedFeatureCoordinateIndex: number | undefined;
 	private editedSnapType: "line" | "coordinate" | undefined;
@@ -99,8 +103,6 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private pixelDistance!: PixelDistanceBehavior;
 	private closingPoints!: ClosingPointsBehavior;
 	private clickBoundingBox!: ClickBoundingBoxBehavior;
-	private cursors: Required<Cursors>;
-	private mouseMove = false;
 
 	constructor(options?: TerraDrawPolygonModeOptions<PolygonStyling>) {
 		super(options);


### PR DESCRIPTION
## Description of Changes

This brings the editable feature in line with point and polygon modes. 

## Link to Issue

#433

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 