### PR TITLE
feat(terra-draw): allow deletion of coordinates with right clicks when editable is true

### DIFF
--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -93,6 +93,28 @@ test.describe("point mode", () => {
 
 		await expectGroupPosition({ page, x: 419, y: 233 });
 	});
+
+	test("mode can set with editable set to true and points can be deleted", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["pointEditable"],
+		});
+		await changeMode({ page, mode });
+
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+		await expectPaths({ page, count: 1 });
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 2);
+
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2, {
+			button: "right",
+			clickCount: 1,
+		});
+
+		// await page.pause();
+		await expectPaths({ page, count: 0 });
+	});
 });
 
 test.describe("linestring mode", () => {
@@ -281,6 +303,36 @@ test.describe("linestring mode", () => {
 
 		await expectPaths({ page, count: 1 });
 		await expectPathDimensions({ page, width: 217, height: 64 });
+	});
+
+	test(`mode can set with editable set to true and points can be deleted`, async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["lineStringEditable"],
+		});
+		await changeMode({ page, mode });
+
+		await page.mouse.move(mapDiv.width / 2, mapDiv.height / 2, { steps: 30 });
+		await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+		await page.mouse.move(mapDiv.width / 3, mapDiv.height / 2, { steps: 30 });
+		await page.mouse.click(mapDiv.width / 3, mapDiv.height / 2);
+		await page.mouse.move(mapDiv.width / 4, mapDiv.height / 3, { steps: 30 });
+		await page.mouse.click(mapDiv.width / 4, mapDiv.height / 3);
+
+		// Close
+		await page.mouse.click(mapDiv.width / 4, mapDiv.height / 3);
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 324, height: 124 });
+
+		await page.mouse.click(mapDiv.width / 4, mapDiv.height / 3, {
+			button: "right",
+			clickCount: 1,
+		});
+
+		await expectPathDimensions({ page, width: 217, height: 4 });
 	});
 });
 
@@ -560,6 +612,56 @@ test.describe("polygon mode", () => {
 
 		// Check to see the dimensions have changed due to the edit
 		await expectPathDimensions({ page, width: 104, height: 104 + offset });
+	});
+
+	test("can use editable setting to delete a coordinate with right click", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["polygonEditable"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = {
+			x: centerX - halfLength + 25,
+			y: centerY + halfLength + 25,
+		};
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 104, height: 129 });
+
+		await page.mouse.click(bottomLeft.x, bottomLeft.y, {
+			button: "right",
+			clickCount: 1,
+		});
+
+		// The dimensions should have changed due to the deletion
+		await expectPaths({ page, count: 1 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
 	});
 });
 

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -110,7 +110,7 @@ export const expectPaths = async ({
 	} else {
 		await expect(
 			await page.locator(selector).count(),
-			`locator count should be greater than 0 for selector ${selector}`,
+			`locator count should be 0 for selector ${selector}`,
 		).toBe(0);
 	}
 };

--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -121,6 +121,30 @@ describe("TerraDrawPointMode", () => {
 			);
 		});
 
+		it("right click can delete a point if editable is true", () => {
+			const pointMode = new TerraDrawPointMode({ editable: true });
+
+			const mockConfig = MockModeConfig(pointMode.mode);
+
+			pointMode.register(mockConfig);
+
+			pointMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
+			expect(mockConfig.onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+			);
+
+			pointMode.onClick(MockCursorEvent({ lng: 0, lat: 0, button: "right" }));
+
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(2);
+			expect(mockConfig.onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"delete",
+			);
+		});
+
 		describe("validate", () => {
 			it("does not create the point if validation returns false", () => {
 				const pointMode = new TerraDrawPointMode({

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -99,37 +99,11 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			throw new Error("Mode must be registered first");
 		}
 
-		const geometry = {
-			type: "Point",
-			coordinates: [event.lng, event.lat],
-		} as Point;
-
-		const properties = { mode: this.mode };
-
-		if (this.validate) {
-			const validationResult = this.validate(
-				{
-					type: "Feature",
-					geometry,
-					properties,
-				} as GeoJSONStoreFeatures,
-				{
-					project: this.project,
-					unproject: this.unproject,
-					coordinatePrecision: this.coordinatePrecision,
-					updateType: UpdateTypes.Finish,
-				},
-			);
-
-			if (!validationResult.valid) {
-				return;
-			}
+		if (event.button === "right") {
+			this.onRightClick(event);
+		} else if (event.button === "left") {
+			this.onLeftClick(event);
 		}
-
-		const [pointId] = this.store.create([{ geometry, properties }]);
-
-		// Ensure that any listerers are triggered with the main created geometry
-		this.onFinish(pointId, { mode: this.mode, action: "draw" });
 	}
 
 	/** @internal */
@@ -151,39 +125,8 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		setMapDraggability: (enabled: boolean) => void,
 	) {
 		if (this.editable) {
-			const bbox = this.clickBoundingBox.create(event) as BBoxPolygon;
-			const features = this.store.search(bbox);
-
-			let distance = Infinity;
-			let clickedFeature: GeoJSONStoreFeatures | undefined = undefined;
-
-			for (let i = 0; i < features.length; i++) {
-				const feature = features[i];
-				const isPoint =
-					feature.geometry.type === "Point" &&
-					feature.properties.mode === this.mode;
-
-				if (!isPoint) {
-					continue;
-				}
-
-				const position = feature.geometry.coordinates as Position;
-				const distanceToFeature = this.pixelDistance.measure(event, position);
-
-				if (
-					distanceToFeature > distance ||
-					distanceToFeature > this.pointerDistance
-				) {
-					continue;
-				}
-
-				distance = distanceToFeature;
-				clickedFeature = feature;
-			}
-
-			if (clickedFeature) {
-				this.editedFeatureId = clickedFeature.id;
-			}
+			const nearestPointFeature = this.getNearestPointFeature(event);
+			this.editedFeatureId = nearestPointFeature?.id;
 		}
 
 		// We only need to stop the map dragging if
@@ -335,5 +278,86 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		return this.validateModeFeature(feature, (baseValidatedFeature) =>
 			ValidatePointFeature(baseValidatedFeature, this.coordinatePrecision),
 		);
+	}
+
+	private onLeftClick(event: TerraDrawMouseEvent) {
+		const geometry = {
+			type: "Point",
+			coordinates: [event.lng, event.lat],
+		} as Point;
+
+		const properties = { mode: this.mode };
+
+		if (this.validate) {
+			const validationResult = this.validate(
+				{
+					type: "Feature",
+					geometry,
+					properties,
+				} as GeoJSONStoreFeatures,
+				{
+					project: this.project,
+					unproject: this.unproject,
+					coordinatePrecision: this.coordinatePrecision,
+					updateType: UpdateTypes.Finish,
+				},
+			);
+
+			if (!validationResult.valid) {
+				return;
+			}
+		}
+
+		const [pointId] = this.store.create([{ geometry, properties }]);
+
+		// Ensure that any listerers are triggered with the main created geometry
+		this.onFinish(pointId, { mode: this.mode, action: "draw" });
+	}
+
+	private onRightClick(event: TerraDrawMouseEvent) {
+		// We only want to be able to delete points if the mode is editable
+		if (!this.editable) {
+			return;
+		}
+
+		const clickedFeature = this.getNearestPointFeature(event);
+
+		if (clickedFeature) {
+			this.store.delete([clickedFeature.id as FeatureId]);
+		}
+	}
+
+	private getNearestPointFeature(event: TerraDrawMouseEvent) {
+		const bbox = this.clickBoundingBox.create(event) as BBoxPolygon;
+		const features = this.store.search(bbox);
+
+		let distance = Infinity;
+		let clickedFeature: GeoJSONStoreFeatures | undefined = undefined;
+
+		for (let i = 0; i < features.length; i++) {
+			const feature = features[i];
+			const isPoint =
+				feature.geometry.type === "Point" &&
+				feature.properties.mode === this.mode;
+
+			if (!isPoint) {
+				continue;
+			}
+
+			const position = feature.geometry.coordinates as Position;
+			const distanceToFeature = this.pixelDistance.measure(event, position);
+
+			if (
+				distanceToFeature > distance ||
+				distanceToFeature > this.pointerDistance
+			) {
+				continue;
+			}
+
+			distance = distanceToFeature;
+			clickedFeature = feature;
+		}
+
+		return clickedFeature;
 	}
 }


### PR DESCRIPTION
## Description of Changes

Adds right click deletion behaviour to match select mode for `editable` properties for Point, LineString and Polygon

## Link to Issue

#433 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 