### PR TITLE
fix(terra-draw): ensure that polygons created by builtin modes abide by right hand rule

### DIFF
--- a/packages/terra-draw/src/geometry/boolean/right-hand-rule.spec.ts
+++ b/packages/terra-draw/src/geometry/boolean/right-hand-rule.spec.ts
@@ -1,0 +1,108 @@
+import { followsRightHandRule } from "./right-hand-rule";
+import { Polygon } from "geojson";
+
+describe("followsRightHandRule", () => {
+	test("returns true for a counterclockwise (right-hand rule) polygon", () => {
+		const counterclockwisePolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[4, 0],
+					[4, 4],
+					[0, 4],
+					[0, 0], // Counterclockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(counterclockwisePolygon)).toBe(true);
+	});
+
+	test("returns false for a clockwise (left-hand rule) polygon", () => {
+		const clockwisePolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[0, 4],
+					[4, 4],
+					[4, 0],
+					[0, 0], // Clockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(clockwisePolygon)).toBe(false);
+	});
+
+	test("returns true for an irregular counterclockwise polygon", () => {
+		const irregularCCWPolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[1, 1],
+					[3, 0],
+					[4, 2],
+					[3, 4],
+					[1, 3],
+					[1, 1], // Counterclockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(irregularCCWPolygon)).toBe(true);
+	});
+
+	test("returns false for an irregular clockwise polygon", () => {
+		const irregularCWPolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[1, 1],
+					[1, 3],
+					[3, 4],
+					[4, 2],
+					[3, 0],
+					[1, 1], // Clockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(irregularCWPolygon)).toBe(false);
+	});
+
+	test("returns true for a large counterclockwise polygon", () => {
+		const largeCCWPolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[-10, -10],
+					[10, -10],
+					[10, 10],
+					[-10, 10],
+					[-10, -10], // Counterclockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(largeCCWPolygon)).toBe(true);
+	});
+
+	test("returns false for a small clockwise polygon", () => {
+		const smallCWPolygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[2, 2],
+					[2, 3],
+					[3, 3],
+					[3, 2],
+					[2, 2], // Clockwise order
+				],
+			],
+		};
+
+		expect(followsRightHandRule(smallCWPolygon)).toBe(false);
+	});
+});

--- a/packages/terra-draw/src/geometry/boolean/right-hand-rule.ts
+++ b/packages/terra-draw/src/geometry/boolean/right-hand-rule.ts
@@ -1,0 +1,19 @@
+import { Polygon } from "geojson";
+
+/**
+ * Checks if a GeoJSON Polygon follows the right-hand rule.
+ * @param polygon - The GeoJSON Polygon to check.
+ * @returns {boolean} - True if the polygon follows the right-hand rule (counterclockwise outer ring), otherwise false.
+ */
+export function followsRightHandRule(polygon: Polygon): boolean {
+	const outerRing = polygon.coordinates[0];
+
+	let sum = 0;
+	for (let i = 0; i < outerRing.length - 1; i++) {
+		const [x1, y1] = outerRing[i];
+		const [x2, y2] = outerRing[i + 1];
+		sum += (x2 - x1) * (y2 + y1);
+	}
+
+	return sum < 0; // Right-hand rule: counterclockwise = negative area
+}

--- a/packages/terra-draw/src/geometry/ensure-right-hand-rule.spec.ts
+++ b/packages/terra-draw/src/geometry/ensure-right-hand-rule.spec.ts
@@ -1,0 +1,53 @@
+import { Polygon } from "geojson";
+import { followsRightHandRule } from "./boolean/right-hand-rule";
+import { ensureRightHandRule } from "./ensure-right-hand-rule";
+
+describe("ensureRightHandRule", () => {
+	it("should return undefined if the polygon follows the right-hand rule", () => {
+		const polygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[4, 0],
+					[4, 4],
+					[0, 4],
+					[0, 0],
+				],
+			],
+		};
+
+		const result = ensureRightHandRule(polygon);
+		expect(result).toBeUndefined();
+	});
+
+	it("should return a reversed polygon if it does not follow the right-hand rule", () => {
+		const polygon: Polygon = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[0, 4],
+					[4, 4],
+					[4, 0],
+					[0, 0],
+				],
+			],
+		};
+
+		const result = ensureRightHandRule(polygon);
+
+		expect(result).toEqual({
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[4, 0],
+					[4, 4],
+					[0, 4],
+					[0, 0],
+				],
+			],
+		});
+	});
+});

--- a/packages/terra-draw/src/geometry/ensure-right-hand-rule.ts
+++ b/packages/terra-draw/src/geometry/ensure-right-hand-rule.ts
@@ -1,0 +1,12 @@
+import { Feature, Polygon } from "geojson";
+import { followsRightHandRule } from "./boolean/right-hand-rule";
+
+export function ensureRightHandRule(polygon: Polygon): undefined | Polygon {
+	const isFollowingRightHandRule = followsRightHandRule(polygon);
+	if (!isFollowingRightHandRule) {
+		return {
+			type: "Polygon",
+			coordinates: [polygon.coordinates[0].reverse()],
+		} as Polygon;
+	}
+}

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
@@ -2,6 +2,8 @@ import { GeoJSONStore } from "../../store/store";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { TerraDrawAngledRectangleMode } from "./angled-rectangle.mode";
+import { Polygon } from "geojson";
+import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 
 describe("TerraDrawAngledRectangleMode", () => {
 	describe("constructor", () => {
@@ -213,6 +215,10 @@ describe("TerraDrawAngledRectangleMode", () => {
 				let features = store.copyAll();
 				expect(features.length).toBe(1);
 
+				expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(
+					true,
+				);
+
 				// Create a new angled rectangle polygon
 				angledRectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
@@ -325,6 +331,10 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
+			rectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			rectangleMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+
 			let features = store.copyAll();
 			expect(features.length).toBe(1);
 
@@ -340,7 +350,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 			// Two as the rectangle has been closed via enter
 			expect(features.length).toBe(2);
 
-			expect(onChange).toHaveBeenCalledTimes(2);
+			expect(onChange).toHaveBeenCalledTimes(5);
 			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 			expect(onFinish).toHaveBeenCalledTimes(1);
 		});

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -345,6 +345,11 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 		if (event.key === this.keyEvents.cancel) {
 			this.cleanUp();
 		} else if (event.key === this.keyEvents.finish) {
+			// We don't want to close a unfinished polygon
+			if (this.currentCoordinate < 2) {
+				this.cleanUp();
+				return;
+			}
 			this.close();
 		}
 	}

--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -2,6 +2,8 @@ import { GeoJSONStore } from "../../store/store";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { TerraDrawCircleMode } from "./circle.mode";
+import { Polygon } from "geojson";
+import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 
 describe("TerraDrawCircleMode", () => {
 	describe("constructor", () => {
@@ -161,6 +163,10 @@ describe("TerraDrawCircleMode", () => {
 					features = store.copyAll();
 					expect(features.length).toBe(1);
 
+					expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(
+						true,
+					);
+
 					// We don't expect any changes if there is no cursor movement
 					expect(onChange).toHaveBeenCalledTimes(1);
 					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
@@ -180,6 +186,10 @@ describe("TerraDrawCircleMode", () => {
 
 					features = store.copyAll();
 					expect(features.length).toBe(1);
+
+					expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(
+						true,
+					);
 
 					expect(onChange).toHaveBeenCalledTimes(5);
 					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
@@ -3,6 +3,8 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { TerraDrawFreehandMode } from "./freehand.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { Polygon } from "geojson";
+import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 
 describe("TerraDrawFreehandMode", () => {
 	describe("constructor", () => {
@@ -129,6 +131,7 @@ describe("TerraDrawFreehandMode", () => {
 			beforeEach(() => {
 				const mockConfig = MockModeConfig(freehandMode.mode);
 				onChange = mockConfig.onChange;
+				onFinish = mockConfig.onFinish;
 				store = mockConfig.store;
 				freehandMode.register(mockConfig);
 				freehandMode.start();
@@ -153,20 +156,23 @@ describe("TerraDrawFreehandMode", () => {
 			it("finishes drawing polygon on second click", () => {
 				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
+				freehandMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 1 }));
+
 				let features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
 
 				// No more closing coordinate so we drop to 1 feature
 				features = store.copyAll();
 				expect(features.length).toBe(1);
 
-				expect(onChange).toHaveBeenCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(4);
 				expect(onChange).toHaveBeenCalledWith(
 					[expect.any(String), expect.any(String)],
 					"create",
 				);
+				expect(onFinish).toHaveBeenCalledTimes(1);
 			});
 		});
 
@@ -196,13 +202,13 @@ describe("TerraDrawFreehandMode", () => {
 				let features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
 
 				// Closing coordinate should still exist
 				features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				expect(onChange).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(2);
 				expect(onFinish).not.toHaveBeenCalled();
 			});
 
@@ -214,13 +220,14 @@ describe("TerraDrawFreehandMode", () => {
 				let features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
 
 				// Closing coordinate should be removed
 				features = store.copyAll();
 				expect(features.length).toBe(1);
+				expect(features[0].geometry.type).toBe("Polygon");
 
-				expect(onChange).toHaveBeenCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(3);
 				expect(onFinish).toHaveBeenCalledTimes(1);
 				expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 					action: "draw",
@@ -339,6 +346,10 @@ describe("TerraDrawFreehandMode", () => {
 				expect(onFinish).toHaveBeenCalledTimes(1);
 
 				const updatedFeature = store.copyAll()[0];
+
+				expect(followsRightHandRule(updatedFeature.geometry as Polygon)).toBe(
+					true,
+				);
 
 				expect(feature.id).toBe(updatedFeature.id);
 				expect(feature.geometry.coordinates).not.toStrictEqual(
@@ -480,6 +491,9 @@ describe("TerraDrawFreehandMode", () => {
 			expect(onFinish).toHaveBeenCalledTimes(1);
 
 			const updatedFeature = store.copyAll()[0];
+			expect(followsRightHandRule(updatedFeature.geometry as Polygon)).toBe(
+				true,
+			);
 
 			expect(feature.id).toBe(updatedFeature.id);
 			expect(feature.geometry.coordinates).not.toStrictEqual(
@@ -579,6 +593,7 @@ describe("TerraDrawFreehandMode", () => {
 		describe("finish", () => {
 			it("finishes drawing polygon on finish key press", () => {
 				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				freehandMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 1 }));
 
 				let features = store.copyAll();
 				expect(features.length).toBe(2);
@@ -586,9 +601,10 @@ describe("TerraDrawFreehandMode", () => {
 				freehandMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
 
 				features = store.copyAll();
+
 				expect(features.length).toBe(1);
 
-				expect(onChange).toHaveBeenCalledTimes(2);
+				expect(onChange).toHaveBeenCalledTimes(4);
 				expect(onChange).toHaveBeenNthCalledWith(
 					1,
 					[expect.any(String), expect.any(String)],
@@ -596,6 +612,16 @@ describe("TerraDrawFreehandMode", () => {
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					2,
+					[expect.any(String)],
+					"update",
+				);
+				expect(onChange).toHaveBeenNthCalledWith(
+					3,
+					[expect.any(String)],
+					"update",
+				);
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
 					[expect.any(String)],
 					"delete",
 				);

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -314,15 +314,16 @@ describe("TerraDrawPolygonMode", () => {
 			const coordinates = [
 				[5, 5],
 				[5, 5],
-				[5, 10],
-				[5, 10],
-				[10, 10],
-				[10, 10],
 				[10, 5],
 				[10, 5],
+				[10, 10],
+				[10, 10],
+				[5, 10],
+				[5, 10],
 				[5, 5],
 				[5, 5],
 			];
+
 			polygonMode = new TerraDrawPolygonMode({
 				snapping: {
 					toCustom: () => {
@@ -360,9 +361,9 @@ describe("TerraDrawPolygonMode", () => {
 			expect(features[0].geometry.coordinates).toStrictEqual([
 				[
 					[5, 5],
-					[5, 10],
-					[10, 10],
 					[10, 5],
+					[10, 10],
+					[5, 10],
 					[5, 5],
 				],
 			]);
@@ -446,7 +447,7 @@ describe("TerraDrawPolygonMode", () => {
 					[3, 3],
 					[4, 4],
 					[0, 0],
-				],
+				].reverse(), // Reverse to make it right hand rule valid
 			]);
 		});
 
@@ -506,7 +507,8 @@ describe("TerraDrawPolygonMode", () => {
 			expect(store.updateGeometry).toHaveBeenCalledTimes(7);
 
 			polygonMode.onClick(thirdPoint);
-			expect(store.updateGeometry).toHaveBeenCalledTimes(8);
+			// Right hand rule is not valid so extra update!
+			expect(store.updateGeometry).toHaveBeenCalledTimes(9);
 
 			// Polygon is now closed
 			expect(store.updateGeometry).toHaveBeenNthCalledWith(8, [
@@ -548,15 +550,16 @@ describe("TerraDrawPolygonMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledTimes(12);
+			// Extra call because of the right hand rule fixing
+			expect(onChange).toHaveBeenCalledTimes(13);
 
 			// Delete a coordinate
 			polygonMode.onClick(MockCursorEvent({ lng: 1, lat: 1, button: "right" }));
 
 			expect(onChange).toHaveBeenNthCalledWith(
 				13,
-				[expect.any(String)],
-				"update",
+				[expect.any(String), expect.any(String)],
+				"delete",
 			);
 
 			const featuresAfter = store.copyAll();

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -29,6 +29,7 @@ import {
 import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 import { LineSnappingBehavior } from "../line-snapping.behavior";
 import { CoordinateSnappingBehavior } from "../coordinate-snapping.behavior";
+import { ensureRightHandRule } from "../../geometry/ensure-right-hand-rule";
 
 type TerraDrawPolygonModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
@@ -167,6 +168,18 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		}
 
 		const finishedId = this.currentId;
+
+		// Fix right hand rule if necessary
+		if (this.currentId) {
+			const correctedGeometry = ensureRightHandRule(
+				this.store.getGeometryCopy<Polygon>(this.currentId),
+			);
+			if (correctedGeometry) {
+				this.store.updateGeometry([
+					{ id: this.currentId, geometry: correctedGeometry },
+				]);
+			}
+		}
 
 		if (this.snappedPointId) {
 			this.store.delete([this.snappedPointId]);

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -3,6 +3,8 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { TerraDrawRectangleMode } from "./rectangle.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { Polygon } from "geojson";
+import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 
 describe("TerraDrawRectangleMode", () => {
 	describe("constructor", () => {
@@ -149,10 +151,14 @@ describe("TerraDrawRectangleMode", () => {
 				let features = store.copyAll();
 				expect(features.length).toBe(1);
 
-				rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				rectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
 
 				features = store.copyAll();
 				expect(features.length).toBe(1);
+
+				expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(
+					true,
+				);
 
 				expect(onChange).toHaveBeenCalledTimes(2);
 				expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
@@ -195,7 +201,8 @@ describe("TerraDrawRectangleMode", () => {
 			// Two as the rectangle has been closed via enter
 			expect(features.length).toBe(2);
 
-			expect(onChange).toHaveBeenCalledTimes(2);
+			// close calls onChange an extra time because of the right hand rule fixing
+			expect(onChange).toHaveBeenCalledTimes(3);
 			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
 			expect(onFinish).toHaveBeenCalledTimes(1);
 		});
@@ -270,6 +277,10 @@ describe("TerraDrawRectangleMode", () => {
 			expect(feature.id).toBe(updatedFeature.id);
 			expect(feature.geometry.coordinates).not.toStrictEqual(
 				updatedFeature.geometry.coordinates,
+			);
+
+			expect(followsRightHandRule(updatedFeature.geometry as Polygon)).toBe(
+				true,
 			);
 		});
 	});

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -20,6 +20,7 @@ import {
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
+import { ensureRightHandRule } from "../../geometry/ensure-right-hand-rule";
 
 type TerraDrawRectangleModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
@@ -128,6 +129,19 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 	private close() {
 		const finishedId = this.currentRectangleId;
+
+		// Fix right hand rule if necessary
+		if (finishedId) {
+			const correctedGeometry = ensureRightHandRule(
+				this.store.getGeometryCopy<Polygon>(finishedId),
+			);
+			if (correctedGeometry) {
+				this.store.updateGeometry([
+					{ id: finishedId, geometry: correctedGeometry },
+				]);
+			}
+		}
+
 		this.center = undefined;
 		this.currentRectangleId = undefined;
 		this.clickCount = 0;

--- a/packages/terra-draw/src/modes/sector/sector.mode.spec.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.spec.ts
@@ -1,9 +1,10 @@
-import { Position } from "geojson";
+import { Polygon, Position } from "geojson";
 import { GeoJSONStore } from "../../store/store";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawSectorMode } from "./sector.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 
 describe("TerraDrawSectorMode", () => {
 	describe("constructor", () => {
@@ -201,6 +202,7 @@ describe("TerraDrawSectorMode", () => {
 	describe("onClick", () => {
 		let sectorMode: TerraDrawSectorMode;
 		let store: GeoJSONStore;
+		let onFinish: jest.Mock;
 
 		describe("with successful validation", () => {
 			beforeEach(() => {
@@ -212,23 +214,42 @@ describe("TerraDrawSectorMode", () => {
 				const mockConfig = MockModeConfig(sectorMode.mode);
 
 				store = mockConfig.store;
+				onFinish = mockConfig.onFinish;
 				sectorMode.register(mockConfig);
 				sectorMode.start();
 			});
 
 			it("can create a sector", () => {
-				sectorMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				sectorMode.onClick(
+					MockCursorEvent({ lng: -0.128673315, lat: 51.500349947 }),
+				);
 
-				sectorMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+				sectorMode.onMouseMove(
+					MockCursorEvent({ lng: -0.092495679, lat: 51.515995286 }),
+				);
 
-				sectorMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+				sectorMode.onClick(
+					MockCursorEvent({ lng: -0.092495679, lat: 51.515995286 }),
+				);
 
-				sectorMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+				sectorMode.onMouseMove(
+					MockCursorEvent({ lng: -0.087491348, lat: 51.490132315 }),
+				);
 
-				sectorMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+				sectorMode.onClick(
+					MockCursorEvent({ lng: -0.087491348, lat: 51.490132315 }),
+				);
 
 				let features = store.copyAll();
 				expect(features.length).toBe(1);
+
+				expect(features[0].geometry.type).toBe("Polygon");
+
+				expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(
+					true,
+				);
+
+				expect(onFinish).toHaveBeenCalledTimes(1);
 
 				// Create a new sector polygon
 				sectorMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
@@ -336,20 +357,21 @@ describe("TerraDrawSectorMode", () => {
 
 			sectorMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
-			let features = store.copyAll();
-			expect(features.length).toBe(1);
+			sectorMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			sectorMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 1 }));
 
 			sectorMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
 
-			sectorMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
+				action: "draw",
+				mode: "sector",
+			});
 
-			features = store.copyAll();
-			// Two as the sector has been closed via enter
-			expect(features.length).toBe(2);
-
-			expect(onChange).toHaveBeenCalledTimes(2);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
-			expect(onFinish).toHaveBeenCalledTimes(1);
+			const features = store.copyAll();
+			expect(features.length).toBe(1);
+			expect(features[0].geometry.type).toBe("Polygon");
+			expect(followsRightHandRule(features[0].geometry as Polygon)).toBe(true);
 		});
 
 		it("does not finish on key press when keyEvents null", () => {

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -33,6 +33,7 @@ import {
 import { cartesianDistance } from "../../geometry/measure/pixel-distance";
 import { isClockwiseWebMercator } from "../../geometry/clockwise";
 import { limitPrecision } from "../../geometry/limit-decimal-precision";
+import { ensureRightHandRule } from "../../geometry/ensure-right-hand-rule";
 
 type TerraDrawSectorModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
@@ -106,6 +107,16 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 			return;
 		}
 
+		// Fix right hand rule if necessary
+		const correctedGeometry = ensureRightHandRule(
+			this.store.getGeometryCopy<Polygon>(this.currentId),
+		);
+		if (correctedGeometry) {
+			this.store.updateGeometry([
+				{ id: this.currentId, geometry: correctedGeometry },
+			]);
+		}
+
 		const finishedId = this.currentId;
 
 		this.currentCoordinate = 0;
@@ -146,7 +157,7 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 			this.currentId,
 		).coordinates[0];
 
-		let updatedCoordinates;
+		let updatedCoordinates: Polygon["coordinates"][0] | undefined;
 
 		if (this.currentCoordinate === 1) {
 			// We must add a very small epsilon value so that Mapbox GL

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -32,6 +32,7 @@ import {
 import { cartesianDistance } from "../../geometry/measure/pixel-distance";
 import { isClockwiseWebMercator } from "../../geometry/clockwise";
 import { limitPrecision } from "../../geometry/limit-decimal-precision";
+import { ensureRightHandRule } from "../../geometry/ensure-right-hand-rule";
 
 type TerraDrawSensorModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
@@ -121,6 +122,18 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 
 		if (finishedInitialArcId) {
 			this.store.delete([finishedInitialArcId]);
+		}
+
+		// Fix right hand rule if necessary
+		if (this.currentId) {
+			const correctedGeometry = ensureRightHandRule(
+				this.store.getGeometryCopy<Polygon>(this.currentId),
+			);
+			if (correctedGeometry) {
+				this.store.updateGeometry([
+					{ id: this.currentId, geometry: correctedGeometry },
+				]);
+			}
 		}
 
 		this.currentCoordinate = 0;


### PR DESCRIPTION
## Description of Changes

Helps ensure that polygons are created following the [Right Hand Rule](https://en.wikipedia.org/wiki/Right-hand_rule)

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 