### PR TITLE
chore(terra-draw): fix build due to e2e package.json referencing terra-draw v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21789,7 +21789,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"leaflet": "1.9.4",
-				"terra-draw": "1.1.0",
+				"terra-draw": "1.2.0",
 				"terra-draw-leaflet-adapter": "1.0.0"
 			},
 			"devDependencies": {
@@ -22033,7 +22033,7 @@
 			}
 		},
 		"packages/terra-draw": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "MIT"
 		},
 		"packages/terra-draw-arcgis-adapter": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -15,7 +15,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"leaflet": "1.9.4",
-		"terra-draw": "1.1.0",
+		"terra-draw": "1.2.0",
 		"terra-draw-leaflet-adapter": "1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description of Changes

Fixs the build for 1.2.0

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 