### PR TITLE
docs(terra-draw): correct guidance around using updateModeOptions

### DIFF
--- a/guides/5.STYLING.md
+++ b/guides/5.STYLING.md
@@ -159,7 +159,7 @@ The `TerraDrawSensorMode` is styled using the following properties:
 
 ## Dynamically Changing Styling
 
-You can update styles after a mode has been initialised using the `setModeOptions` method, which takes a `styles` object. This can be done like so:
+You can update styles after a mode has been initialised using the `updateModeOptions` method, which takes a `styles` object. This can be done like so:
 
 ```typescript
 const draw = new TerraDraw({
@@ -179,7 +179,7 @@ const draw = new TerraDraw({
 
 // Later on...
 
-draw.setModeOptions<typeof TerraDrawPolygonMode>('polygon', {
+draw.updateModeOptions<typeof TerraDrawPolygonMode>('polygon', {
   // We can pass in a partial styles object and it will just update the fields passed
   styles: {
     fillColor: "#b3250a",
@@ -188,7 +188,7 @@ draw.setModeOptions<typeof TerraDrawPolygonMode>('polygon', {
 })
 ```
 
-This will tigger a `styling` change event, which can be listened to like so:
+This will trigger a `styling` change event, which can be listened to like so:
 
 ```typescript
 draw.on('change', (ids, type) => {


### PR DESCRIPTION
## Description of Changes

Fixes guidance around using updateModeOptions which was incorrectly called setModeOptions

## Link to Issue

No issue
 
## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 