### PR TITLE
fix(terra-draw-leaflet-adapter): ensure deleted features are removed from layer state

### DIFF
--- a/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.spec.ts
+++ b/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.spec.ts
@@ -255,7 +255,7 @@ describe("TerraDrawLeafletAdapter", () => {
 
 			// Create the adapter instance with the mocked map
 			const lib = {
-				geoJSON: jest.fn(),
+				geoJSON: jest.fn(() => ({})),
 			} as any;
 
 			const adapter = new TerraDrawLeafletAdapter({
@@ -291,8 +291,34 @@ describe("TerraDrawLeafletAdapter", () => {
 								mode: "test",
 							},
 						},
+						{
+							id: "4",
+							type: "Feature",
+							geometry: {
+								type: "Point",
+								coordinates: [1, 2],
+							},
+							properties: {
+								mode: "test",
+							},
+						},
 					],
-					deletedIds: ["3"],
+					deletedIds: [],
+					updated: [],
+				},
+				{
+					test: () => ({}) as any,
+				},
+			);
+
+			expect(lib.geoJSON).toHaveBeenCalledTimes(2);
+			expect(map.addLayer).toHaveBeenCalledTimes(2); // 1 for created 1 for updated
+
+			adapter.render(
+				{
+					unchanged: [],
+					created: [],
+					deletedIds: ["2"],
 					updated: [
 						{
 							id: "4",
@@ -311,9 +337,6 @@ describe("TerraDrawLeafletAdapter", () => {
 					test: () => ({}) as any,
 				},
 			);
-
-			expect(lib.geoJSON).toHaveBeenCalledTimes(2);
-			expect(map.addLayer).toHaveBeenCalledTimes(2); // 1 for created 1 for updated
 			expect(map.removeLayer).toHaveBeenCalledTimes(2); // 1 for update 1 for delete
 		});
 

--- a/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
+++ b/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
@@ -265,24 +265,41 @@ export class TerraDrawLeafletAdapter extends TerraDrawExtend.TerraDrawBaseAdapte
 	 */
 	public render(changes: TerraDrawChanges, styling: TerraDrawStylingFunction) {
 		changes.created.forEach((created) => {
-			this._layers[created.id as string] = this._lib.geoJSON(
+			if (!created.id) {
+				// This should never happen but protects against a run time error
+				return;
+			}
+			this._layers[created.id] = this._lib.geoJSON(
 				created,
 				this.styleGeoJSONLayer(styling),
 			);
-			this._map.addLayer(this._layers[created.id as string]);
+			this._map.addLayer(this._layers[created.id]);
 		});
 
 		changes.deletedIds.forEach((deleted) => {
-			this._map.removeLayer(this._layers[deleted]);
+			if (this._layers[deleted]) {
+				this._map.removeLayer(this._layers[deleted]);
+				delete this._layers[deleted];
+			}
 		});
 
 		changes.updated.forEach((updated) => {
-			this._map.removeLayer(this._layers[updated.id as string]);
-			this._layers[updated.id as string] = this._lib.geoJSON(
+			if (!updated.id) {
+				// This should never happen but protects against a run time error
+				return;
+			}
+
+			// Remove the layer if it exists
+			if (this._layers[updated.id]) {
+				this._map.removeLayer(this._layers[updated.id]);
+			}
+
+			// Create a new layer to replace it with new styling
+			this._layers[updated.id] = this._lib.geoJSON(
 				updated,
 				this.styleGeoJSONLayer(styling),
 			);
-			this._map.addLayer(this._layers[updated.id as string]);
+			this._map.addLayer(this._layers[updated.id]);
 		});
 
 		// Handle the scenario where only the styles have change and not the geometries
@@ -292,9 +309,10 @@ export class TerraDrawLeafletAdapter extends TerraDrawExtend.TerraDrawBaseAdapte
 			changes.deletedIds.length === 0;
 
 		if (isStylingChange) {
+			const scheduleStyleUpdates: (() => void)[] = [];
+
 			Object.keys(this._layers).forEach((layer) => {
-				// TODO: without rAF, this seems to not update styles when there is only 1 layer
-				requestAnimationFrame(() => {
+				scheduleStyleUpdates.push(() => {
 					const layerObj = this._layers[layer];
 					const layerGeoJSON = layerObj.toGeoJSON();
 					this._map.removeLayer(layerObj);
@@ -308,6 +326,11 @@ export class TerraDrawLeafletAdapter extends TerraDrawExtend.TerraDrawBaseAdapte
 					newLayer.addTo(this._map);
 					this._map.addLayer(this._layers[layer]);
 				});
+			});
+
+			// TODO: without rAF, this seems to not update styles when there is only 1 layer
+			setTimeout(() => {
+				scheduleStyleUpdates.forEach((rerender) => rerender());
 			});
 		}
 	}


### PR DESCRIPTION
## Description of Changes

Fixes issue where deleted features were getting re-rendered because they are not deleted from the internal map of layers. We now delete them from that map. Also does not schedule so many rAFs as one is enough per style change. 

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/472

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 