### PR TITLE
chore(terra-draw): update the e2e and development package terra-draw and adapter versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21456,7 +21456,7 @@
 				"mapbox-gl": "3.9.2",
 				"maplibre-gl": "3.6.2",
 				"ol": "10.3.1",
-				"terra-draw": "1.0.0"
+				"terra-draw": "1.2.0"
 			},
 			"devDependencies": {
 				"dotenv-webpack": "8.0.0",
@@ -21718,11 +21718,6 @@
 			"version": "2.0.0",
 			"license": "ISC"
 		},
-		"packages/development/node_modules/terra-draw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.0.0.tgz",
-			"integrity": "sha512-LMD5wLHHSfkXOX0eGjhUV/Pnxedn5MvsKBvGOP6txCY1D1LAIVnIx1g+trTXfBHUjogDJj/vmswsGMD/5LtNKQ=="
-		},
 		"packages/development/node_modules/tinyqueue": {
 			"version": "2.0.3",
 			"license": "ISC"
@@ -21790,7 +21785,7 @@
 			"dependencies": {
 				"leaflet": "1.9.4",
 				"terra-draw": "1.2.0",
-				"terra-draw-leaflet-adapter": "1.0.0"
+				"terra-draw-leaflet-adapter": "1.0.1"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.49.1",
@@ -21977,16 +21972,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"packages/e2e/node_modules/terra-draw-leaflet-adapter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/terra-draw-leaflet-adapter/-/terra-draw-leaflet-adapter-1.0.0.tgz",
-			"integrity": "sha512-4cMwJBvhXCUWg7dxg047KSoj6xCuJj7CMVIbV0+hu41apb2AgXDqM2J2K7wIFzVp0ZCJlgDUJq2eRxhvG+NyfA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"leaflet": "^1.9.4",
-				"terra-draw": "^1.0.0"
 			}
 		},
 		"packages/e2e/node_modules/undici-types": {

--- a/packages/development/package.json
+++ b/packages/development/package.json
@@ -11,7 +11,7 @@
 	"author": "James Milner",
 	"license": "MIT",
 	"dependencies": {
-		"terra-draw": "1.0.0",
+		"terra-draw": "1.2.0",
 		"leaflet": "1.9.4",
 		"maplibre-gl": "3.6.2",
 		"@arcgis/core": "4.31.6",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"leaflet": "1.9.4",
 		"terra-draw": "1.2.0",
-		"terra-draw-leaflet-adapter": "1.0.0"
+		"terra-draw-leaflet-adapter": "1.0.1"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.1",


### PR DESCRIPTION
## Description of Changes

They are pointing at the wrong versions. Long term we should automatically bump these on release.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 