### PR TITLE
chore(terra-draw): add a script that can bump all necessary packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21785,7 +21785,7 @@
 			"dependencies": {
 				"leaflet": "1.9.4",
 				"terra-draw": "1.2.0",
-				"terra-draw-leaflet-adapter": "1.0.1"
+				"terra-draw-leaflet-adapter": "1.0.2"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.49.1",
@@ -21972,16 +21972,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"packages/e2e/node_modules/terra-draw-leaflet-adapter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/terra-draw-leaflet-adapter/-/terra-draw-leaflet-adapter-1.0.1.tgz",
-			"integrity": "sha512-NuXR9VTCsi2liEnmUF8oGrzqYLUjpSAyIiokHYAZaH6pPbiygdlgIAXs+ue4hP47a64nevzFyMKlNBQ5/e89MQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"leaflet": "^1.9.4",
-				"terra-draw": "^1.0.0"
 			}
 		},
 		"packages/e2e/node_modules/undici-types": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"leaflet": "1.9.4",
 		"terra-draw": "1.2.0",
-		"terra-draw-leaflet-adapter": "1.0.1"
+		"terra-draw-leaflet-adapter": "1.0.2"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.1",

--- a/update.mjs
+++ b/update.mjs
@@ -1,0 +1,73 @@
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+
+// Get a list of all package file names
+const packagesRaw = readdirSync('./packages', { encoding: 'utf8' });
+
+// Ignore .DS_Store or other local ignored files
+const packages = packagesRaw.filter((name) => !name.startsWith('.'))
+
+const latestVersions = {}
+
+for (let i = 0; i < packages.length; i++) {
+    const packageName = packages[i];
+    const packagePath = `./packages/${packageName}/package.json`
+    const packageJsonString = readFileSync(packagePath, 'utf8');
+    const packageJson = JSON.parse(packageJsonString)
+
+    latestVersions[packageName] = packageJson.version
+}
+
+
+const isValidInteger = (n) => !isNaN(Number(n))
+
+// We loop through all relevant packages
+for (let i = 0; i < packages.length; i++) {
+    for (let j = 0; j < packages.length; j++) {
+        if (i === j) {
+            continue;
+        }
+
+        const bumpedPackageName = packages[j];
+        const bumpedPackageVersion = latestVersions[bumpedPackageName];
+
+        const version = bumpedPackageVersion.split('.')
+
+        if (version.length !== 3) {
+            throw new Error(`Passed bumped version is not valid: ${bumpedPackageVersion}`)
+        }
+
+        if (!isValidInteger(version[0])) {
+            throw new Error(`Major version is not valid: ${version[0]}`)
+        }
+
+        if (!isValidInteger(version[1])) {
+            throw new Error(`Major version is not valid: ${version[1]}`)
+        }
+
+        if (!isValidInteger(version[2])) {
+            throw new Error(`Major version is not valid: ${version[2]}`)
+        }
+
+        const packageName = packages[i];
+        const packagePath = `./packages/${packageName}/package.json`
+        const packageJsonString = readFileSync(packagePath, 'utf8');
+        const packageJson = JSON.parse(packageJsonString)
+        const currentPackageVersion = packageJson.dependencies && packageJson.dependencies[bumpedPackageName]
+
+        // If the package is listed as a dependency, bump it
+        if (currentPackageVersion) {
+            // Case where they are already bumped so do nothing
+            if (packageJson.dependencies[bumpedPackageName] === bumpedPackageVersion) {
+                console.log(`${bumpedPackageName} is used in ${packageName}! Package is already set to ${bumpedPackageVersion}`)
+            }
+            // Case where they are not matching and it needs to be updated
+            else {
+                console.log(`${bumpedPackageName} is used in ${packageName}! Bumping from ${currentPackageVersion} to ${bumpedPackageVersion}`)
+                packageJson.dependencies[bumpedPackageName] = bumpedPackageVersion;
+                writeFileSync(packagePath, JSON.stringify(packageJson, null, '\t'), 'utf8')
+            }
+        }
+    }
+}
+
+console.log('Finished!')


### PR DESCRIPTION
## Description of Changes

Adds a script that can be run (eventually on CI) which bumps all the necessary packages.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/486

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 