### PR TITLE
fix(terra-draw): added new ValidationReason if feature has excessive coordinate precision

### DIFF
--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
@@ -1,6 +1,7 @@
 import {
 	validLatitude,
 	validLongitude,
+	coordinatePrecisionIsValid,
 	coordinateIsValid,
 	getDecimalPlaces,
 } from "./is-valid-coordinate";
@@ -82,5 +83,21 @@ describe("getDecimalPlaces", () => {
 
 	it("returns the correct number of decimal places for a float less than 0", () => {
 		expect(getDecimalPlaces(-0.123)).toBe(3);
+	});
+});
+
+describe("coordinatePrecisionIsValid", () => {
+	it("should return true for valid coordinate", () => {
+		expect(coordinatePrecisionIsValid([45, 90], 9)).toBe(true);
+	});
+
+	it("should return false for coordinate with more decimal places than given", () => {
+		expect(coordinatePrecisionIsValid([45.123, 90.123], 2)).toBe(false);
+	});
+
+	it("should return false for coordinate with non-number elements", () => {
+		expect(coordinatePrecisionIsValid(["45", 90], 9)).toBe(false);
+		expect(coordinatePrecisionIsValid([45, "90"], 9)).toBe(false);
+		expect(coordinatePrecisionIsValid(["45", "90"], 9)).toBe(false);
 	});
 });

--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
@@ -6,6 +6,21 @@ export function validLongitude(lng: number) {
 	return lng >= -180 && lng <= 180;
 }
 
+export function coordinatePrecisionIsValid(
+	coordinate: unknown[],
+	coordinatePrecision: number,
+) {
+	return (
+		coordinate.length === 2 &&
+		typeof coordinate[0] === "number" &&
+		typeof coordinate[1] === "number" &&
+		coordinate[0] !== Infinity &&
+		coordinate[1] !== Infinity &&
+		getDecimalPlaces(coordinate[0]) <= coordinatePrecision &&
+		getDecimalPlaces(coordinate[1]) <= coordinatePrecision
+	);
+}
+
 export function coordinateIsValid(
 	coordinate: unknown[],
 	coordinatePrecision: number,
@@ -18,8 +33,7 @@ export function coordinateIsValid(
 		coordinate[1] !== Infinity &&
 		validLongitude(coordinate[0]) &&
 		validLatitude(coordinate[1]) &&
-		getDecimalPlaces(coordinate[0]) <= coordinatePrecision &&
-		getDecimalPlaces(coordinate[1]) <= coordinatePrecision
+		coordinatePrecisionIsValid(coordinate, coordinatePrecision)
 	);
 }
 

--- a/packages/terra-draw/src/validation-reasons.ts
+++ b/packages/terra-draw/src/validation-reasons.ts
@@ -10,6 +10,7 @@ import {
 import {
 	ValidationReasonFeatureInvalidCoordinates,
 	ValidationReasonFeatureNotPoint,
+	ValidationReasonFeatureInvalidCoordinatePrecision,
 } from "./validations/point.validation";
 import {
 	ValidationReasonFeatureHasHoles,
@@ -21,6 +22,7 @@ import {
 export const ValidationReasons = {
 	ValidationReasonFeatureNotPoint,
 	ValidationReasonFeatureInvalidCoordinates,
+	ValidationReasonFeatureInvalidCoordinatePrecision,
 	ValidationReasonFeatureNotPolygon,
 	ValidationReasonFeatureHasHoles,
 	ValidationReasonFeatureLessThanFourCoordinates,

--- a/packages/terra-draw/src/validations/linestring.validation.spec.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.spec.ts
@@ -65,7 +65,8 @@ describe("ValidateLineStringFeature", () => {
 		} as Feature<LineString, Record<string, any>>;
 		expect(ValidateLineStringFeature(validFeature, 2)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/linestring.validation.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.ts
@@ -1,11 +1,18 @@
 import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 
 export const ValidationReasonFeatureIsNotALineString =
 	"Feature is not a LineString";
 export const ValidationReasonFeatureHasLessThanTwoCoordinates =
 	"Feature has less than 2 coordinates";
+export const ValidationReasonFeatureInvalidCoordinates =
+	"Feature has invalid coordinates";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidateLineStringFeature(
 	feature: GeoJSONStoreFeatures,
@@ -27,12 +34,23 @@ export function ValidateLineStringFeature(
 
 	if (
 		!feature.geometry.coordinates.every((coordinate) =>
+			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
+		};
+	}
+
+	if (
+		!feature.geometry.coordinates.every((coordinate) =>
 			coordinateIsValid(coordinate, coordinatePrecision),
 		)
 	) {
 		return {
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason: ValidationReasonFeatureInvalidCoordinates,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/point.validation.spec.ts
+++ b/packages/terra-draw/src/validations/point.validation.spec.ts
@@ -43,7 +43,8 @@ describe("isValidPoint", () => {
 		} as Feature<Point, Record<string, any>>;
 		expect(ValidatePointFeature(invalidPoint, 2)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/point.validation.ts
+++ b/packages/terra-draw/src/validations/point.validation.ts
@@ -1,10 +1,15 @@
 import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 
 export const ValidationReasonFeatureNotPoint = "Feature is not a Point";
 export const ValidationReasonFeatureInvalidCoordinates =
 	"Feature has invalid coordinates";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidatePointFeature(
 	feature: GeoJSONStoreFeatures,
@@ -14,6 +19,18 @@ export function ValidatePointFeature(
 		return {
 			valid: false,
 			reason: ValidationReasonFeatureNotPoint,
+		};
+	}
+
+	if (
+		!coordinatePrecisionIsValid(
+			feature.geometry.coordinates,
+			coordinatePrecision,
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/polygon.validation.spec.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.spec.ts
@@ -128,7 +128,8 @@ describe("isValidPolygonFeature", () => {
 		} as Feature<Polygon, Record<string, any>>;
 		expect(ValidatePolygonFeature(validFeature, 9)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/polygon.validation.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.ts
@@ -1,7 +1,10 @@
 import { Feature, Polygon, Position } from "geojson";
 import { GeoJSONStoreFeatures } from "../terra-draw";
 import { selfIntersects } from "../geometry/boolean/self-intersects";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 import { Validation } from "../common";
 
 export const ValidationReasonFeatureNotPolygon = "Feature is not a Polygon";
@@ -12,6 +15,8 @@ export const ValidationReasonFeatureHasInvalidCoordinates =
 	"Feature has invalid coordinates";
 export const ValidationReasonFeatureCoordinatesNotClosed =
 	"Feature coordinates are not closed";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidatePolygonFeature(
 	feature: GeoJSONStoreFeatures,
@@ -35,6 +40,17 @@ export function ValidatePolygonFeature(
 		return {
 			valid: false,
 			reason: ValidationReasonFeatureLessThanFourCoordinates,
+		};
+	}
+
+	if (
+		!feature.geometry.coordinates[0].every((coordinate) =>
+			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
 		};
 	}
 


### PR DESCRIPTION
## Description of Changes

I made this changes, so users/developers will know exact reason why feature is rejected by terradraw if it has more than default coordinate decimal places of `9`.

- added `coordinatePrecisionIsValid` function to ensure feature has correct coordinate precision
- use `coordinatePrecisionIsValid` from `coorinateIsValid` function
- added `ValidationReasonFeatureInvalidCoordinatePrecision` to ValidationReason. Error message is `Feature has invalid coordinates with excessive coordinate precision`
- Refactored `linestring.validation.ts` uses constant variable for `Feature has invalid coordinates` error like point and polygon does the same.

## Link to Issue

fixes #490

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 