### PR TITLE
fix(terra-draw-leaflet-adapter): use polygonOutlineColor instead of polygonFillColor for color

### DIFF
--- a/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
+++ b/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
@@ -154,7 +154,7 @@ export class TerraDrawLeafletAdapter extends TerraDrawExtend.TerraDrawBaseAdapte
 						fillColor: featureStyles.polygonFillColor,
 						weight: featureStyles.polygonOutlineWidth,
 						stroke: true,
-						color: featureStyles.polygonFillColor,
+						color: featureStyles.polygonOutlineColor,
 						pane: paneId,
 					};
 				}


### PR DESCRIPTION
## Description of Changes

TerraDrawLeafletAdapter was using polygonFillColor to set the stroke color of polygons.

I changed this to polygonOutlineColor instead

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/493

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 