### PR TITLE
feat(terra-draw): allow dragging of midpoints in select mode by passing a flag

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -234,8 +234,11 @@ const selectMode = new TerraDrawSelectMode({
 
         // Individual coordinates that make up the Feature...
         coordinates: {
-          // Can be added
-          midpoints: true,
+          // Midpoint be added 
+          midpoints: {
+            // Midpoint be dragged
+            draggable: true
+          },
 
           // Can be moved
           draggable: true,

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -1214,6 +1214,39 @@ test.describe("select mode", () => {
 			await expectGroupPosition({ page, x: 538, y: 308 });
 		});
 
+		test(`selected polygon can insert midpoints ${name}`, async ({ page }) => {
+			const mapDiv = await setupMap({ page, configQueryParam: config });
+
+			await changeMode({ page, mode: "polygon" });
+
+			// Draw a rectangle
+			const { topLeft, topRight } = await drawRectangularPolygon({
+				mapDiv,
+				page,
+			});
+
+			// Change to select mode
+			await changeMode({ page, mode });
+
+			const x = topLeft.x - 2;
+			const y = topLeft.y - 2;
+			await expectGroupPosition({ page, x, y });
+
+			// Select
+			await page.mouse.click(mapDiv.width / 2, mapDiv.height / 2);
+			await expectPaths({ page, count: 9 }); // 4 selection + 4 midpoints points and 1 square
+
+			// Insert midpoint between topLeft and topRight
+			await page.mouse.click(
+				(topLeft.x + topRight.x) / 2,
+				(topLeft.y + topRight.y) / 2,
+			);
+
+			// When we add a midpoint, it converts to a selection point and
+			// we insert two more midpoints each side giving us 11 paths
+			await expectPaths({ page, count: 11 });
+		});
+
 		test(`selected polygon can have individual coordinates dragged and succeeds when validation succeeds ${name}`, async ({
 			page,
 		}) => {

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -1458,7 +1458,7 @@ describe("TerraDrawSelectMode", () => {
 			});
 		});
 
-		describe("drag reszing with center", () => {
+		describe("drag resizing with center", () => {
 			it("does trigger drag events if mode is draggable for linestring", () => {
 				setSelectMode({
 					flags: {
@@ -1606,6 +1606,123 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"update",
+				);
+			});
+		});
+
+		describe("drag midpoint", () => {
+			it("does trigger when midpoints draggable flag enabled", () => {
+				setSelectMode({
+					flags: {
+						polygon: {
+							feature: {
+								draggable: false,
+								coordinates: {
+									draggable: false,
+									midpoints: {
+										draggable: true,
+									},
+								},
+							},
+						},
+					},
+				});
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					1,
+					[expect.any(String)],
+					"create",
+				);
+
+				// Store the ids of the created feature
+				const idOne = onChange.mock.calls[0][0] as string[];
+
+				// Select polygon
+				selectMode.onClick(MockCursorEvent({ lng: 0.5, lat: 0.5 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
+
+				// Polygon selected set to true
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+
+				// Create mid points
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+				);
+
+				expect(onChange).toHaveBeenCalledTimes(4);
+
+				selectMode.onDragStart(
+					MockCursorEvent({ lng: 0, lat: 0.5 }),
+					jest.fn(),
+				);
+
+				expect(onChange).toHaveBeenCalledTimes(8);
+
+				expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update");
+
+				// Delete existing midpoints and selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					6,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"delete",
+				);
+
+				// Mid points
+				expect(onChange).toHaveBeenNthCalledWith(
+					7,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+				);
+
+				// Selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					8,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+				);
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					MockCursorEvent({ lng: 0, lat: 0.5 }),
+					setMapDraggability,
 				);
 			});
 		});


### PR DESCRIPTION
## Description of Changes

Allows a midpoint to be dragged immediately from it's initial state in a similar to way to selection points for Select mode.

## Link to Issue

[[Feature Request] Draggable midpoints](https://github.com/JamesLMilner/terra-draw/issues/496)

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 