### PR TITLE
chore(terra-draw): ensure e2e test package is using latest terra-draw-leaflet-adapter version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21785,7 +21785,7 @@
 			"dependencies": {
 				"leaflet": "1.9.4",
 				"terra-draw": "1.2.0",
-				"terra-draw-leaflet-adapter": "1.0.2"
+				"terra-draw-leaflet-adapter": "1.0.3"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.49.1",
@@ -21972,16 +21972,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"packages/e2e/node_modules/terra-draw-leaflet-adapter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/terra-draw-leaflet-adapter/-/terra-draw-leaflet-adapter-1.0.2.tgz",
-			"integrity": "sha512-PbdrXt+xDDUKqnNY1ML2HqTHMftrFChN4ySQOq02SQJPZy/i4/blM/jWoaMN91CdcDVyq6+As/LnxePavpv9iw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"leaflet": "^1.9.4",
-				"terra-draw": "^1.0.0"
 			}
 		},
 		"packages/e2e/node_modules/undici-types": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"leaflet": "1.9.4",
 		"terra-draw": "1.2.0",
-		"terra-draw-leaflet-adapter": "1.0.2"
+		"terra-draw-leaflet-adapter": "1.0.3"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.49.1",


### PR DESCRIPTION
## Description of Changes

Updates e2e package.json file to use terra-draw-leaflet-adapter-version v1.0.3. Long term we need to run update.mjs on every release.

## Link to Issue

No issue but CI is failing

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 