### PR TITLE
fix(terra-draw): added new ValidationReason if feature has excessive coordinate precision

### DIFF
--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
@@ -1,6 +1,7 @@
 import {
 	validLatitude,
 	validLongitude,
+	coordinatePrecisionIsValid,
 	coordinateIsValid,
 	getDecimalPlaces,
 } from "./is-valid-coordinate";
@@ -82,5 +83,21 @@ describe("getDecimalPlaces", () => {
 
 	it("returns the correct number of decimal places for a float less than 0", () => {
 		expect(getDecimalPlaces(-0.123)).toBe(3);
+	});
+});
+
+describe("coordinatePrecisionIsValid", () => {
+	it("should return true for valid coordinate", () => {
+		expect(coordinatePrecisionIsValid([45, 90], 9)).toBe(true);
+	});
+
+	it("should return false for coordinate with more decimal places than given", () => {
+		expect(coordinatePrecisionIsValid([45.123, 90.123], 2)).toBe(false);
+	});
+
+	it("should return false for coordinate with non-number elements", () => {
+		expect(coordinatePrecisionIsValid(["45", 90], 9)).toBe(false);
+		expect(coordinatePrecisionIsValid([45, "90"], 9)).toBe(false);
+		expect(coordinatePrecisionIsValid(["45", "90"], 9)).toBe(false);
 	});
 });

--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.spec.ts
@@ -44,24 +44,24 @@ describe("validLatitude", () => {
 
 describe("coordinateIsValid", () => {
 	it("should return true for valid coordinate", () => {
-		expect(coordinateIsValid([45, 90], 9)).toBe(true);
+		expect(coordinateIsValid([45, 90])).toBe(true);
 	});
 
 	it("should return false for coordinate with incorrect length", () => {
-		expect(coordinateIsValid([45], 9)).toBe(false);
-		expect(coordinateIsValid([45, 90, 100], 9)).toBe(false);
+		expect(coordinateIsValid([45])).toBe(false);
+		expect(coordinateIsValid([45, 90, 100])).toBe(false);
 	});
 
 	it("should return false for coordinate with non-number elements", () => {
-		expect(coordinateIsValid(["45", 90], 9)).toBe(false);
-		expect(coordinateIsValid([45, "90"], 9)).toBe(false);
-		expect(coordinateIsValid(["45", "90"], 9)).toBe(false);
+		expect(coordinateIsValid(["45", 90])).toBe(false);
+		expect(coordinateIsValid([45, "90"])).toBe(false);
+		expect(coordinateIsValid(["45", "90"])).toBe(false);
 	});
 
 	it("should return false for coordinate with invalid longitude and latitude", () => {
-		expect(coordinateIsValid([181, 90], 9)).toBe(false);
-		expect(coordinateIsValid([45, 91], 9)).toBe(false);
-		expect(coordinateIsValid([-181, -91], 9)).toBe(false);
+		expect(coordinateIsValid([181, 90])).toBe(false);
+		expect(coordinateIsValid([45, 91])).toBe(false);
+		expect(coordinateIsValid([-181, -91])).toBe(false);
 	});
 });
 
@@ -93,11 +93,5 @@ describe("coordinatePrecisionIsValid", () => {
 
 	it("should return false for coordinate with more decimal places than given", () => {
 		expect(coordinatePrecisionIsValid([45.123, 90.123], 2)).toBe(false);
-	});
-
-	it("should return false for coordinate with non-number elements", () => {
-		expect(coordinatePrecisionIsValid(["45", 90], 9)).toBe(false);
-		expect(coordinatePrecisionIsValid([45, "90"], 9)).toBe(false);
-		expect(coordinatePrecisionIsValid(["45", "90"], 9)).toBe(false);
 	});
 });

--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
@@ -6,6 +6,21 @@ export function validLongitude(lng: number) {
 	return lng >= -180 && lng <= 180;
 }
 
+export function coordinatePrecisionIsValid(
+	coordinate: unknown[],
+	coordinatePrecision: number,
+) {
+	return (
+		coordinate.length === 2 &&
+		typeof coordinate[0] === "number" &&
+		typeof coordinate[1] === "number" &&
+		coordinate[0] !== Infinity &&
+		coordinate[1] !== Infinity &&
+		getDecimalPlaces(coordinate[0]) <= coordinatePrecision &&
+		getDecimalPlaces(coordinate[1]) <= coordinatePrecision
+	);
+}
+
 export function coordinateIsValid(
 	coordinate: unknown[],
 	coordinatePrecision: number,
@@ -18,8 +33,7 @@ export function coordinateIsValid(
 		coordinate[1] !== Infinity &&
 		validLongitude(coordinate[0]) &&
 		validLatitude(coordinate[1]) &&
-		getDecimalPlaces(coordinate[0]) <= coordinatePrecision &&
-		getDecimalPlaces(coordinate[1]) <= coordinatePrecision
+		coordinatePrecisionIsValid(coordinate, coordinatePrecision)
 	);
 }
 

--- a/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
+++ b/packages/terra-draw/src/geometry/boolean/is-valid-coordinate.ts
@@ -1,3 +1,5 @@
+import { Position } from "geojson";
+
 export function validLatitude(lat: number) {
 	return lat >= -90 && lat <= 90;
 }
@@ -7,24 +9,16 @@ export function validLongitude(lng: number) {
 }
 
 export function coordinatePrecisionIsValid(
-	coordinate: unknown[],
+	coordinate: Position,
 	coordinatePrecision: number,
 ) {
 	return (
-		coordinate.length === 2 &&
-		typeof coordinate[0] === "number" &&
-		typeof coordinate[1] === "number" &&
-		coordinate[0] !== Infinity &&
-		coordinate[1] !== Infinity &&
 		getDecimalPlaces(coordinate[0]) <= coordinatePrecision &&
 		getDecimalPlaces(coordinate[1]) <= coordinatePrecision
 	);
 }
 
-export function coordinateIsValid(
-	coordinate: unknown[],
-	coordinatePrecision: number,
-) {
+export function coordinateIsValid(coordinate: unknown[]) {
 	return (
 		coordinate.length === 2 &&
 		typeof coordinate[0] === "number" &&
@@ -32,8 +26,7 @@ export function coordinateIsValid(
 		coordinate[0] !== Infinity &&
 		coordinate[1] !== Infinity &&
 		validLongitude(coordinate[0]) &&
-		validLatitude(coordinate[1]) &&
-		coordinatePrecisionIsValid(coordinate, coordinatePrecision)
+		validLatitude(coordinate[1])
 	);
 }
 

--- a/packages/terra-draw/src/modes/insert-coordinates.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/insert-coordinates.behavior.spec.ts
@@ -1,4 +1,7 @@
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 import { coordinatesIdentical } from "../geometry/coordinates-identical";
 import { haversineDistanceKilometers } from "../geometry/measure/haversine-distance";
 import { MockBehaviorConfig } from "../test/mock-behavior-config";
@@ -27,9 +30,10 @@ describe("InsertCoordinatesBehavior", () => {
 
 			const seenCoordinatesOne = new Set();
 			thousandKms.forEach((coordinate) => {
-				expect(coordinateIsValid(coordinate, config.coordinatePrecision)).toBe(
-					true,
-				);
+				expect(coordinateIsValid(coordinate)).toBe(true);
+				expect(
+					coordinatePrecisionIsValid(coordinate, config.coordinatePrecision),
+				).toBe(true);
 				expect(seenCoordinatesOne.has(coordinate.toString)).toBe(false);
 				seenCoordinatesOne.add(coordinate.toString());
 
@@ -59,9 +63,10 @@ describe("InsertCoordinatesBehavior", () => {
 
 			const seenCoordinatesTwo = new Set();
 			hundredKms.forEach((coordinate) => {
-				expect(coordinateIsValid(coordinate, config.coordinatePrecision)).toBe(
-					true,
-				);
+				expect(coordinateIsValid(coordinate)).toBe(true);
+				expect(
+					coordinatePrecisionIsValid(coordinate, config.coordinatePrecision),
+				).toBe(true);
 				expect(seenCoordinatesTwo.has(coordinate.toString)).toBe(false);
 				seenCoordinatesTwo.add(coordinate.toString());
 
@@ -98,9 +103,10 @@ describe("InsertCoordinatesBehavior", () => {
 
 			const seenCoordinatesOne = new Set();
 			thousandKms.forEach((coordinate) => {
-				expect(coordinateIsValid(coordinate, config.coordinatePrecision)).toBe(
-					true,
-				);
+				expect(coordinateIsValid(coordinate)).toBe(true);
+				expect(
+					coordinatePrecisionIsValid(coordinate, config.coordinatePrecision),
+				).toBe(true);
 				expect(seenCoordinatesOne.has(coordinate.toString)).toBe(false);
 				seenCoordinatesOne.add(coordinate.toString());
 
@@ -131,9 +137,11 @@ describe("InsertCoordinatesBehavior", () => {
 
 			const seenCoordinatesTwo = new Set();
 			hundredKms.forEach((coordinate) => {
-				expect(coordinateIsValid(coordinate, config.coordinatePrecision)).toBe(
-					true,
-				);
+				expect(coordinateIsValid(coordinate)).toBe(true);
+				expect(
+					coordinatePrecisionIsValid(coordinate, config.coordinatePrecision),
+				).toBe(true);
+
 				expect(seenCoordinatesTwo.has(coordinate.toString)).toBe(false);
 				seenCoordinatesOne.add(coordinate.toString());
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -12,7 +12,10 @@ import { SelectionPointBehavior } from "./selection-point.behavior";
 import { FeatureId, GeoJSONStoreGeometries } from "../../../store/store";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 import { cartesianDistance } from "../../../geometry/measure/pixel-distance";
-import { coordinateIsValid } from "../../../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../../../geometry/boolean/is-valid-coordinate";
 import {
 	lngLatToWebMercatorXY,
 	webMercatorXYToLngLat,
@@ -706,7 +709,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			coordinate[1] = limitPrecision(coordinate[1], this.coordinatePrecision);
 
 			// Ensure the coordinate we are about to update with is valid
-			if (!coordinateIsValid(coordinate, this.coordinatePrecision)) {
+			if (!coordinatePrecisionIsValid(coordinate, this.coordinatePrecision)) {
 				return false;
 			}
 		}

--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -416,7 +416,7 @@ describe("Terra Draw", () => {
 	});
 
 	describe("selectFeature", () => {
-		it("throws an error if there is no select moded", () => {
+		it("throws an error if there is no select mode present", () => {
 			const draw = new TerraDraw({
 				adapter,
 				modes: [new TerraDrawPointMode()],
@@ -479,6 +479,84 @@ describe("Terra Draw", () => {
 
 			const feature = draw.getSnapshot()[0];
 			expect(feature.properties.selected).toBe(true);
+		});
+	});
+
+	describe("addFeatures", () => {
+		it("returns valid false if the coordinate precision is excessive", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-25.431289673, 34.355907891],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(false);
+			expect(result.reason).toBe(
+				"Feature has coordinates with excessive precision",
+			);
+		});
+
+		it("returns valid true if the coordinate precision is exactly the adapter coordinate precision", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 9,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [-25.431289673, 34.355907891],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+			expect(result.reason).toBe(undefined);
 		});
 	});
 

--- a/packages/terra-draw/src/validation-reasons.ts
+++ b/packages/terra-draw/src/validation-reasons.ts
@@ -10,6 +10,7 @@ import {
 import {
 	ValidationReasonFeatureInvalidCoordinates,
 	ValidationReasonFeatureNotPoint,
+	ValidationReasonFeatureInvalidCoordinatePrecision,
 } from "./validations/point.validation";
 import {
 	ValidationReasonFeatureHasHoles,
@@ -21,6 +22,7 @@ import {
 export const ValidationReasons = {
 	ValidationReasonFeatureNotPoint,
 	ValidationReasonFeatureInvalidCoordinates,
+	ValidationReasonFeatureInvalidCoordinatePrecision,
 	ValidationReasonFeatureNotPolygon,
 	ValidationReasonFeatureHasHoles,
 	ValidationReasonFeatureLessThanFourCoordinates,

--- a/packages/terra-draw/src/validations/linestring.validation.spec.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.spec.ts
@@ -65,8 +65,7 @@ describe("ValidateLineStringFeature", () => {
 		} as Feature<LineString, Record<string, any>>;
 		expect(ValidateLineStringFeature(validFeature, 2)).toEqual({
 			valid: false,
-			reason:
-				"Feature has invalid coordinates with excessive coordinate precision",
+			reason: "Feature has coordinates with excessive precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/linestring.validation.spec.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.spec.ts
@@ -65,7 +65,8 @@ describe("ValidateLineStringFeature", () => {
 		} as Feature<LineString, Record<string, any>>;
 		expect(ValidateLineStringFeature(validFeature, 2)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/linestring.validation.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.ts
@@ -1,11 +1,18 @@
 import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 
 export const ValidationReasonFeatureIsNotALineString =
 	"Feature is not a LineString";
 export const ValidationReasonFeatureHasLessThanTwoCoordinates =
 	"Feature has less than 2 coordinates";
+export const ValidationReasonFeatureInvalidCoordinates =
+	"Feature has invalid coordinates";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidateLineStringFeature(
 	feature: GeoJSONStoreFeatures,
@@ -27,12 +34,23 @@ export function ValidateLineStringFeature(
 
 	if (
 		!feature.geometry.coordinates.every((coordinate) =>
+			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
+		};
+	}
+
+	if (
+		!feature.geometry.coordinates.every((coordinate) =>
 			coordinateIsValid(coordinate, coordinatePrecision),
 		)
 	) {
 		return {
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason: ValidationReasonFeatureInvalidCoordinates,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/linestring.validation.ts
+++ b/packages/terra-draw/src/validations/linestring.validation.ts
@@ -12,7 +12,7 @@ export const ValidationReasonFeatureHasLessThanTwoCoordinates =
 export const ValidationReasonFeatureInvalidCoordinates =
 	"Feature has invalid coordinates";
 export const ValidationReasonFeatureInvalidCoordinatePrecision =
-	"Feature has invalid coordinates with excessive coordinate precision";
+	"Feature has coordinates with excessive precision";
 
 export function ValidateLineStringFeature(
 	feature: GeoJSONStoreFeatures,
@@ -32,26 +32,25 @@ export function ValidateLineStringFeature(
 		};
 	}
 
-	if (
-		!feature.geometry.coordinates.every((coordinate) =>
-			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
-		)
-	) {
-		return {
-			valid: false,
-			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
-		};
-	}
+	for (let i = 0; i < feature.geometry.coordinates.length; i++) {
+		if (!coordinateIsValid(feature.geometry.coordinates[i])) {
+			return {
+				valid: false,
+				reason: ValidationReasonFeatureInvalidCoordinates,
+			};
+		}
 
-	if (
-		!feature.geometry.coordinates.every((coordinate) =>
-			coordinateIsValid(coordinate, coordinatePrecision),
-		)
-	) {
-		return {
-			valid: false,
-			reason: ValidationReasonFeatureInvalidCoordinates,
-		};
+		if (
+			!coordinatePrecisionIsValid(
+				feature.geometry.coordinates[i],
+				coordinatePrecision,
+			)
+		) {
+			return {
+				valid: false,
+				reason: ValidationReasonFeatureInvalidCoordinatePrecision,
+			};
+		}
 	}
 
 	return { valid: true };

--- a/packages/terra-draw/src/validations/point.validation.spec.ts
+++ b/packages/terra-draw/src/validations/point.validation.spec.ts
@@ -32,7 +32,7 @@ describe("isValidPoint", () => {
 		});
 	});
 
-	it("returns false for a Point with incorrect coordinate precision", () => {
+	it("returns false for a Point with invalid latitude", () => {
 		const invalidPoint = {
 			type: "Feature",
 			properties: {},
@@ -41,10 +41,24 @@ describe("isValidPoint", () => {
 				coordinates: [45.123, 90.123],
 			},
 		} as Feature<Point, Record<string, any>>;
+		expect(ValidatePointFeature(invalidPoint, 9)).toEqual({
+			valid: false,
+			reason: "Feature has invalid coordinates",
+		});
+	});
+
+	it("returns false for a Point with incorrect coordinate precision", () => {
+		const invalidPoint = {
+			type: "Feature",
+			properties: {},
+			geometry: {
+				type: "Point",
+				coordinates: [45.123, 89.123],
+			},
+		} as Feature<Point, Record<string, any>>;
 		expect(ValidatePointFeature(invalidPoint, 2)).toEqual({
 			valid: false,
-			reason:
-				"Feature has invalid coordinates with excessive coordinate precision",
+			reason: "Feature has coordinates with excessive precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/point.validation.spec.ts
+++ b/packages/terra-draw/src/validations/point.validation.spec.ts
@@ -43,7 +43,8 @@ describe("isValidPoint", () => {
 		} as Feature<Point, Record<string, any>>;
 		expect(ValidatePointFeature(invalidPoint, 2)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/point.validation.ts
+++ b/packages/terra-draw/src/validations/point.validation.ts
@@ -1,10 +1,15 @@
 import { Validation } from "../common";
 import { GeoJSONStoreFeatures } from "../terra-draw";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 
 export const ValidationReasonFeatureNotPoint = "Feature is not a Point";
 export const ValidationReasonFeatureInvalidCoordinates =
 	"Feature has invalid coordinates";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidatePointFeature(
 	feature: GeoJSONStoreFeatures,
@@ -14,6 +19,18 @@ export function ValidatePointFeature(
 		return {
 			valid: false,
 			reason: ValidationReasonFeatureNotPoint,
+		};
+	}
+
+	if (
+		!coordinatePrecisionIsValid(
+			feature.geometry.coordinates,
+			coordinatePrecision,
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/point.validation.ts
+++ b/packages/terra-draw/src/validations/point.validation.ts
@@ -9,7 +9,7 @@ export const ValidationReasonFeatureNotPoint = "Feature is not a Point";
 export const ValidationReasonFeatureInvalidCoordinates =
 	"Feature has invalid coordinates";
 export const ValidationReasonFeatureInvalidCoordinatePrecision =
-	"Feature has invalid coordinates with excessive coordinate precision";
+	"Feature has coordinates with excessive precision";
 
 export function ValidatePointFeature(
 	feature: GeoJSONStoreFeatures,
@@ -22,6 +22,13 @@ export function ValidatePointFeature(
 		};
 	}
 
+	if (!coordinateIsValid(feature.geometry.coordinates)) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinates,
+		};
+	}
+
 	if (
 		!coordinatePrecisionIsValid(
 			feature.geometry.coordinates,
@@ -31,13 +38,6 @@ export function ValidatePointFeature(
 		return {
 			valid: false,
 			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
-		};
-	}
-
-	if (!coordinateIsValid(feature.geometry.coordinates, coordinatePrecision)) {
-		return {
-			valid: false,
-			reason: ValidationReasonFeatureInvalidCoordinates,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/polygon.validation.spec.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.spec.ts
@@ -128,8 +128,7 @@ describe("isValidPolygonFeature", () => {
 		} as Feature<Polygon, Record<string, any>>;
 		expect(ValidatePolygonFeature(validFeature, 9)).toEqual({
 			valid: false,
-			reason:
-				"Feature has invalid coordinates with excessive coordinate precision",
+			reason: "Feature has coordinates with excessive precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/polygon.validation.spec.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.spec.ts
@@ -128,7 +128,8 @@ describe("isValidPolygonFeature", () => {
 		} as Feature<Polygon, Record<string, any>>;
 		expect(ValidatePolygonFeature(validFeature, 9)).toEqual({
 			valid: false,
-			reason: "Feature has invalid coordinates",
+			reason:
+				"Feature has invalid coordinates with excessive coordinate precision",
 		});
 	});
 });

--- a/packages/terra-draw/src/validations/polygon.validation.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.ts
@@ -1,7 +1,10 @@
 import { Feature, Polygon, Position } from "geojson";
 import { GeoJSONStoreFeatures } from "../terra-draw";
 import { selfIntersects } from "../geometry/boolean/self-intersects";
-import { coordinateIsValid } from "../geometry/boolean/is-valid-coordinate";
+import {
+	coordinateIsValid,
+	coordinatePrecisionIsValid,
+} from "../geometry/boolean/is-valid-coordinate";
 import { Validation } from "../common";
 
 export const ValidationReasonFeatureNotPolygon = "Feature is not a Polygon";
@@ -12,6 +15,8 @@ export const ValidationReasonFeatureHasInvalidCoordinates =
 	"Feature has invalid coordinates";
 export const ValidationReasonFeatureCoordinatesNotClosed =
 	"Feature coordinates are not closed";
+export const ValidationReasonFeatureInvalidCoordinatePrecision =
+	"Feature has invalid coordinates with excessive coordinate precision";
 
 export function ValidatePolygonFeature(
 	feature: GeoJSONStoreFeatures,
@@ -35,6 +40,17 @@ export function ValidatePolygonFeature(
 		return {
 			valid: false,
 			reason: ValidationReasonFeatureLessThanFourCoordinates,
+		};
+	}
+
+	if (
+		!feature.geometry.coordinates[0].every((coordinate) =>
+			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
+		)
+	) {
+		return {
+			valid: false,
+			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
 		};
 	}
 

--- a/packages/terra-draw/src/validations/polygon.validation.ts
+++ b/packages/terra-draw/src/validations/polygon.validation.ts
@@ -16,7 +16,7 @@ export const ValidationReasonFeatureHasInvalidCoordinates =
 export const ValidationReasonFeatureCoordinatesNotClosed =
 	"Feature coordinates are not closed";
 export const ValidationReasonFeatureInvalidCoordinatePrecision =
-	"Feature has invalid coordinates with excessive coordinate precision";
+	"Feature has coordinates with excessive precision";
 
 export function ValidatePolygonFeature(
 	feature: GeoJSONStoreFeatures,
@@ -43,26 +43,25 @@ export function ValidatePolygonFeature(
 		};
 	}
 
-	if (
-		!feature.geometry.coordinates[0].every((coordinate) =>
-			coordinatePrecisionIsValid(coordinate, coordinatePrecision),
-		)
-	) {
-		return {
-			valid: false,
-			reason: ValidationReasonFeatureInvalidCoordinatePrecision,
-		};
-	}
+	for (let i = 0; i < feature.geometry.coordinates[0].length; i++) {
+		if (!coordinateIsValid(feature.geometry.coordinates[0][i])) {
+			return {
+				valid: false,
+				reason: ValidationReasonFeatureHasInvalidCoordinates,
+			};
+		}
 
-	if (
-		!feature.geometry.coordinates[0].every((coordinate) =>
-			coordinateIsValid(coordinate, coordinatePrecision),
-		)
-	) {
-		return {
-			valid: false,
-			reason: ValidationReasonFeatureHasInvalidCoordinates,
-		};
+		if (
+			!coordinatePrecisionIsValid(
+				feature.geometry.coordinates[0][i],
+				coordinatePrecision,
+			)
+		) {
+			return {
+				valid: false,
+				reason: ValidationReasonFeatureInvalidCoordinatePrecision,
+			};
+		}
 	}
 
 	if (


### PR DESCRIPTION
## Description of Changes

Originally raised by @JinIgarashi - thank you! I have built on his original commits just making some additional changes to avoid double looping and to add some more tests

At a high level this ensures that excessive precision is handled separately and you get a specific error message when the precision is higher than what is defined by the adapter.

## Link to Issue

fixes #490

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 