### PR TITLE
fix(terra-draw-maplibre-gl-adapter): respect dragRotate and dragPan settings at initialisation

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -37,13 +37,13 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 				enable: jest.fn(),
 				disable: jest.fn(),
 				isActive: jest.fn(),
-				isEnabled: jest.fn(),
+				isEnabled: jest.fn(() => true),
 			} as unknown as maplibregl.DragPanHandler,
 			dragRotate: {
 				enable: jest.fn(),
 				disable: jest.fn(),
 				isActive: jest.fn(),
-				isEnabled: jest.fn(),
+				isEnabled: jest.fn(() => true),
 			} as unknown as maplibregl.DragRotateHandler,
 			addSource: jest.fn(),
 			addLayer: jest.fn(),
@@ -133,6 +133,7 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 	describe("setDraggability", () => {
 		it("setDraggability enables and disables map dragging", () => {
 			const map = createMapLibreGLMap();
+
 			const adapter = new TerraDrawMapLibreGLAdapter({
 				map: map as maplibregl.Map,
 			});
@@ -148,8 +149,58 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			adapter.setDraggability(false);
 			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
 			expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(1);
+			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+		});
+
+		it("respects original pan/rotate settings when calling setDraggability", () => {
+			const map = createMapLibreGLMap();
+
+			map.dragPan!.isEnabled = jest.fn(() => false);
+			map.dragRotate!.isEnabled = jest.fn(() => false);
+
+			const adapter = new TerraDrawMapLibreGLAdapter({
+				map: map as maplibregl.Map,
+			});
+
+			// Test enabling dragging
+			adapter.setDraggability(true);
+			expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
+
+			// Test disabling dragging
+			adapter.setDraggability(false);
+			expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
+		});
+
+		it("respects mixed pan/rotate settings when calling setDraggability", () => {
+			const map = createMapLibreGLMap();
+
+			map.dragPan!.isEnabled = jest.fn(() => true);
+			map.dragRotate!.isEnabled = jest.fn(() => false);
+
+			const adapter = new TerraDrawMapLibreGLAdapter({
+				map: map as maplibregl.Map,
+			});
+
+			// Test enabling dragging
+			adapter.setDraggability(true);
+			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
+			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
+
+			// Test disabling dragging
+			adapter.setDraggability(false);
 			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
 			expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
 		});
 	});
 

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -30,8 +30,14 @@ export class TerraDrawMapLibreGLAdapter<
 
 		this._map = config.map as Map;
 		this._container = this._map.getContainer();
+
+		// We want to respect the initial map settings
+		this._initialDragRotate = this._map.dragRotate.isEnabled();
+		this._initialDragPan = this._map.dragPan.isEnabled();
 	}
 
+	private _initialDragPan: boolean;
+	private _initialDragRotate: boolean;
 	private _nextRender: number | undefined;
 	private _map: Map;
 	private _container: HTMLElement;
@@ -243,11 +249,19 @@ export class TerraDrawMapLibreGLAdapter<
 		if (enabled) {
 			// MapLibre GL has both drag rotation and drag panning interactions
 			// hence having to enable/disable both
-			this._map.dragRotate.enable();
-			this._map.dragPan.enable();
+			if (this._initialDragRotate) {
+				this._map.dragRotate.enable();
+			}
+			if (this._initialDragPan) {
+				this._map.dragPan.enable();
+			}
 		} else {
-			this._map.dragRotate.disable();
-			this._map.dragPan.disable();
+			if (this._initialDragRotate) {
+				this._map.dragRotate.disable();
+			}
+			if (this._initialDragPan) {
+				this._map.dragPan.disable();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description of Changes

Fixes a long standing issue where initial dragRotate and dragPan are not respected when we need to call `setDraggability`. We do this so we can do our own custom behaviours without rotating or panning the map, but in the scenario the user has already disabled these we do not need to turn them back on.  

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/391

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 