### PR TITLE
fix(terra-draw): edits made via the editable option now trigger a finish event

### DIFF
--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -948,6 +948,8 @@ describe("TerraDrawLineStringMode", () => {
 
 			lineStringMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
 
+			mockConfig.onFinish.mockClear();
+
 			// Ensure it's there
 			let features = mockConfig.store.copyAll();
 			expect(features.length).toBe(1);
@@ -966,6 +968,9 @@ describe("TerraDrawLineStringMode", () => {
 			);
 			expect(mockConfig.setCursor).toHaveBeenCalledTimes(1);
 			expect(mockConfig.setCursor).toHaveBeenNthCalledWith(1, "grabbing");
+
+			// We don't call onFinish in onDragStart but in onDragEnd
+			expect(mockConfig.onFinish).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -1001,6 +1006,8 @@ describe("TerraDrawLineStringMode", () => {
 			lineStringMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
 
 			lineStringMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
+
+			mockConfig.onFinish.mockClear();
 
 			// Ensure it's there
 			let features = mockConfig.store.copyAll();
@@ -1046,6 +1053,9 @@ describe("TerraDrawLineStringMode", () => {
 
 			// We don't change the cursor in onDrag
 			expect(mockConfig.setCursor).toHaveBeenCalledTimes(0);
+
+			// We don't call onFinish in onDrag but in onDragEnd
+			expect(mockConfig.onFinish).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -1082,6 +1092,8 @@ describe("TerraDrawLineStringMode", () => {
 
 			lineStringMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
 
+			mockConfig.onFinish.mockClear();
+
 			// Ensure it's there
 			let features = mockConfig.store.copyAll();
 			expect(features.length).toBe(1);
@@ -1111,6 +1123,8 @@ describe("TerraDrawLineStringMode", () => {
 				[expect.any(String)],
 				"update",
 			);
+
+			expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -589,6 +589,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				geometry,
 			},
 		]);
+
+		this.onFinish(featureId, { mode: this.mode, action: "edit" });
 	}
 
 	private onLeftClick(event: TerraDrawMouseEvent) {
@@ -841,6 +843,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				value: false,
 			},
 		]);
+
+		this.onFinish(this.editedFeatureId, { mode: this.mode, action: "edit" });
 
 		// Reset edit state
 		this.editedFeatureId = undefined;

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -761,6 +761,8 @@ describe("TerraDrawPolygonMode", () => {
 			expect(featuresAfter[0].geometry.coordinates[0]).not.toEqual(
 				features[0].geometry.coordinates[0],
 			);
+
+			expect(onFinish).toHaveBeenCalledTimes(2);
 		});
 
 		describe("validate", () => {
@@ -1049,6 +1051,7 @@ describe("onDragStart", () => {
 
 		polygonMode.onDragStart(MockCursorEvent({ lng: 0, lat: 0 }), () => {});
 		expect(mockConfig.onChange).not.toHaveBeenCalled();
+		expect(mockConfig.onFinish).not.toHaveBeenCalled();
 	});
 
 	it("creates the drag point when editable is true and a coordinate is selected", () => {
@@ -1074,6 +1077,8 @@ describe("onDragStart", () => {
 
 		polygonMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
 
+		mockConfig.onFinish.mockClear();
+
 		// Ensure it's there
 		let features = mockConfig.store.copyAll();
 		expect(features.length).toBe(1);
@@ -1092,6 +1097,9 @@ describe("onDragStart", () => {
 		);
 		expect(mockConfig.setCursor).toHaveBeenCalledTimes(1);
 		expect(mockConfig.setCursor).toHaveBeenNthCalledWith(1, "grabbing");
+
+		// We don't call onFinish in onDragStart but in onDragEnd
+		expect(mockConfig.onFinish).toHaveBeenCalledTimes(0);
 	});
 });
 
@@ -1208,6 +1216,8 @@ describe("onDragEnd", () => {
 
 		polygonMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
 
+		mockConfig.onFinish.mockClear();
+
 		// Ensure it's there
 		let features = mockConfig.store.copyAll();
 		expect(features.length).toBe(1);
@@ -1237,6 +1247,8 @@ describe("onDragEnd", () => {
 			[expect.any(String)],
 			"update",
 		);
+
+		expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -441,6 +441,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	}
 
 	private onRightClick(event: TerraDrawMouseEvent) {
+		// Right click is only relevant when editable is true
 		if (!this.editable) {
 			return;
 		}
@@ -517,6 +518,8 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				geometry,
 			},
 		]);
+
+		this.onFinish(featureId, { mode: this.mode, action: "edit" });
 	}
 
 	private onLeftClick(event: TerraDrawMouseEvent) {
@@ -928,6 +931,8 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				value: false,
 			},
 		]);
+
+		this.onFinish(this.editedFeatureId, { mode: this.mode, action: "edit" });
 
 		// Reset edit state
 		this.editedFeatureId = undefined;


### PR DESCRIPTION
## Description of Changes

This PR ensures that a `finish` event is triggered when editing action is completed in polygon and linestring modes. Previously no event was triggered which made it hard to know when the edit was completed.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/506

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 