### PR TITLE
fix(terra-draw-arcgis-adapter): initial handling of zIndexes in the render function

### DIFF
--- a/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.spec.ts
+++ b/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.spec.ts
@@ -371,7 +371,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			);
 
 			expect(graphicsMock.add).toHaveBeenCalledTimes(1);
-			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall);
+			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall, 0);
 			expect(removeMock).not.toHaveBeenCalled();
 		});
 
@@ -404,7 +404,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 			expect(removeMock).toHaveBeenCalledTimes(1);
 			expect(removeMock).toHaveBeenLastCalledWith(mockedFeature);
 			expect(graphicsMock.add).toHaveBeenCalledTimes(1);
-			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall);
+			expect(graphicsMock.add).toHaveBeenLastCalledWith(mockedGraphicCall, 0);
 		});
 
 		it("handles deleted ids", () => {
@@ -535,7 +535,7 @@ describe("TerraDrawArcGISMapsSDKAdapter", () => {
 					},
 				);
 
-				expect(graphicsMock.add).toHaveBeenCalledWith(mockedGraphicCall);
+				expect(graphicsMock.add).toHaveBeenCalledWith(mockedGraphicCall, 0);
 			});
 		});
 

--- a/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
+++ b/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
@@ -261,7 +261,7 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawExtend.TerraDrawBase
 		});
 
 		// ensure we add points at the topmost position by adding other geometries at index 0
-		if (type === "Point") {
+		if (type === "Point" && style.zIndex >= 30) {
 			this._featureLayer.graphics.add(graphic);
 		} else {
 			this._featureLayer.graphics.add(graphic, 0);


### PR DESCRIPTION
## Description of Changes

Adds basic zIndex support for the ArcGIS adapter, this needs improving long term to handle zindexing properly.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 