### PR TITLE
fix(terra-draw-google-maps-adapter): initial handling of zIndexes in the render function 

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -434,12 +434,14 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 							rotation: 0,
 							scale: 1,
 						},
+						zIndex: calculatedStyles.zIndex,
 					};
 
 				case "LineString":
 					return {
 						strokeColor: calculatedStyles.lineStringColor,
 						strokeWeight: calculatedStyles.lineStringWidth,
+						zIndex: calculatedStyles.zIndex,
 					};
 				case "Polygon":
 					return {
@@ -447,6 +449,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 						strokeWeight: calculatedStyles.polygonOutlineWidth,
 						fillOpacity: calculatedStyles.polygonFillOpacity,
 						fillColor: calculatedStyles.polygonFillColor,
+						zIndex: calculatedStyles.zIndex,
 					};
 			}
 


### PR DESCRIPTION
## Description of Changes

Adds simple handling for zIndexs in the Google Maps adapter

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 