### PR TITLE
fix(terra-draw-mapbox-gl-adapter): better handle zindexes to support layered points

### DIFF
--- a/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.spec.ts
+++ b/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.spec.ts
@@ -258,8 +258,8 @@ describe("TerraDrawMapboxGLAdapter", () => {
 			const rAFCallback = (requestAnimationFrame as jest.Mock).mock.calls[0][0];
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(3);
-			expect(map.addLayer).toHaveBeenCalledTimes(4);
+			expect(map.addSource).toHaveBeenCalledTimes(4);
+			expect(map.addLayer).toHaveBeenCalledTimes(5);
 
 			adapter.clear();
 
@@ -295,8 +295,8 @@ describe("TerraDrawMapboxGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(3);
-			expect(map.addLayer).toHaveBeenCalledTimes(4);
+			expect(map.addSource).toHaveBeenCalledTimes(4);
+			expect(map.addLayer).toHaveBeenCalledTimes(5);
 		});
 
 		it("updates layers and sources when data is passed", () => {
@@ -307,7 +307,13 @@ describe("TerraDrawMapboxGLAdapter", () => {
 				map: map as mapboxgl.Map,
 			});
 
+			expect(map.addSource).toHaveBeenCalledTimes(0);
+			expect(map.addLayer).toHaveBeenCalledTimes(0);
+
 			adapter.register(MockCallbacks());
+
+			expect(map.addSource).toHaveBeenCalledTimes(4);
+			expect(map.addLayer).toHaveBeenCalledTimes(5);
 
 			adapter.render(
 				{
@@ -325,8 +331,8 @@ describe("TerraDrawMapboxGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(3);
-			expect(map.addLayer).toHaveBeenCalledTimes(4);
+			expect(map.addSource).toHaveBeenCalledTimes(4);
+			expect(map.addLayer).toHaveBeenCalledTimes(5);
 
 			adapter.render(
 				{
@@ -391,7 +397,7 @@ describe("TerraDrawMapboxGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.getSource).toHaveBeenCalledTimes(6);
+			expect(map.getSource).toHaveBeenCalledTimes(8);
 
 			adapter.render(
 				{
@@ -412,7 +418,7 @@ describe("TerraDrawMapboxGLAdapter", () => {
 			rAFCallback();
 
 			// Force update because of the deletion
-			expect(map.getSource).toHaveBeenCalledTimes(9);
+			expect(map.getSource).toHaveBeenCalledTimes(12);
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

This PR allows handling of layered points by creating a separate layer for points that sit under the main points layer

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 