### PR TITLE
feat(terra-draw): add showCoordinatePoints to provide a way to render coordinate points for polygons

### DIFF
--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -173,6 +173,7 @@ const example = {
 					snapping: {
 						toCoordinate: this.config?.includes("snappingCoordinate"),
 					},
+					showCoordinatePoints: this.config?.includes("showCoordinatePoints"),
 				}),
 				new TerraDrawRectangleMode(),
 				new TerraDrawCircleMode({

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -663,6 +663,148 @@ test.describe("polygon mode", () => {
 		await expectPaths({ page, count: 1 });
 		await expectPathDimensions({ page, width: 104, height: 104 });
 	});
+
+	test("can use showCoordinatePoints to render coordinate points", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["showCoordinatePoints"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 5 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
+	});
+
+	test("can use showCoordinatePoints alongside editable to edit drawn polygon by dragging one of it's coordinates", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["polygonEditable", "showCoordinatePoints"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = { x: centerX - halfLength, y: centerY + halfLength };
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 5 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
+
+		await page.mouse.move(topLeft.x, topLeft.y);
+		await page.mouse.down();
+		await page.mouse.move(topLeft.x - 100, topLeft.y - 10, { steps: 30 });
+
+		// Check to see the editable point has appeared
+		await expectPaths({ page, count: 6 });
+
+		// Stop editing (dragging)
+		await page.mouse.up();
+
+		// Check to see the editable point has disappeared
+		await expectPaths({ page, count: 5 });
+
+		// Check to see the dimensions have changed due to the edit
+		await expectPathDimensions({ page, width: 204, height: 114 });
+	});
+
+	test("can use  showCoordinatePoints alongside editable to delete a coordinate with right click", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["polygonEditable", "showCoordinatePoints"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		// Coordinates of the four corners of the square
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+		const topRight = { x: centerX + halfLength, y: centerY - halfLength };
+		const bottomLeft = {
+			x: centerX - halfLength + 25,
+			y: centerY + halfLength + 25,
+		};
+		const bottomRight = { x: centerX + halfLength, y: centerY + halfLength };
+
+		// Perform clicks at each corner
+		await page.mouse.click(topLeft.x, topLeft.y);
+		await page.mouse.click(topRight.x, topRight.y);
+		await page.mouse.click(bottomRight.x, bottomRight.y);
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		// Close the square
+		await page.mouse.click(bottomLeft.x, bottomLeft.y);
+
+		await expectPaths({ page, count: 5 });
+		await expectPathDimensions({ page, width: 104, height: 129 });
+
+		await page.mouse.click(bottomLeft.x, bottomLeft.y, {
+			button: "right",
+			clickCount: 1,
+		});
+
+		// The dimensions should have changed due to the deletion
+		await expectPaths({ page, count: 4 });
+		await expectPathDimensions({ page, width: 104, height: 104 });
+	});
 });
 
 test.describe("rectangle mode", () => {

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -12,7 +12,8 @@ export type TestConfigOptions =
 	| "insertCoordinatesGlobe"
 	| "globeCircle"
 	| "globeSelect"
-	| "snappingCoordinate";
+	| "snappingCoordinate"
+	| "showCoordinatePoints";
 
 export const setupMap = async ({
 	page,

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -175,4 +175,6 @@ export const COMMON_PROPERTIES = {
 	EDITED: "edited",
 	CLOSING_POINT: "closingPoint",
 	SNAPPING_POINT: "snappingPoint",
+	COORDINATE_POINT: "coordinatePoint",
+	COORDINATE_POINT_IDS: "coordinatePointIds",
 };

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -179,6 +179,8 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 		return this.performFeatureValidation(feature);
 	}
 
+	afterFeatureAdded(feature: GeoJSONStoreFeatures) {}
+
 	private performFeatureValidation(feature: unknown): ReturnType<Validation> {
 		if (this._state === "unregistered") {
 			throw new Error("Mode must be registered");

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -1,0 +1,120 @@
+import { Feature, Position } from "geojson";
+import { COMMON_PROPERTIES } from "../../../common";
+import { GeoJSONStoreFeatures, JSONObject } from "../../../store/store";
+import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
+import { MockPolygonSquare } from "../../../test/mock-features";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
+
+describe("CoordinatePointBehavior", () => {
+	const UUIDV4 = new RegExp(
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+	);
+
+	const isUUIDV4 = (received: string) => UUIDV4.test(received);
+
+	describe("constructor", () => {
+		it("constructs", () => {
+			new CoordinatePointBehavior(MockBehaviorConfig("test"));
+		});
+	});
+
+	describe("api", () => {
+		it("createOrUpdate", () => {
+			const config = MockBehaviorConfig("test");
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			expect(config.store.has(featureId)).toBe(true);
+			coordinatePointBehavior.createOrUpdate(featureId);
+
+			const properties = config.store.getPropertiesCopy(featureId);
+			expect(properties).toBeDefined();
+
+			const coordinatePointIds = properties.coordinatePointIds as string[];
+			expect(coordinatePointIds.length).toBe(4);
+			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
+		});
+
+		it("deletePointsByFeatureIds", () => {
+			const config = MockBehaviorConfig("test");
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			expect(config.store.has(featureId)).toBe(true);
+			coordinatePointBehavior.createOrUpdate(featureId);
+
+			const properties = config.store.getPropertiesCopy(featureId);
+			expect(properties).toBeDefined();
+
+			const coordinatePointIds = properties.coordinatePointIds as string[];
+			expect(coordinatePointIds.length).toBe(4);
+			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
+
+			coordinatePointBehavior.deletePointsByFeatureIds([featureId]);
+
+			const propertiesAfterDelete = config.store.getPropertiesCopy(featureId);
+			expect(propertiesAfterDelete.coordinatePointIds).toBe(null);
+
+			const coordinatePointsAfterDelete = config.store.copyAllWhere(
+				(properties) => Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+			);
+			expect(coordinatePointsAfterDelete).toStrictEqual([]);
+		});
+
+		it("getUpdated", () => {
+			const config = MockBehaviorConfig("test");
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			expect(config.store.has(featureId)).toBe(true);
+			coordinatePointBehavior.createOrUpdate(featureId);
+
+			const properties = config.store.getPropertiesCopy(featureId);
+			expect(properties).toBeDefined();
+
+			const coordinatePointIds = properties.coordinatePointIds as string[];
+			expect(coordinatePointIds.length).toBe(4);
+			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
+
+			const updatedCoordinates = [
+				[0, 0],
+				[0, 1],
+				[1, 0],
+				[1, 1],
+			] as Position[];
+
+			const updatedPoints = coordinatePointBehavior.getUpdated(
+				featureId,
+				updatedCoordinates,
+			) as GeoJSONStoreFeatures[];
+
+			expect(updatedPoints).toBeDefined();
+			expect(updatedPoints.length).toBe(4);
+			expect(
+				updatedPoints.every((point) => point.geometry.type === "Point"),
+			).toBe(true);
+			expect(updatedPoints.every((_, i) => updatedCoordinates[i])).toBe(true);
+		});
+	});
+});

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
@@ -1,0 +1,146 @@
+import { Point, Position } from "geojson";
+import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
+import { FeatureId } from "../../../store/store";
+import { COMMON_PROPERTIES } from "../../../common";
+
+export class CoordinatePointBehavior extends TerraDrawModeBehavior {
+	constructor(config: BehaviorConfig) {
+		super(config);
+	}
+
+	public createOrUpdate(featureId: FeatureId) {
+		const existingFeature = this.store.getGeometryCopy(featureId);
+		const existingProperties = this.store.getPropertiesCopy(featureId);
+
+		let coordinates: Position[];
+
+		if (existingFeature.type === "Polygon") {
+			coordinates = existingFeature.coordinates[0].slice(0, -1) as Position[];
+		} else if (existingFeature.type === "LineString") {
+			coordinates = existingFeature.coordinates as Position[];
+		} else {
+			return;
+		}
+
+		const existingFeatureProps = this.store.getPropertiesCopy(featureId);
+
+		if (!existingFeatureProps.coordinatePointIds) {
+			const coordinatePointIds = this.createPoints(
+				coordinates,
+				existingProperties.mode as string,
+			);
+			this.setFeatureCoordinatePoints(featureId, coordinatePointIds);
+		} else {
+			// Check if the coordinates have changed
+			const existingCoordinates =
+				existingFeatureProps.coordinatePointIds as FeatureId[];
+			const existingCoordinatePoints = existingCoordinates.map(
+				(id) => this.store.getGeometryCopy(id).coordinates as Position,
+			);
+
+			// If the number of coordinates has changed, delete and recreate as it's too
+			// complex to update the existing coordinates unless someone is feeling brave
+			if (existingCoordinates.length !== coordinates.length) {
+				this.deleteCoordinatePoints(existingCoordinates);
+				const coordinatePointIds = this.createPoints(
+					coordinates,
+					existingProperties.mode as string,
+				);
+				this.setFeatureCoordinatePoints(featureId, coordinatePointIds);
+			} else {
+				// Update the coordinates
+				coordinates.forEach((coordinate, i) => {
+					// If the coordinates are the same, don't update
+					if (
+						coordinate[0] === existingCoordinatePoints[i][0] &&
+						coordinate[1] === existingCoordinatePoints[i][1]
+					) {
+						return;
+					}
+					// Only update the coordinates that have changed
+					this.store.updateGeometry([
+						{
+							id: existingCoordinates[i],
+							geometry: {
+								type: "Point",
+								coordinates: coordinate,
+							} as Point,
+						},
+					]);
+				});
+			}
+		}
+	}
+
+	public deletePointsByFeatureIds(features: FeatureId[]) {
+		for (const featureId of features) {
+			this.deleteIfPresent(featureId);
+		}
+	}
+
+	public getUpdated(featureId: FeatureId, updatedCoordinates: Position[]) {
+		const featureProperties = this.store.getPropertiesCopy(featureId);
+
+		if (!featureProperties.coordinatePointIds) {
+			return undefined;
+		}
+
+		return (featureProperties.coordinatePointIds as FeatureId[]).map(
+			(id, i) => {
+				return {
+					id,
+					geometry: {
+						...this.store.getGeometryCopy(id),
+						coordinates: updatedCoordinates[i],
+					} as Point,
+				};
+			},
+		) as {
+			id: FeatureId;
+			geometry: Point;
+		}[];
+	}
+
+	private createPoints(coordinates: Position[], mode: string) {
+		return this.store.create(
+			coordinates.map((coordinate) => ({
+				geometry: {
+					type: "Point",
+					coordinates: coordinate,
+				},
+				properties: {
+					mode,
+					[COMMON_PROPERTIES.COORDINATE_POINT]: true,
+				},
+			})),
+		);
+	}
+
+	private setFeatureCoordinatePoints(
+		featureId: FeatureId,
+		value: FeatureId[] | null,
+	) {
+		this.store.updateProperty([
+			{
+				id: featureId,
+				property: COMMON_PROPERTIES.COORDINATE_POINT_IDS,
+				value: value,
+			},
+		]);
+	}
+
+	private deleteCoordinatePoints(coordinatePointIds: FeatureId[]) {
+		this.store.delete(coordinatePointIds as FeatureId[]);
+	}
+
+	private deleteIfPresent(featureId: FeatureId) {
+		const existingFeatureProps = this.store.getPropertiesCopy(featureId);
+
+		if (existingFeatureProps.coordinatePointIds) {
+			this.deleteCoordinatePoints(
+				existingFeatureProps.coordinatePointIds as FeatureId[],
+			);
+			this.setFeatureCoordinatePoints(featureId, null);
+		}
+	}
+}

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -10,6 +10,7 @@ import { DragCoordinateResizeBehavior } from "./drag-coordinate-resize.behavior"
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MockCursorEvent } from "../../../test/mock-cursor-event";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 describe("DragCoordinateResizeBehavior", () => {
 	const createLineString = (
@@ -38,11 +39,17 @@ describe("DragCoordinateResizeBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
 			new DragCoordinateResizeBehavior(
 				config,
 				new PixelDistanceBehavior(config),
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 		});
 	});
@@ -55,9 +62,12 @@ describe("DragCoordinateResizeBehavior", () => {
 			config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
 			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			const midpointBehavior = new MidPointBehavior(
 				config,
 				selectionPointBehavior,
+				coordinatePointBehavior,
 			);
 
 			dragMaintainedShapeBehavior = new DragCoordinateResizeBehavior(
@@ -65,6 +75,7 @@ describe("DragCoordinateResizeBehavior", () => {
 				pixelDistanceBehavior,
 				selectionPointBehavior,
 				midpointBehavior,
+				coordinatePointBehavior,
 			);
 		});
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -21,6 +21,7 @@ import {
 	webMercatorXYToLngLat,
 } from "../../../geometry/project/web-mercator";
 import { webMercatorCentroid } from "../../../geometry/web-mercator-centroid";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 export type ResizeOptions =
 	| "center"
@@ -47,6 +48,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		private readonly pixelDistance: PixelDistanceBehavior,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior,
+		private readonly coordinatePoints: CoordinatePointBehavior,
 	) {
 		super(config);
 	}
@@ -473,9 +475,12 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			return null;
 		}
 
-		const feature = { type: "Feature", geometry, properties: {} } as Feature<
-			Polygon | LineString
-		>;
+		const feature = {
+			id,
+			type: "Feature",
+			geometry,
+			properties: {},
+		} as Feature<Polygon | LineString>;
 
 		return feature;
 	}
@@ -718,6 +723,11 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const updatedMidPoints = this.midPoints.getUpdated(updatedCoords) || [];
 		const updatedSelectionPoints =
 			this.selectionPoints.getUpdated(updatedCoords) || [];
+		const updatedCoordinatePoints =
+			this.coordinatePoints.getUpdated(
+				feature.id as FeatureId,
+				updatedCoords,
+			) || [];
 
 		const updatedGeometry = {
 			type: feature.geometry.type as "Polygon" | "LineString",
@@ -753,6 +763,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			},
 			...updatedSelectionPoints,
 			...updatedMidPoints,
+			...updatedCoordinatePoints,
 		]);
 
 		return true;

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -10,6 +10,7 @@ import { DragCoordinateBehavior } from "./drag-coordinate.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { MockCursorEvent } from "../../../test/mock-cursor-event";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 describe("DragCoordinateBehavior", () => {
 	const createLineString = (
@@ -38,11 +39,18 @@ describe("DragCoordinateBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			new DragCoordinateBehavior(
 				config,
 				new PixelDistanceBehavior(config),
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 		});
 	});
@@ -55,9 +63,12 @@ describe("DragCoordinateBehavior", () => {
 			config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
 			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			const midpointBehavior = new MidPointBehavior(
 				config,
 				selectionPointBehavior,
+				coordinatePointBehavior,
 			);
 
 			dragCoordinateBehavior = new DragCoordinateBehavior(
@@ -65,6 +76,7 @@ describe("DragCoordinateBehavior", () => {
 				pixelDistanceBehavior,
 				selectionPointBehavior,
 				midpointBehavior,
+				coordinatePointBehavior,
 			);
 		});
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -7,6 +7,7 @@ import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { selfIntersects } from "../../../geometry/boolean/self-intersects";
 import { FeatureId } from "../../../store/store";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -14,6 +15,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		private readonly pixelDistance: PixelDistanceBehavior,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior,
+		private readonly coordinatePoints: CoordinatePointBehavior,
 	) {
 		super(config);
 	}
@@ -142,6 +144,12 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 
 		const updatedMidPoints = this.midPoints.getUpdated(geomCoordinates) || [];
 
+		const updatedCoordinatePoints =
+			this.coordinatePoints.getUpdated(
+				this.draggedCoordinate.id,
+				geomCoordinates,
+			) || [];
+
 		if (
 			geometry.type !== "Point" &&
 			!allowSelfIntersection &&
@@ -185,6 +193,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 			// Update selection and mid points
 			...updatedSelectionPoints,
 			...updatedMidPoints,
+			...updatedCoordinatePoints,
 		]);
 
 		return true;

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -4,6 +4,7 @@ import { MockCursorEvent } from "../../../test/mock-cursor-event";
 import { BehaviorConfig } from "../../base.behavior";
 import { ClickBoundingBoxBehavior } from "../../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { DragFeatureBehavior } from "./drag-feature.behavior";
 import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
@@ -19,9 +20,12 @@ describe("DragFeatureBehavior", () => {
 				new ClickBoundingBoxBehavior(config),
 				new PixelDistanceBehavior(config),
 			);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			const midpointBehavior = new MidPointBehavior(
 				config,
 				selectionPointBehavior,
+				coordinatePointBehavior,
 			);
 
 			new DragFeatureBehavior(
@@ -29,6 +33,7 @@ describe("DragFeatureBehavior", () => {
 				featureAtPointerEventBehavior,
 				selectionPointBehavior,
 				midpointBehavior,
+				coordinatePointBehavior,
 			);
 		});
 	});
@@ -48,9 +53,12 @@ describe("DragFeatureBehavior", () => {
 				new ClickBoundingBoxBehavior(config),
 				new PixelDistanceBehavior(config),
 			);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			const midpointBehavior = new MidPointBehavior(
 				config,
 				selectionPointBehavior,
+				coordinatePointBehavior,
 			);
 
 			dragFeatureBehavior = new DragFeatureBehavior(
@@ -58,6 +66,7 @@ describe("DragFeatureBehavior", () => {
 				featureAtPointerEventBehavior,
 				selectionPointBehavior,
 				midpointBehavior,
+				coordinatePointBehavior,
 			);
 		});
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -10,6 +10,7 @@ import {
 	lngLatToWebMercatorXY,
 	webMercatorXYToLngLat,
 } from "../../../geometry/project/web-mercator";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 export class DragFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -17,6 +18,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 		private readonly featuresAtCursorEvent: FeatureAtPointerEventBehavior,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior,
+		private readonly coordinatePoints: CoordinatePointBehavior,
 	) {
 		super(config);
 	}
@@ -158,6 +160,12 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 
 			const updatedMidPoints = this.midPoints.getUpdated(updatedCoords) || [];
 
+			const updatedCoordinatePoints =
+				this.coordinatePoints.getUpdated(
+					this.draggedFeatureId,
+					updatedCoords,
+				) || [];
+
 			if (validateFeature) {
 				const validationResult = validateFeature(
 					{
@@ -184,6 +192,7 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 				{ id: this.draggedFeatureId, geometry },
 				...updatedSelectionPoints,
 				...updatedMidPoints,
+				...updatedCoordinatePoints,
 			]);
 
 			this.dragPosition = [event.lng, event.lat];

--- a/packages/terra-draw/src/modes/select/behaviors/feature-at-pointer-event.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/feature-at-pointer-event.behavior.ts
@@ -37,10 +37,11 @@ export class FeatureAtPointerEventBehavior extends TerraDrawModeBehavior {
 				// Ignore selection points always, and ignore mid points
 				// when nothing is selected
 				const isSelectionPoint = feature.properties.selectionPoint;
+				const isCoordinatePoint = feature.properties.coordinatePoint;
 				const isNonSelectedMidPoint =
 					!hasSelection && feature.properties[SELECT_PROPERTIES.MID_POINT];
 
-				if (isSelectionPoint || isNonSelectedMidPoint) {
+				if (isSelectionPoint || isCoordinatePoint || isNonSelectedMidPoint) {
 					continue;
 				}
 

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../test/create-store-features";
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { BehaviorConfig } from "../../base.behavior";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 
@@ -18,7 +19,11 @@ describe("MidPointBehavior", () => {
 
 	describe("constructor", () => {
 		it("constructs", () => {
-			new MidPointBehavior(config, new SelectionPointBehavior(config));
+			new MidPointBehavior(
+				config,
+				new SelectionPointBehavior(config),
+				new CoordinatePointBehavior(config),
+			);
 		});
 	});
 
@@ -34,6 +39,7 @@ describe("MidPointBehavior", () => {
 				const midPointBehavior = new MidPointBehavior(
 					config,
 					new SelectionPointBehavior(config),
+					new CoordinatePointBehavior(config),
 				);
 
 				expect(midPointBehavior.ids).toStrictEqual([]);
@@ -43,6 +49,7 @@ describe("MidPointBehavior", () => {
 				const midPointBehavior = new MidPointBehavior(
 					config,
 					new SelectionPointBehavior(config),
+					new CoordinatePointBehavior(config),
 				);
 
 				midPointBehavior.ids = ["test"];
@@ -54,6 +61,7 @@ describe("MidPointBehavior", () => {
 				const midPointBehavior = new MidPointBehavior(
 					config,
 					new SelectionPointBehavior(config),
+					new CoordinatePointBehavior(config),
 				);
 
 				jest.spyOn(config.store, "create");
@@ -74,6 +82,7 @@ describe("MidPointBehavior", () => {
 				const midPointBehavior = new MidPointBehavior(
 					config,
 					new SelectionPointBehavior(config),
+					new CoordinatePointBehavior(config),
 				);
 
 				jest.spyOn(config.store, "create");
@@ -98,6 +107,7 @@ describe("MidPointBehavior", () => {
 				const midPointBehavior = new MidPointBehavior(
 					config,
 					new SelectionPointBehavior(config),
+					new CoordinatePointBehavior(config),
 				);
 
 				const createdId = createStoreLineString(config);
@@ -121,6 +131,7 @@ describe("MidPointBehavior", () => {
 					const midPointBehavior = new MidPointBehavior(
 						config,
 						new SelectionPointBehavior(config),
+						new CoordinatePointBehavior(config),
 					);
 					const result = midPointBehavior.getUpdated([
 						[0, 0],
@@ -136,6 +147,7 @@ describe("MidPointBehavior", () => {
 					const midPointBehavior = new MidPointBehavior(
 						config,
 						new SelectionPointBehavior(config),
+						new CoordinatePointBehavior(config),
 					);
 
 					const createdId = createStoreLineString(config);
@@ -179,6 +191,7 @@ describe("MidPointBehavior", () => {
 					const midPointBehavior = new MidPointBehavior(
 						config,
 						new SelectionPointBehavior(config),
+						new CoordinatePointBehavior(config),
 					);
 
 					jest.spyOn(config.store, "create");
@@ -208,7 +221,7 @@ describe("MidPointBehavior", () => {
 
 					expect(isUUIDV4(midPointId)).toBe(true);
 
-					midPointBehavior.insert(midPointId, coordinatePrecision);
+					midPointBehavior.insert(createdId, midPointId, coordinatePrecision);
 
 					expect(config.store.create).toHaveBeenCalledTimes(4);
 
@@ -237,6 +250,7 @@ describe("MidPointBehavior", () => {
 					const midPointBehavior = new MidPointBehavior(
 						config,
 						new SelectionPointBehavior(config),
+						new CoordinatePointBehavior(config),
 					);
 
 					jest.spyOn(config.store, "create");
@@ -269,7 +283,7 @@ describe("MidPointBehavior", () => {
 
 					expect(isUUIDV4(midPointId)).toBe(true);
 
-					midPointBehavior.insert(midPointId, coordinatePrecision);
+					midPointBehavior.insert(createdId, midPointId, coordinatePrecision);
 
 					expect(config.store.create).toHaveBeenCalledTimes(4);
 

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -6,6 +6,7 @@ import {
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { MockCursorEvent } from "../../../test/mock-cursor-event";
 import { BehaviorConfig } from "../../base.behavior";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { RotateFeatureBehavior } from "./rotate-feature.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -15,10 +16,17 @@ describe("RotateFeatureBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			new RotateFeatureBehavior(
 				config,
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 		});
 	});
@@ -30,10 +38,17 @@ describe("RotateFeatureBehavior", () => {
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			rotateFeatureBehavior = new RotateFeatureBehavior(
 				config,
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 
 			jest.spyOn(config.store, "updateGeometry");

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.ts
@@ -14,12 +14,14 @@ import { FeatureId } from "../../../store/store";
 import { webMercatorCentroid } from "../../../geometry/web-mercator-centroid";
 import { lngLatToWebMercatorXY } from "../../../geometry/project/web-mercator";
 import { webMercatorBearing } from "../../../geometry/measure/bearing";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior,
+		private readonly coordinatePoints: CoordinatePointBehavior,
 	) {
 		super(config);
 	}
@@ -101,6 +103,9 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 		const updatedSelectionPoints =
 			this.selectionPoints.getUpdated(updatedCoords) || [];
 
+		const updatedCoordinatePoints =
+			this.coordinatePoints.getUpdated(selectedId, updatedCoords) || [];
+
 		if (validateFeature) {
 			if (
 				!validateFeature(
@@ -127,6 +132,7 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 			{ id: selectedId, geometry },
 			...updatedSelectionPoints,
 			...updatedMidPoints,
+			...updatedCoordinatePoints,
 		]);
 
 		if (this.projection === "web-mercator") {

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -6,6 +6,7 @@ import {
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { MockCursorEvent } from "../../../test/mock-cursor-event";
 import { BehaviorConfig } from "../../base.behavior";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { ScaleFeatureBehavior } from "./scale-feature.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
@@ -15,10 +16,16 @@ describe("ScaleFeatureBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
 			new ScaleFeatureBehavior(
 				config,
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 		});
 	});
@@ -30,10 +37,17 @@ describe("ScaleFeatureBehavior", () => {
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
 			const selectionPointBehavior = new SelectionPointBehavior(config);
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
 			scaleFeatureBehavior = new ScaleFeatureBehavior(
 				config,
 				selectionPointBehavior,
-				new MidPointBehavior(config, selectionPointBehavior),
+				new MidPointBehavior(
+					config,
+					selectionPointBehavior,
+					coordinatePointBehavior,
+				),
+				coordinatePointBehavior,
 			);
 
 			jest.spyOn(config.store, "updateGeometry");

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -17,12 +17,14 @@ import {
 	webMercatorXYToLngLat,
 } from "../../../geometry/project/web-mercator";
 import { cartesianDistance } from "../../../geometry/measure/pixel-distance";
+import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 
 export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
 		private readonly selectionPoints: SelectionPointBehavior,
 		private readonly midPoints: MidPointBehavior,
+		private readonly coordinatePoints: CoordinatePointBehavior,
 	) {
 		super(config);
 	}
@@ -105,6 +107,9 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 		const updatedSelectionPoints =
 			this.selectionPoints.getUpdated(updatedCoords) || [];
 
+		const updatedCoordinatePoints =
+			this.coordinatePoints.getUpdated(selectedId, updatedCoords) || [];
+
 		if (validateFeature) {
 			if (
 				!validateFeature(
@@ -131,6 +136,7 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 			{ id: selectedId, geometry },
 			...updatedSelectionPoints,
 			...updatedMidPoints,
+			...updatedCoordinatePoints,
 		]);
 
 		this.lastDistance = distance;

--- a/packages/terra-draw/src/store/store.ts
+++ b/packages/terra-draw/src/store/store.ts
@@ -93,6 +93,7 @@ export class GeoJSONStore<Id extends FeatureId = FeatureId> {
 			feature: unknown,
 			tracked?: boolean,
 		) => StoreValidation,
+		afterFeatureAdded?: (feature: GeoJSONStoreFeatures) => void,
 	): StoreValidation[] {
 		if (data.length === 0) {
 			return [];
@@ -164,6 +165,8 @@ export class GeoJSONStore<Id extends FeatureId = FeatureId> {
 
 			this.store[id] = feature;
 			changes.push(id);
+
+			afterFeatureAdded && afterFeatureAdded(feature);
 
 			validations.push({ id, valid: true });
 
@@ -341,6 +344,18 @@ export class GeoJSONStore<Id extends FeatureId = FeatureId> {
 
 	copyAll(): GeoJSONStoreFeatures[] {
 		return this.clone(Object.keys(this.store).map((id) => this.store[id]));
+	}
+
+	copyAllWhere(
+		equals: (properties: JSONObject) => boolean,
+	): GeoJSONStoreFeatures[] {
+		return this.clone(
+			Object.keys(this.store)
+				.map((id) => this.store[id])
+				.filter((feature) => {
+					return feature.properties && equals(feature.properties);
+				}),
+		);
 	}
 
 	clear(): void {


### PR DESCRIPTION
## Description of Changes

This PR attempts to add the concept of 'coordinate points' to polygon mode, so that all coordinates of a polygon geometry are always rendered whilst drawing. 

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 