### PR TITLE
feat(terra-draw): add snappable as an option for dragging geometry coordinates in select mode

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -243,6 +243,9 @@ const selectMode = new TerraDrawSelectMode({
           // Can be moved
           draggable: true,
 
+          // Can snap to other coordinates from geometries _of the same mode_
+          snappable: true,
+
           // Allow resizing of the geometry from a given origin. 
           // center will allow resizing of the aspect ratio from the center
           // and opposite allows resizing from the opposite corner of the 

--- a/packages/development/src/index.ts
+++ b/packages/development/src/index.ts
@@ -116,6 +116,7 @@ const getModes = () => {
 						rotateable: true,
 						scaleable: true,
 						coordinates: {
+							snappable: true,
 							midpoints: true,
 							draggable: true,
 							deletable: true,
@@ -195,11 +196,11 @@ const getModes = () => {
 			},
 			styles: {
 				snappingPointColor: "#ffff00",
-				editedPointColor: "#008000",
-				coordinatePointColor: "#ff0000",
-				closingPointColor: "#0000ff",
+				// editedPointColor: "#008000",
+				// coordinatePointColor: "#ff0000",
+				// closingPointColor: "#0000ff",
 			},
-			showCoordinatePoints: true,
+			// showCoordinatePoints: true,
 		}),
 		new TerraDrawRectangleMode(),
 		new TerraDrawCircleMode(),

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -105,6 +105,7 @@ class TestMap {
 								rotateable: true,
 								scaleable: true,
 								coordinates: {
+									snappable: this.config?.includes("selectDragSnapping"),
 									midpoints: true,
 									draggable: true,
 									deletable: true,

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -13,7 +13,8 @@ export type TestConfigOptions =
 	| "globeCircle"
 	| "globeSelect"
 	| "snappingCoordinate"
-	| "showCoordinatePoints";
+	| "showCoordinatePoints"
+	| "selectDragSnapping";
 
 export const setupMap = async ({
 	page,
@@ -144,10 +145,12 @@ export const expectGroupPosition = async ({
 	page,
 	x,
 	y,
+	item,
 }: {
 	page: Page;
 	x: number;
 	y: number;
+	item?: number;
 }) => {
 	const selector = "svg > g > path";
 


### PR DESCRIPTION
## Description of Changes

Provides a way to snap to other coordinates in select mode for geometries of the same mode. You can now configure flags like so in TerraDrawSelectMode:

```typescript

new TerraDrawSelectMode({
	projection: "web-mercator",
	flags: {
		polygon: {
			feature: {
				coordinates: {
					snappable: true,
					midpoints: true,
					draggable: true,
					deletable: true,
				},
			},
		},
```

Then you would be able to drag coordinates in select mode for linestrings mode geometries and snap them to other linestring geometry coordinates.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/507

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 