### PR TITLE
fix(terra-draw): delete coordinate, mid and selection points on calls to removeFeatures

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -123,8 +123,8 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 			snapped = this.coordinateSnapping.getSnappable(event, (feature) => {
 				return Boolean(
 					feature.properties &&
-					feature.properties.mode === properties.mode &&
-					feature.id !== this.draggedCoordinate.id,
+						feature.properties.mode === properties.mode &&
+						feature.id !== this.draggedCoordinate.id,
 				);
 			}).coordinate;
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -59,10 +59,10 @@ type ModeFlags = {
 		coordinates?: {
 			snappable?: boolean;
 			midpoints?:
-			| boolean
-			| {
-				draggable?: boolean;
-			};
+				| boolean
+				| {
+						draggable?: boolean;
+				  };
 			draggable?: boolean;
 			resizable?: ResizeOptions;
 			deletable?: boolean;
@@ -345,9 +345,9 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 		let clickedSelectionPointProps:
 			| {
-				selectionPointFeatureId: string;
-				index: number;
-			}
+					selectionPointFeatureId: string;
+					index: number;
+			  }
 			| undefined;
 
 		let clickedFeatureDistance = Infinity;
@@ -520,7 +520,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		this.selected = [featureId];
 
 		this.store.updateProperty([
-			{ id: featureId, property: "selected", value: true },
+			{ id: featureId, property: SELECT_PROPERTIES.SELECTED, value: true },
 		]);
 		this.onSelect(featureId);
 

--- a/packages/terra-draw/src/store/store.ts
+++ b/packages/terra-draw/src/store/store.ts
@@ -329,7 +329,7 @@ export class GeoJSONStore<Id extends FeatureId = FeatureId> {
 				delete this.store[id];
 				this.spatialIndex.remove(id as FeatureId);
 			} else {
-				throw new Error("No feature with this id, can not delete");
+				throw new Error(`No feature with id ${id}, can not delete`);
 			}
 		});
 


### PR DESCRIPTION
## Description of Changes

Ensures that coordinate, mid and selection points are all deleted correctly when a related feature is deleted.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/520

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 