### PR TITLE
fix(terra-draw): account for coordinate points potentially not existing

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -42,6 +42,37 @@ describe("CoordinatePointBehavior", () => {
 			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
 		});
 
+		it("createOrUpdate creates new points if previous ones have been deleted", () => {
+			const config = MockBehaviorConfig("test");
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			expect(config.store.has(featureId)).toBe(true);
+			coordinatePointBehavior.createOrUpdate(featureId);
+
+			const properties = config.store.getPropertiesCopy(featureId);
+			const coordinatePointIds = properties.coordinatePointIds as string[];
+
+			config.store.delete(coordinatePointIds);
+
+			coordinatePointBehavior.createOrUpdate(featureId);
+			const propertiesAfterDelete = config.store.getPropertiesCopy(featureId);
+			const coordinatePointIdsAfterDelete =
+				propertiesAfterDelete.coordinatePointIds as string[];
+			expect(coordinatePointIdsAfterDelete.length).toBe(4);
+			expect(coordinatePointIdsAfterDelete.every(isUUIDV4)).toBe(true);
+
+			// Ensure they have changed
+			expect(coordinatePointIdsAfterDelete).not.toEqual(coordinatePointIds);
+		});
+
 		it("deletePointsByFeatureIds", () => {
 			const config = MockBehaviorConfig("test");
 			const coordinatePointBehavior = new CoordinatePointBehavior(config);
@@ -65,6 +96,47 @@ describe("CoordinatePointBehavior", () => {
 			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
 
 			coordinatePointBehavior.deletePointsByFeatureIds([featureId]);
+
+			const propertiesAfterDelete = config.store.getPropertiesCopy(featureId);
+			expect(propertiesAfterDelete.coordinatePointIds).toBe(null);
+
+			const coordinatePointsAfterDelete = config.store.copyAllWhere(
+				(properties) => Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+			);
+			expect(coordinatePointsAfterDelete).toStrictEqual([]);
+		});
+
+		it("deletePointsByFeatureIds when points no longer exist doesn't throw an error", () => {
+			const config = MockBehaviorConfig("test");
+			const coordinatePointBehavior = new CoordinatePointBehavior(config);
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			expect(config.store.has(featureId)).toBe(true);
+			coordinatePointBehavior.createOrUpdate(featureId);
+
+			const properties = config.store.getPropertiesCopy(featureId);
+			expect(properties).toBeDefined();
+
+			const coordinatePointIds = properties.coordinatePointIds as string[];
+			expect(coordinatePointIds.length).toBe(4);
+			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
+
+			// Delete all the coordinate points
+			config.store.delete(coordinatePointIds);
+
+			jest.spyOn(config.store, "delete");
+
+			coordinatePointBehavior.deletePointsByFeatureIds([featureId]);
+
+			expect(config.store.delete).toHaveBeenCalledTimes(1);
+			expect(config.store.delete).toHaveBeenNthCalledWith(1, []);
 
 			const propertiesAfterDelete = config.store.getPropertiesCopy(featureId);
 			expect(propertiesAfterDelete.coordinatePointIds).toBe(null);


### PR DESCRIPTION
## Description of Changes

Currently we do not handle the case where the coordinatePointIds associated with a polygon mode feature might have been deleted or not exist. This attempts to handle that scenario better.

## Link to Issue

#520 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 