### PR TITLE
fix(terra-draw-maplibre-gl-adapter): ensure lower point layer is cleaned up correctly

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -306,8 +306,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			adapter.clear();
 
-			expect(map.removeLayer).toHaveBeenCalledTimes(4);
-			expect(map.removeSource).toHaveBeenCalledTimes(3);
+			expect(map.removeLayer).toHaveBeenCalledTimes(5);
+			expect(map.removeSource).toHaveBeenCalledTimes(4);
 		});
 	});
 
@@ -520,8 +520,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			adapter.unregister();
 
 			// Clears any set data
-			expect(map.removeLayer).toHaveBeenCalledTimes(4);
-			expect(map.removeSource).toHaveBeenCalledTimes(3);
+			expect(map.removeLayer).toHaveBeenCalledTimes(5);
+			expect(map.removeSource).toHaveBeenCalledTimes(4);
 		});
 	});
 });

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -59,6 +59,13 @@ export class TerraDrawMapLibreGLAdapter<
 				if (geometryKey === "polygon") {
 					this._map.removeLayer(id + "-outline");
 				}
+
+				// Special case for points as it has another id for the lower z-index
+				if (geometryKey === "point") {
+					this._map.removeLayer(id + "-lower");
+					this._map.removeSource(id + "-lower");
+				}
+
 				this._map.removeSource(id);
 			});
 


### PR DESCRIPTION
## Description of Changes

Currently the coordinate point layer (td-point-lower) is not being cleaned up correctly. This PR corrects that.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 