### PR TITLE
chore(terra-draw): export additional types for easier typing and extension 

### DIFF
--- a/packages/terra-draw/src/extend.ts
+++ b/packages/terra-draw/src/extend.ts
@@ -1,12 +1,19 @@
 import { TerraDrawBaseAdapter, BaseAdapterConfig } from "./common/base.adapter";
 import {
+	Cursor,
 	HexColorStyling,
 	NumericStyling,
 	SELECT_PROPERTIES,
 	TerraDrawCallbacks,
 } from "./common";
-import { BaseModeOptions, TerraDrawBaseDrawMode } from "./modes/base.mode";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+	TerraDrawBaseSelectMode,
+} from "./modes/base.mode";
 import { FeatureId, GeoJSONStore } from "./store/store";
+import { getDefaultStyling } from "./util/styling";
 
 // This object allows 3rd party developers to
 // extend these abstract classes and create there
@@ -14,12 +21,18 @@ import { FeatureId, GeoJSONStore } from "./store/store";
 export {
 	GeoJSONStore,
 	TerraDrawBaseDrawMode,
+	TerraDrawBaseSelectMode,
 	TerraDrawBaseAdapter,
-	BaseAdapterConfig,
+	getDefaultStyling,
+	SELECT_PROPERTIES,
+
+	// Types
+	FeatureId,
+	Cursor,
+	BaseModeOptions,
+	CustomStyling,
 	NumericStyling,
 	HexColorStyling,
-	BaseModeOptions,
 	TerraDrawCallbacks,
-	FeatureId,
-	SELECT_PROPERTIES,
+	BaseAdapterConfig,
 };

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -18,7 +18,6 @@ import {
 	COMMON_PROPERTIES,
 } from "./common";
 import {
-	CustomStyling,
 	ModeTypes,
 	TerraDrawBaseDrawMode,
 	TerraDrawBaseSelectMode,
@@ -836,6 +835,9 @@ class TerraDraw {
 
 export {
 	TerraDraw,
+	IdStrategy,
+	TerraDrawEvents,
+	TerraDrawEventListeners,
 
 	// Modes
 	TerraDrawSelectMode,
@@ -853,20 +855,14 @@ export {
 	// Types that are required for 3rd party developers to extend
 	TerraDrawExtend,
 
-	// Basic types that appear in the public API
+	// TerraDrawBaseMode
 	BehaviorConfig,
-	FeatureId,
 	GeoJSONStoreFeatures,
 	GeoJSONStoreGeometries,
 	HexColor,
-	IdStrategy,
-	TerraDrawAdapterStyling,
-	TerraDrawBaseDrawMode,
-	TerraDrawBaseSelectMode,
-	TerraDrawEventListeners,
-	TerraDrawEvents,
-	TerraDrawKeyboardEvent,
 	TerraDrawMouseEvent,
+	TerraDrawAdapterStyling,
+	TerraDrawKeyboardEvent,
 
 	// TerraDrawBaseAdapter
 	TerraDrawChanges,

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -853,14 +853,20 @@ export {
 	// Types that are required for 3rd party developers to extend
 	TerraDrawExtend,
 
-	// TerraDrawBaseMode
+	// Basic types that appear in the public API
 	BehaviorConfig,
+	FeatureId,
 	GeoJSONStoreFeatures,
 	GeoJSONStoreGeometries,
 	HexColor,
-	TerraDrawMouseEvent,
+	IdStrategy,
 	TerraDrawAdapterStyling,
+	TerraDrawBaseDrawMode,
+	TerraDrawBaseSelectMode,
+	TerraDrawEventListeners,
+	TerraDrawEvents,
 	TerraDrawKeyboardEvent,
+	TerraDrawMouseEvent,
 
 	// TerraDrawBaseAdapter
 	TerraDrawChanges,


### PR DESCRIPTION
## Description of Changes

This PR aims to make it easier to type code from the Terra Draw API, and also to extend Terra Draw by exposing types for creating your own adapters and modes.

Thanks to @ciscorn for helping push this through.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/439

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 