### PR TITLE
feat(terra-draw): add context object when onChange is called via the Terra Draw API

### DIFF
--- a/guides/6.EVENTS.md
+++ b/guides/6.EVENTS.md
@@ -67,6 +67,22 @@ draw.on("change", (ids, type) => {
 });
 ```
 
+If you are interested if the event was triggered by the Terra Draw API (i.e. `addFeatures`, `removeFeatures`), there is a third optional parameter ('context') that will have a property called origin, which is of type `api` if it has come from the API.
+
+
+```typescript
+draw.on("change", (ids, type, context) => {
+  //Done editing
+  if (type === 'change') {
+    if (context && context.origin === 'api') {
+      console.log('this was changed via the API!')
+    } else {
+      console.log('this change did not originate from the API!')
+    }
+  }
+});
+```
+
 The other Terra Draw events are:
 
 ```typescript

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -75,12 +75,19 @@ export type Projection = "web-mercator" | "globe";
 
 export type OnFinishContext = { mode: string; action: string };
 
+export type OnChangeContext = { origin: "api" };
+
+export type TerraDrawGeoJSONStore = GeoJSONStore<
+	OnChangeContext | undefined,
+	FeatureId
+>;
+
 export interface TerraDrawModeRegisterConfig {
 	mode: string;
-	store: GeoJSONStore;
+	store: TerraDrawGeoJSONStore;
 	setDoubleClickToZoom: (enabled: boolean) => void;
 	setCursor: SetCursor;
-	onChange: StoreChangeHandler;
+	onChange: StoreChangeHandler<OnChangeContext | undefined>;
 	onSelect: (selectedId: string) => void;
 	onDeselect: (deselectedId: string) => void;
 	onFinish: (finishedId: string, context: OnFinishContext) => void;

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawAngledRectangleMode } from "./angled-rectangle.mode";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawAngledRectangleMode", () => {
 	describe("constructor", () => {
@@ -174,7 +175,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 	describe("onMouseMove", () => {
 		let angledRectangleMode: TerraDrawAngledRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -247,7 +248,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 	describe("onClick", () => {
 		let angledRectangleMode: TerraDrawAngledRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		describe("with successful validation", () => {
 			beforeEach(() => {
@@ -324,7 +325,7 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 	describe("onKeyUp", () => {
 		let rectangleMode: TerraDrawAngledRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -411,7 +412,11 @@ describe("TerraDrawAngledRectangleMode", () => {
 			expect(features.length).toBe(2);
 
 			expect(onChange).toHaveBeenCalledTimes(5);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(1);
 		});
 
@@ -442,7 +447,11 @@ describe("TerraDrawAngledRectangleMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(0);
 		});
 	});

--- a/packages/terra-draw/src/modes/base.behavior.ts
+++ b/packages/terra-draw/src/modes/base.behavior.ts
@@ -1,8 +1,12 @@
-import { Project, Projection, Unproject } from "../common";
-import { GeoJSONStore } from "../store/store";
+import {
+	Project,
+	Projection,
+	TerraDrawGeoJSONStore,
+	Unproject,
+} from "../common";
 
 export type BehaviorConfig = {
-	store: GeoJSONStore;
+	store: TerraDrawGeoJSONStore;
 	mode: string;
 	project: Project;
 	unproject: Unproject;
@@ -12,7 +16,7 @@ export type BehaviorConfig = {
 };
 
 export class TerraDrawModeBehavior {
-	protected store: GeoJSONStore;
+	protected store: TerraDrawGeoJSONStore;
 	protected mode: string;
 	protected project: Project;
 	protected unproject: Unproject;

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -1,9 +1,11 @@
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
 import {
+	OnChangeContext,
 	HexColor,
 	OnFinishContext,
 	Projection,
 	TerraDrawAdapterStyling,
+	TerraDrawGeoJSONStore,
 	TerraDrawKeyboardEvent,
 	TerraDrawModeRegisterConfig,
 	TerraDrawModeState,
@@ -73,8 +75,8 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 	protected validate: Validation | undefined;
 	protected pointerDistance: number = 40;
 	protected coordinatePrecision!: number;
-	protected onStyleChange!: StoreChangeHandler;
-	protected store!: GeoJSONStore;
+	protected onStyleChange!: StoreChangeHandler<OnChangeContext | undefined>;
+	protected store!: TerraDrawGeoJSONStore;
 	protected projection: Projection = "web-mercator";
 
 	protected setDoubleClickToZoom!: TerraDrawModeRegisterConfig["setDoubleClickToZoom"];

--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawCircleMode } from "./circle.mode";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawCircleMode", () => {
 	describe("constructor", () => {
@@ -175,7 +176,7 @@ describe("TerraDrawCircleMode", () => {
 
 	describe("onClick", () => {
 		let circleMode: TerraDrawCircleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -208,7 +209,11 @@ describe("TerraDrawCircleMode", () => {
 					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
 					expect(onChange).toHaveBeenCalledTimes(1);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 				});
 
 				it("finishes drawing circle on second click with no cursor movement", () => {
@@ -228,7 +233,11 @@ describe("TerraDrawCircleMode", () => {
 
 					// We don't expect any changes if there is no cursor movement
 					expect(onChange).toHaveBeenCalledTimes(1);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 
 					expect(onFinish).toHaveBeenCalledTimes(1);
 				});
@@ -251,7 +260,11 @@ describe("TerraDrawCircleMode", () => {
 					);
 
 					expect(onChange).toHaveBeenCalledTimes(5);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 
 					expect(onFinish).toHaveBeenCalledTimes(1);
 				});
@@ -276,7 +289,11 @@ describe("TerraDrawCircleMode", () => {
 					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
 					expect(onChange).toHaveBeenCalledTimes(1);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 					expect(store.copyAll()[0].properties.radiusKilometers).toStrictEqual(
 						1000,
 					);
@@ -314,7 +331,11 @@ describe("TerraDrawCircleMode", () => {
 					expect(features.length).toBe(1);
 
 					expect(onChange).toHaveBeenCalledTimes(1);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 
 					expect(onFinish).toHaveBeenCalledTimes(0);
 				});
@@ -333,7 +354,11 @@ describe("TerraDrawCircleMode", () => {
 					expect(features.length).toBe(1);
 
 					expect(onChange).toHaveBeenCalledTimes(1);
-					expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+					expect(onChange).toHaveBeenCalledWith(
+						[expect.any(String)],
+						"create",
+						undefined,
+					);
 					expect(onFinish).toHaveBeenCalledTimes(1);
 					expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 						action: "draw",
@@ -346,7 +371,7 @@ describe("TerraDrawCircleMode", () => {
 
 	describe("onKeyUp", () => {
 		let circleMode: TerraDrawCircleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -379,7 +404,11 @@ describe("TerraDrawCircleMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(1);
 			expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 				action: "draw",
@@ -390,7 +419,7 @@ describe("TerraDrawCircleMode", () => {
 
 	describe("onMouseMove", () => {
 		let circleMode: TerraDrawCircleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -413,6 +442,7 @@ describe("TerraDrawCircleMode", () => {
 				1,
 				[expect.any(String)],
 				"create",
+				undefined,
 			);
 
 			const feature = store.copyAll()[0];
@@ -423,6 +453,7 @@ describe("TerraDrawCircleMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			const updatedFeature = store.copyAll()[0];
@@ -464,12 +495,13 @@ describe("TerraDrawCircleMode", () => {
 				2,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 		});
 	});
 
 	describe("onKeyUp", () => {
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let circleMode: TerraDrawCircleMode;
 
 		beforeEach(() => {

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawFreehandMode } from "./freehand.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawFreehandMode", () => {
 	describe("constructor", () => {
@@ -171,7 +172,7 @@ describe("TerraDrawFreehandMode", () => {
 
 	describe("onClick", () => {
 		let freehandMode: TerraDrawFreehandMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -203,6 +204,7 @@ describe("TerraDrawFreehandMode", () => {
 				expect(onChange).toHaveBeenCalledWith(
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				const features = store.copyAll();
@@ -230,6 +232,7 @@ describe("TerraDrawFreehandMode", () => {
 				expect(onChange).toHaveBeenCalledWith(
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 				expect(onFinish).toHaveBeenCalledTimes(1);
 			});
@@ -298,7 +301,7 @@ describe("TerraDrawFreehandMode", () => {
 
 	describe("onMouseMove", () => {
 		let freehandMode: TerraDrawFreehandMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -321,6 +324,7 @@ describe("TerraDrawFreehandMode", () => {
 				1,
 				[expect.any(String), expect.any(String)],
 				"create",
+				undefined,
 			);
 
 			const feature = store.copyAll()[0];
@@ -368,6 +372,7 @@ describe("TerraDrawFreehandMode", () => {
 					1,
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				const feature = store.copyAll()[0];
@@ -433,6 +438,7 @@ describe("TerraDrawFreehandMode", () => {
 					1,
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				const feature = store.copyAll()[0];
@@ -490,7 +496,7 @@ describe("TerraDrawFreehandMode", () => {
 
 	describe("onMouseMove - autoClose", () => {
 		let freehandMode: TerraDrawFreehandMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -513,6 +519,7 @@ describe("TerraDrawFreehandMode", () => {
 				1,
 				[expect.any(String), expect.any(String)],
 				"create",
+				undefined,
 			);
 
 			const feature = store.copyAll()[0];
@@ -588,12 +595,13 @@ describe("TerraDrawFreehandMode", () => {
 				2,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 		});
 	});
 
 	describe("onKeyUp", () => {
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let freehandMode: TerraDrawFreehandMode;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
@@ -668,21 +676,25 @@ describe("TerraDrawFreehandMode", () => {
 					1,
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					2,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					3,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					4,
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 				expect(onFinish).toHaveBeenCalledTimes(1);
 				expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -4,6 +4,7 @@ import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { ValidateNotSelfIntersecting } from "../../validations/not-self-intersecting.validation";
 import { TerraDrawLineStringMode } from "./linestring.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawLineStringMode", () => {
 	describe("constructor", () => {
@@ -167,7 +168,7 @@ describe("TerraDrawLineStringMode", () => {
 	describe("onMouseMove", () => {
 		let lineStringMode: TerraDrawLineStringMode;
 		let onChange: jest.Mock;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		beforeEach(() => {
 			lineStringMode = new TerraDrawLineStringMode();
@@ -206,7 +207,7 @@ describe("TerraDrawLineStringMode", () => {
 		let lineStringMode: TerraDrawLineStringMode;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		beforeEach(() => {
 			lineStringMode = new TerraDrawLineStringMode({ editable: true });
@@ -288,6 +289,7 @@ describe("TerraDrawLineStringMode", () => {
 				9,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
@@ -347,6 +349,7 @@ describe("TerraDrawLineStringMode", () => {
 				9,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
@@ -479,6 +482,7 @@ describe("TerraDrawLineStringMode", () => {
 				9,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
@@ -504,6 +508,7 @@ describe("TerraDrawLineStringMode", () => {
 				10,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			const featuresAfter = store.copyAll();
@@ -698,6 +703,7 @@ describe("TerraDrawLineStringMode", () => {
 				expect(onChange).not.toHaveBeenCalledWith(
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 
 				lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
@@ -708,6 +714,7 @@ describe("TerraDrawLineStringMode", () => {
 					9,
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 
 				features = store.copyAll();
@@ -726,7 +733,7 @@ describe("TerraDrawLineStringMode", () => {
 		let lineStringMode: TerraDrawLineStringMode;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		beforeEach(() => {
 			lineStringMode = new TerraDrawLineStringMode();
@@ -784,6 +791,7 @@ describe("TerraDrawLineStringMode", () => {
 				expect(onChange).not.toHaveBeenCalledWith(
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 
 				lineStringMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
@@ -794,6 +802,7 @@ describe("TerraDrawLineStringMode", () => {
 					8,
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 
 				features = store.copyAll();
@@ -847,6 +856,7 @@ describe("TerraDrawLineStringMode", () => {
 				expect(onChange).not.toHaveBeenCalledWith(
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 
 				lineStringMode.onKeyUp(MockKeyboardEvent({ key: "Escape" }));
@@ -871,7 +881,7 @@ describe("TerraDrawLineStringMode", () => {
 
 	describe("cleanUp", () => {
 		let lineStringMode: TerraDrawLineStringMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		beforeEach(() => {
 			lineStringMode = new TerraDrawLineStringMode();
@@ -965,6 +975,7 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[expect.any(String)],
 				"create",
+				undefined,
 			);
 			expect(mockConfig.setCursor).toHaveBeenCalledTimes(1);
 			expect(mockConfig.setCursor).toHaveBeenNthCalledWith(1, "grabbing");
@@ -1026,16 +1037,19 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				3,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			const allFeatures = mockConfig.store.copyAll();
@@ -1115,6 +1129,7 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 
 			// Remove the edited property from the linestring
@@ -1122,6 +1137,7 @@ describe("TerraDrawLineStringMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -153,6 +153,7 @@ describe("TerraDrawPointMode", () => {
 			expect(mockConfig.onChange).toHaveBeenCalledWith(
 				[expect.any(String)],
 				"create",
+				undefined,
 			);
 		});
 
@@ -169,6 +170,7 @@ describe("TerraDrawPointMode", () => {
 			expect(mockConfig.onChange).toHaveBeenCalledWith(
 				[expect.any(String)],
 				"create",
+				undefined,
 			);
 
 			pointMode.onClick(MockCursorEvent({ lng: 0, lat: 0, button: "right" }));
@@ -177,6 +179,7 @@ describe("TerraDrawPointMode", () => {
 			expect(mockConfig.onChange).toHaveBeenCalledWith(
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 		});
 
@@ -218,6 +221,7 @@ describe("TerraDrawPointMode", () => {
 				expect(mockConfig.onChange).toHaveBeenCalledWith(
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 			});
 		});
@@ -375,6 +379,7 @@ describe("TerraDrawPointMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			// On finished called from onClick and is then only called after onDragEnd

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -1,4 +1,4 @@
-import { Validation } from "../../common";
+import { TerraDrawGeoJSONStore, Validation } from "../../common";
 import {
 	FeatureId,
 	GeoJSONStore,
@@ -291,11 +291,13 @@ describe("TerraDrawPolygonMode", () => {
 					expect.any(String),
 				],
 				"create",
+				undefined,
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				2,
 				[featureId],
 				"update",
+				undefined,
 			);
 		});
 	});
@@ -340,11 +342,13 @@ describe("TerraDrawPolygonMode", () => {
 					expect.any(String),
 				],
 				"create",
+				undefined,
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				2,
 				[featureId],
 				"update",
+				undefined,
 			);
 		});
 
@@ -452,7 +456,7 @@ describe("TerraDrawPolygonMode", () => {
 
 	describe("onMouseMove", () => {
 		let polygonMode: TerraDrawPolygonMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -568,7 +572,7 @@ describe("TerraDrawPolygonMode", () => {
 		let polygonMode: TerraDrawPolygonMode;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 
 		const validation: Validation = (feature, { updateType }) => {
 			if (updateType === "finish" || updateType === "commit") {
@@ -901,6 +905,7 @@ describe("TerraDrawPolygonMode", () => {
 				13,
 				[expect.any(String), expect.any(String)],
 				"delete",
+				undefined,
 			);
 
 			const featuresAfter = store.copyAll();
@@ -1033,7 +1038,7 @@ describe("TerraDrawPolygonMode", () => {
 
 	describe("onKeyUp", () => {
 		let polygonMode: TerraDrawPolygonMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onFinish: jest.Mock;
 
 		beforeEach(() => {
@@ -1157,7 +1162,7 @@ describe("TerraDrawPolygonMode", () => {
 });
 
 describe("cleanUp", () => {
-	let store: GeoJSONStore;
+	let store: TerraDrawGeoJSONStore;
 	let polygonMode: TerraDrawPolygonMode;
 
 	beforeEach(() => {
@@ -1241,6 +1246,7 @@ describe("onDragStart", () => {
 			1,
 			[expect.any(String)],
 			"create",
+			undefined,
 		);
 		expect(mockConfig.setCursor).toHaveBeenCalledTimes(1);
 		expect(mockConfig.setCursor).toHaveBeenNthCalledWith(1, "grabbing");
@@ -1300,16 +1306,19 @@ describe("onDrag", () => {
 			1,
 			[expect.any(String)],
 			"update",
+			undefined,
 		);
 		expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 			2,
 			[expect.any(String)],
 			"update",
+			undefined,
 		);
 		expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 			3,
 			[expect.any(String)],
 			"update",
+			undefined,
 		);
 
 		const allFeatures = mockConfig.store.copyAll();
@@ -1386,6 +1395,7 @@ describe("onDragEnd", () => {
 			1,
 			[expect.any(String)],
 			"delete",
+			undefined,
 		);
 
 		// Remove the edited property from the polygonux
@@ -1393,6 +1403,7 @@ describe("onDragEnd", () => {
 			2,
 			[expect.any(String)],
 			"update",
+			undefined,
 		);
 
 		expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawRectangleMode } from "./rectangle.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawRectangleMode", () => {
 	describe("constructor", () => {
@@ -111,7 +112,7 @@ describe("TerraDrawRectangleMode", () => {
 
 	describe("onClick", () => {
 		let rectangleMode: TerraDrawRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -142,7 +143,11 @@ describe("TerraDrawRectangleMode", () => {
 				rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
 				expect(onChange).toHaveBeenCalledTimes(1);
-				expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+				expect(onChange).toHaveBeenCalledWith(
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
 			});
 
 			it("finishes drawing rectangle on second click", () => {
@@ -161,7 +166,11 @@ describe("TerraDrawRectangleMode", () => {
 				);
 
 				expect(onChange).toHaveBeenCalledTimes(2);
-				expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+				expect(onChange).toHaveBeenCalledWith(
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
 				expect(onFinish).toHaveBeenCalledTimes(1);
 				expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
 					action: "draw",
@@ -173,7 +182,7 @@ describe("TerraDrawRectangleMode", () => {
 
 	describe("onKeyUp", () => {
 		let rectangleMode: TerraDrawRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -203,7 +212,11 @@ describe("TerraDrawRectangleMode", () => {
 
 			// close calls onChange an extra time because of the right hand rule fixing
 			expect(onChange).toHaveBeenCalledTimes(3);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(1);
 		});
 
@@ -230,14 +243,18 @@ describe("TerraDrawRectangleMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(0);
 		});
 	});
 
 	describe("onMouseMove", () => {
 		let rectangleMode: TerraDrawRectangleMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -260,6 +277,7 @@ describe("TerraDrawRectangleMode", () => {
 				1,
 				[expect.any(String)],
 				"create",
+				undefined,
 			);
 
 			const feature = store.copyAll()[0];
@@ -270,6 +288,7 @@ describe("TerraDrawRectangleMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			const updatedFeature = store.copyAll()[0];
@@ -315,12 +334,13 @@ describe("TerraDrawRectangleMode", () => {
 				2,
 				[expect.any(String)],
 				"delete",
+				undefined,
 			);
 		});
 	});
 
 	describe("onKeyUp", () => {
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let rectangleMode: TerraDrawRectangleMode;
 
 		beforeEach(() => {

--- a/packages/terra-draw/src/modes/sector/sector.mode.spec.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawSectorMode } from "./sector.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawSectorMode", () => {
 	describe("constructor", () => {
@@ -173,7 +174,7 @@ describe("TerraDrawSectorMode", () => {
 
 	describe("onMouseMove", () => {
 		let sectorMode: TerraDrawSectorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -259,7 +260,7 @@ describe("TerraDrawSectorMode", () => {
 
 	describe("onClick", () => {
 		let sectorMode: TerraDrawSectorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onFinish: jest.Mock;
 
 		describe("with successful validation", () => {
@@ -356,7 +357,7 @@ describe("TerraDrawSectorMode", () => {
 
 	describe("onKeyUp", () => {
 		let sectorMode: TerraDrawSectorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -455,7 +456,11 @@ describe("TerraDrawSectorMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(0);
 		});
 	});

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -4,10 +4,11 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawSelectMode } from "./select.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawSelectMode", () => {
 	let selectMode: TerraDrawSelectMode;
-	let store: GeoJSONStore;
+	let store: TerraDrawGeoJSONStore;
 	let onChange: jest.Mock;
 	let setCursor: jest.Mock;
 	let project: jest.Mock;
@@ -394,6 +395,7 @@ describe("TerraDrawSelectMode", () => {
 						1,
 						[expect.any(String)],
 						"create",
+						undefined,
 					);
 
 					// Store the ids of the created feature
@@ -406,7 +408,12 @@ describe("TerraDrawSelectMode", () => {
 					expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 					// Polygon selected set to true
-					expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+					expect(onChange).toHaveBeenNthCalledWith(
+						2,
+						idOne,
+						"update",
+						undefined,
+					);
 
 					// Create selection points
 					expect(onChange).toHaveBeenNthCalledWith(
@@ -420,6 +427,7 @@ describe("TerraDrawSelectMode", () => {
 							// as it is identical to to the first
 						],
 						"create",
+						undefined,
 					);
 				});
 
@@ -447,6 +455,7 @@ describe("TerraDrawSelectMode", () => {
 						1,
 						[expect.any(String)],
 						"create",
+						undefined,
 					);
 
 					// Store the ids of the created feature
@@ -459,7 +468,12 @@ describe("TerraDrawSelectMode", () => {
 					expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 					// Polygon selected set to true
-					expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+					expect(onChange).toHaveBeenNthCalledWith(
+						2,
+						idOne,
+						"update",
+						undefined,
+					);
 
 					// Create selection points
 					expect(onChange).toHaveBeenNthCalledWith(
@@ -473,6 +487,7 @@ describe("TerraDrawSelectMode", () => {
 							// as it is identical to to the first
 						],
 						"create",
+						undefined,
 					);
 
 					// Create mid points
@@ -485,6 +500,7 @@ describe("TerraDrawSelectMode", () => {
 							expect.any(String),
 						],
 						"create",
+						undefined,
 					);
 				});
 
@@ -508,6 +524,7 @@ describe("TerraDrawSelectMode", () => {
 							1,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						addPolygonToStore([
@@ -522,6 +539,7 @@ describe("TerraDrawSelectMode", () => {
 							2,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						// Store the ids of the created features
@@ -540,7 +558,12 @@ describe("TerraDrawSelectMode", () => {
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							3,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Deselect first polygon, select second
 						selectMode.onClick(
@@ -559,10 +582,20 @@ describe("TerraDrawSelectMode", () => {
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to false
-						expect(onChange).toHaveBeenNthCalledWith(4, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							4,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Second polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(5, idTwo, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							5,
+							idTwo,
+							"update",
+							undefined,
+						);
 					});
 
 					it("with selection points flag", () => {
@@ -589,6 +622,7 @@ describe("TerraDrawSelectMode", () => {
 							1,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						addPolygonToStore([
@@ -603,6 +637,7 @@ describe("TerraDrawSelectMode", () => {
 							2,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						// Store the ids of the created features
@@ -621,7 +656,12 @@ describe("TerraDrawSelectMode", () => {
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							3,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Create selection points
 						expect(onChange).toHaveBeenNthCalledWith(
@@ -635,6 +675,7 @@ describe("TerraDrawSelectMode", () => {
 								// as it is identical to to the first
 							],
 							"create",
+							undefined,
 						);
 
 						// Deselect first polygon, select second
@@ -653,7 +694,12 @@ describe("TerraDrawSelectMode", () => {
 						expect(onDeselect).toHaveBeenCalledTimes(1);
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
-						expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							5,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Delete first polygon selection points
 						expect(onChange).toHaveBeenNthCalledWith(
@@ -666,10 +712,16 @@ describe("TerraDrawSelectMode", () => {
 								// Again only 4 points as we skip closing coord
 							],
 							"delete",
+							undefined,
 						);
 
 						// Second polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(7, idTwo, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							7,
+							idTwo,
+							"update",
+							undefined,
+						);
 					});
 
 					it("with mid points flag", () => {
@@ -696,6 +748,7 @@ describe("TerraDrawSelectMode", () => {
 							1,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						addPolygonToStore([
@@ -710,6 +763,7 @@ describe("TerraDrawSelectMode", () => {
 							2,
 							[expect.any(String)],
 							"create",
+							undefined,
 						);
 
 						// Store the ids of the created features
@@ -728,7 +782,12 @@ describe("TerraDrawSelectMode", () => {
 						expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 						// First polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							3,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Create selection points
 						expect(onChange).toHaveBeenNthCalledWith(
@@ -742,6 +801,7 @@ describe("TerraDrawSelectMode", () => {
 								// as it is identical to to the first
 							],
 							"create",
+							undefined,
 						);
 
 						// Create mid points
@@ -754,6 +814,7 @@ describe("TerraDrawSelectMode", () => {
 								expect.any(String),
 							],
 							"create",
+							undefined,
 						);
 
 						// Deselect first polygon, select second
@@ -772,7 +833,12 @@ describe("TerraDrawSelectMode", () => {
 						expect(onDeselect).toHaveBeenCalledTimes(1);
 						expect(onDeselect).toHaveBeenNthCalledWith(1, idOne[0]);
 
-						expect(onChange).toHaveBeenNthCalledWith(6, idOne, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							6,
+							idOne,
+							"update",
+							undefined,
+						);
 
 						// Delete first polygon selection points
 						expect(onChange).toHaveBeenNthCalledWith(
@@ -785,6 +851,7 @@ describe("TerraDrawSelectMode", () => {
 								// Again only 4 points as we skip closing coord
 							],
 							"delete",
+							undefined,
 						);
 
 						// Delete first polygon mid points
@@ -797,10 +864,16 @@ describe("TerraDrawSelectMode", () => {
 								expect.any(String),
 							],
 							"delete",
+							undefined,
 						);
 
 						// Second polygon selected set to true
-						expect(onChange).toHaveBeenNthCalledWith(9, idTwo, "update");
+						expect(onChange).toHaveBeenNthCalledWith(
+							9,
+							idTwo,
+							"update",
+							undefined,
+						);
 					});
 				});
 			});
@@ -834,6 +907,7 @@ describe("TerraDrawSelectMode", () => {
 					1,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				addPolygonToStore([
@@ -848,6 +922,7 @@ describe("TerraDrawSelectMode", () => {
 					2,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				// Store the ids of the created features
@@ -860,7 +935,7 @@ describe("TerraDrawSelectMode", () => {
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
-				expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", undefined);
 
 				jest.spyOn(store, "getGeometryCopy");
 				jest.spyOn(store, "getPropertiesCopy");
@@ -900,6 +975,7 @@ describe("TerraDrawSelectMode", () => {
 					1,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				// Store the ids of the created features
@@ -912,7 +988,7 @@ describe("TerraDrawSelectMode", () => {
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
-				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
 
 				jest.spyOn(store, "getGeometryCopy");
 				jest.spyOn(store, "updateGeometry");
@@ -951,6 +1027,7 @@ describe("TerraDrawSelectMode", () => {
 					1,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				// Store the ids of the created features
@@ -968,7 +1045,7 @@ describe("TerraDrawSelectMode", () => {
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
-				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
 
 				jest.spyOn(store, "delete");
 				jest.spyOn(store, "updateGeometry");
@@ -1003,6 +1080,7 @@ describe("TerraDrawSelectMode", () => {
 					1,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				// Store the ids of the created features
@@ -1015,7 +1093,7 @@ describe("TerraDrawSelectMode", () => {
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// First polygon selected set to true
-				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
 
 				jest.spyOn(store, "delete");
 				jest.spyOn(store, "updateGeometry");
@@ -1053,6 +1131,7 @@ describe("TerraDrawSelectMode", () => {
 					2,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				expect(onSelect).toHaveBeenCalledTimes(1);
@@ -1066,6 +1145,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"delete",
+					undefined,
 				);
 			});
 		});
@@ -1292,7 +1372,12 @@ describe("TerraDrawSelectMode", () => {
 					);
 
 					expect(onChange).toHaveBeenCalledTimes(3);
-					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+					expect(onChange).toHaveBeenNthCalledWith(
+						3,
+						idOne,
+						"update",
+						undefined,
+					);
 				});
 			});
 
@@ -1333,7 +1418,12 @@ describe("TerraDrawSelectMode", () => {
 					);
 
 					expect(onChange).toHaveBeenCalledTimes(3);
-					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update");
+					expect(onChange).toHaveBeenNthCalledWith(
+						3,
+						idOne,
+						"update",
+						undefined,
+					);
 				});
 			});
 		});
@@ -1366,6 +1456,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1373,6 +1464,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1391,6 +1483,7 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String), expect.any(String)],
 					"update",
+					undefined,
 				);
 			});
 
@@ -1424,6 +1517,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1436,6 +1530,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1454,6 +1549,7 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String), expect.any(String)],
 					"update",
+					undefined,
 				);
 			});
 
@@ -1501,6 +1597,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1513,6 +1610,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1557,6 +1655,7 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String), expect.any(String)],
 					"update",
+					undefined,
 				);
 			});
 
@@ -1602,6 +1701,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1614,6 +1714,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1655,6 +1756,7 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String), expect.any(String)],
 					"update",
+					undefined,
 				);
 			});
 		});
@@ -1694,6 +1796,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1701,6 +1804,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String), expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1724,6 +1828,7 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String), expect.any(String), expect.any(String)],
 					"update",
+					undefined,
 				);
 			});
 
@@ -1766,6 +1871,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
+					undefined,
 				);
 
 				// Create selection points
@@ -1778,6 +1884,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -1807,6 +1914,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"update",
+					undefined,
 				);
 			});
 		});
@@ -1841,6 +1949,7 @@ describe("TerraDrawSelectMode", () => {
 					1,
 					[expect.any(String)],
 					"create",
+					undefined,
 				);
 
 				// Store the ids of the created feature
@@ -1853,7 +1962,7 @@ describe("TerraDrawSelectMode", () => {
 				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
 
 				// Polygon selected set to true
-				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
 
 				// Create mid points
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -1865,6 +1974,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				expect(onChange).toHaveBeenCalledTimes(4);
@@ -1876,7 +1986,7 @@ describe("TerraDrawSelectMode", () => {
 
 				expect(onChange).toHaveBeenCalledTimes(8);
 
-				expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update");
+				expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update", undefined);
 
 				// Delete existing midpoints and selection points
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -1892,6 +2002,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"delete",
+					undefined,
 				);
 
 				// Mid points
@@ -1905,6 +2016,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				// Selection points
@@ -1918,6 +2030,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"create",
+					undefined,
 				);
 
 				const setMapDraggability = jest.fn();
@@ -1975,6 +2088,7 @@ describe("TerraDrawSelectMode", () => {
 				3,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			// Create selection points
@@ -1987,6 +2101,7 @@ describe("TerraDrawSelectMode", () => {
 					expect.any(String),
 				],
 				"create",
+				undefined,
 			);
 
 			selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
@@ -2089,6 +2204,7 @@ describe("TerraDrawSelectMode", () => {
 				3,
 				[expect.any(String)],
 				"update",
+				undefined,
 			);
 
 			// Create selection points
@@ -2101,6 +2217,7 @@ describe("TerraDrawSelectMode", () => {
 					expect.any(String),
 				],
 				"create",
+				undefined,
 			);
 
 			selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.spec.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.spec.ts
@@ -5,6 +5,7 @@ import { TerraDrawSensorMode } from "./sensor.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
+import { TerraDrawGeoJSONStore } from "../../common";
 
 describe("TerraDrawSensorMode", () => {
 	describe("constructor", () => {
@@ -173,7 +174,7 @@ describe("TerraDrawSensorMode", () => {
 
 	describe("onMouseMove", () => {
 		let sensorMode: TerraDrawSensorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 
 		beforeEach(() => {
@@ -236,7 +237,7 @@ describe("TerraDrawSensorMode", () => {
 
 	describe("onClick", () => {
 		let sensorMode: TerraDrawSensorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onFinish: jest.Mock;
 
 		describe("with successful validation", () => {
@@ -360,7 +361,7 @@ describe("TerraDrawSensorMode", () => {
 
 	describe("onKeyUp", () => {
 		let sensorMode: TerraDrawSensorMode;
-		let store: GeoJSONStore;
+		let store: TerraDrawGeoJSONStore;
 		let onChange: jest.Mock;
 		let onFinish: jest.Mock;
 
@@ -464,7 +465,11 @@ describe("TerraDrawSensorMode", () => {
 			expect(features.length).toBe(1);
 
 			expect(onChange).toHaveBeenCalledTimes(1);
-			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create");
+			expect(onChange).toHaveBeenCalledWith(
+				[expect.any(String)],
+				"create",
+				undefined,
+			);
 			expect(onFinish).toHaveBeenCalledTimes(0);
 		});
 	});

--- a/packages/terra-draw/src/store/store.spec.ts
+++ b/packages/terra-draw/src/store/store.spec.ts
@@ -304,10 +304,33 @@ describe("GeoJSONStore", () => {
 			]);
 			store.delete([id]);
 
-			expect(mockCallback).toHaveBeenCalledTimes(3);
-			expect(mockCallback).toHaveBeenNthCalledWith(1, [id], "create");
-			expect(mockCallback).toHaveBeenNthCalledWith(2, [id], "update");
-			expect(mockCallback).toHaveBeenNthCalledWith(3, [id], "delete");
+			const [idTwo] = store.create<string>(
+				[{ geometry: { type: "Point", coordinates: [0, 0] } }],
+				{ origin: "api" },
+			);
+
+			expect(mockCallback).toHaveBeenCalledTimes(4);
+			expect(mockCallback).toHaveBeenNthCalledWith(
+				1,
+				[id],
+				"create",
+				undefined,
+			);
+			expect(mockCallback).toHaveBeenNthCalledWith(
+				2,
+				[id],
+				"update",
+				undefined,
+			);
+			expect(mockCallback).toHaveBeenNthCalledWith(
+				3,
+				[id],
+				"delete",
+				undefined,
+			);
+			expect(mockCallback).toHaveBeenNthCalledWith(4, [idTwo], "create", {
+				origin: "api",
+			});
 		});
 	});
 

--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -502,6 +502,10 @@ describe("Terra Draw", () => {
 				],
 			});
 
+			const onChange = jest.fn();
+
+			draw.on("change", onChange);
+
 			draw.start();
 			const [result] = draw.addFeatures([
 				{
@@ -521,6 +525,8 @@ describe("Terra Draw", () => {
 			expect(result.reason).toBe(
 				"Feature has coordinates with excessive precision",
 			);
+
+			expect(onChange).not.toHaveBeenCalled();
 		});
 
 		it("returns valid true if the coordinate precision is exactly the adapter coordinate precision", () => {
@@ -541,6 +547,10 @@ describe("Terra Draw", () => {
 				],
 			});
 
+			const onChange = jest.fn();
+
+			draw.on("change", onChange);
+
 			draw.start();
 			const [result] = draw.addFeatures([
 				{
@@ -558,6 +568,11 @@ describe("Terra Draw", () => {
 
 			expect(result.valid).toBe(true);
 			expect(result.reason).toBe(undefined);
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([expect.any(String)], "create", {
+				origin: "api",
+			});
 		});
 	});
 
@@ -580,6 +595,9 @@ describe("Terra Draw", () => {
 				],
 			});
 
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
 			draw.start();
 			const [result] = draw.addFeatures([
 				{
@@ -595,9 +613,16 @@ describe("Terra Draw", () => {
 				},
 			]);
 
+			expect(onChange).toHaveBeenCalledTimes(1);
+
 			expect(result.valid).toBe(true);
 
 			draw.removeFeatures([result.id as FeatureId]);
+
+			expect(onChange).toHaveBeenCalledTimes(2);
+			expect(onChange).toHaveBeenCalledWith([result.id], "delete", {
+				origin: "api",
+			});
 
 			expect(draw.getSnapshot()).toHaveLength(0);
 		});

--- a/packages/terra-draw/src/test/mock-mode-config.ts
+++ b/packages/terra-draw/src/test/mock-mode-config.ts
@@ -1,9 +1,10 @@
+import { OnChangeContext } from "../common";
 import { GeoJSONStore } from "../store/store";
 
 export function MockModeConfig(mode: string) {
 	return {
 		mode,
-		store: new GeoJSONStore(),
+		store: new GeoJSONStore<OnChangeContext | undefined>(),
 		setCursor: jest.fn(),
 		onChange: jest.fn(),
 		onSelect: jest.fn(),


### PR DESCRIPTION
## Description of Changes

This PR ensures that changes from the API can be filtered out/differentiated from changes coming from inside modes (i.e. generally from user interactions).

## Link to Issue

#527 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 