### PR TITLE
chore(terra-draw): use a constant for feature zIndexing

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -185,3 +185,11 @@ export const COMMON_PROPERTIES = {
 	COORDINATE_POINT: "coordinatePoint",
 	COORDINATE_POINT_IDS: "coordinatePointIds",
 };
+
+export const Z_INDEX = {
+	LAYER_ONE: 10,
+	LAYER_TWO: 20,
+	LAYER_THREE: 30,
+	LAYER_FOUR: 40,
+	LAYER_FIVE: 50,
+} as const;

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -6,6 +6,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
+	Z_INDEX,
 } from "../../common";
 import { Polygon } from "geojson";
 import {
@@ -411,7 +412,7 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 			}
 		}
 

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -8,6 +8,7 @@ import {
 	Cursor,
 	UpdateTypes,
 	Projection,
+	Z_INDEX,
 } from "../../common";
 import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import { circle, circleWebMercator } from "../../geometry/shape/create-circle";
@@ -271,7 +272,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 				feature,
 			);
 
-			styles.zIndex = 10;
+			styles.zIndex = Z_INDEX.LAYER_ONE;
 
 			return styles;
 		}

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -7,6 +7,7 @@ import {
 	Cursor,
 	UpdateTypes,
 	COMMON_PROPERTIES,
+	Z_INDEX,
 } from "../../common";
 import { Polygon } from "geojson";
 
@@ -409,7 +410,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				feature,
 			);
 
-			styles.zIndex = 10;
+			styles.zIndex = Z_INDEX.LAYER_ONE;
 
 			return styles;
 		} else if (
@@ -441,7 +442,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				feature,
 			);
 
-			styles.zIndex = 40;
+			styles.zIndex = Z_INDEX.LAYER_FIVE;
 
 			return styles;
 		}

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	CartesianPoint,
 	COMMON_PROPERTIES,
+	Z_INDEX,
 } from "../../common";
 import { Feature, LineString, Point, Position } from "geojson";
 import {
@@ -903,7 +904,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				feature,
 			);
 
-			styles.zIndex = 10;
+			styles.zIndex = Z_INDEX.LAYER_ONE;
 
 			return styles;
 		} else if (
@@ -946,7 +947,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				feature,
 			);
 
-			styles.zIndex = 40;
+			styles.zIndex = Z_INDEX.LAYER_FIVE;
 
 			return styles;
 		}

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -6,6 +6,7 @@ import {
 	Cursor,
 	UpdateTypes,
 	COMMON_PROPERTIES,
+	Z_INDEX,
 } from "../../common";
 import {
 	BBoxPolygon,
@@ -275,7 +276,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 				feature,
 			);
 
-			styles.zIndex = 30;
+			styles.zIndex = Z_INDEX.LAYER_THREE;
 		}
 
 		return styles;

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -9,6 +9,7 @@ import {
 	COMMON_PROPERTIES,
 	Project,
 	Unproject,
+	Z_INDEX,
 } from "../../common";
 import { Feature, Polygon, Position } from "geojson";
 import {
@@ -1061,7 +1062,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 				return styles;
 			} else if (feature.geometry.type === "Point") {
 				const editedPoint = feature.properties[COMMON_PROPERTIES.EDITED];
@@ -1138,11 +1139,11 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				);
 
 				if (editedPoint) {
-					styles.zIndex = 35;
+					styles.zIndex = Z_INDEX.LAYER_FOUR;
 				} else if (coordinatePoint) {
-					styles.zIndex = 25;
+					styles.zIndex = Z_INDEX.LAYER_TWO;
 				} else {
-					styles.zIndex = 30;
+					styles.zIndex = Z_INDEX.LAYER_THREE;
 				}
 
 				return styles;

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -7,6 +7,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
+	Z_INDEX,
 } from "../../common";
 import {
 	FeatureId,
@@ -277,7 +278,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 				feature,
 			);
 
-			styles.zIndex = 10;
+			styles.zIndex = Z_INDEX.LAYER_ONE;
 
 			return styles;
 		}

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -6,6 +6,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
+	Z_INDEX,
 } from "../../common";
 import { Polygon, Position } from "geojson";
 import {
@@ -453,7 +454,7 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 			}
 		}
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -9,6 +9,7 @@ import {
 	Validation,
 	UpdateTypes,
 	COMMON_PROPERTIES,
+	Z_INDEX,
 } from "../../common";
 import { Point, Polygon, Position } from "geojson";
 import {
@@ -991,7 +992,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
-				styles.zIndex = 30;
+				styles.zIndex = Z_INDEX.LAYER_THREE;
 
 				return styles;
 			}
@@ -1021,7 +1022,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
-				styles.zIndex = 40;
+				styles.zIndex = Z_INDEX.LAYER_FIVE;
 
 				return styles;
 			}
@@ -1054,7 +1055,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 				return styles;
 			} else if (feature.geometry.type === "LineString") {
 				styles.lineStringColor = this.getHexColorStylingValue(
@@ -1069,7 +1070,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 				return styles;
 			} else if (feature.geometry.type === "Point") {
 				styles.pointWidth = this.getNumericStylingValue(
@@ -1096,7 +1097,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 				return styles;
 			}
 		}

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -6,6 +6,7 @@ import {
 	NumericStyling,
 	Cursor,
 	UpdateTypes,
+	Z_INDEX,
 } from "../../common";
 import { LineString, Point, Polygon, Position } from "geojson";
 import {
@@ -620,7 +621,7 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 			} else if (feature.geometry.type === "LineString") {
 				styles.lineStringColor = this.getHexColorStylingValue(
 					this.styles.outlineColor,
@@ -634,7 +635,7 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 					feature,
 				);
 
-				styles.zIndex = 10;
+				styles.zIndex = Z_INDEX.LAYER_ONE;
 			} else if (feature.geometry.type === "Point") {
 				styles.pointColor = this.getHexColorStylingValue(
 					this.styles.centerPointColor,
@@ -660,7 +661,7 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 					feature,
 				);
 
-				styles.zIndex = 20;
+				styles.zIndex = Z_INDEX.LAYER_TWO;
 			}
 		}
 


### PR DESCRIPTION
## Description of Changes

It is more maintainable to have a centralised zIndexing constant that we can rely on for different layers. We currently support 5 layers.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 