### PR TITLE
feat(terra-draw): add a way to determine which feature a coordinate point relates to

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -183,6 +183,7 @@ export const COMMON_PROPERTIES = {
 	CLOSING_POINT: "closingPoint",
 	SNAPPING_POINT: "snappingPoint",
 	COORDINATE_POINT: "coordinatePoint",
+	COORDINATE_POINT_FEATURE_ID: "coordinatePointFeatureId",
 	COORDINATE_POINT_IDS: "coordinatePointIds",
 };
 

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -21,6 +21,9 @@ describe("CoordinatePointBehavior", () => {
 	describe("api", () => {
 		it("createOrUpdate", () => {
 			const config = MockBehaviorConfig("test");
+
+			jest.spyOn(config.store, "create");
+
 			const coordinatePointBehavior = new CoordinatePointBehavior(config);
 
 			const mockPolygon = MockPolygonSquare();
@@ -40,6 +43,25 @@ describe("CoordinatePointBehavior", () => {
 			const coordinatePointIds = properties.coordinatePointIds as string[];
 			expect(coordinatePointIds.length).toBe(4);
 			expect(coordinatePointIds.every(isUUIDV4)).toBe(true);
+
+			expect(config.store.create).toHaveBeenCalledTimes(2);
+
+			// Ensure all coordinate points are created
+			const coordinatePoints = config.store.copyAllWhere((properties) =>
+				Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+			);
+
+			expect(coordinatePoints.length).toBe(4);
+			expect(
+				coordinatePoints.every((point) => point.geometry.type === "Point"),
+			).toBe(true);
+			expect(
+				coordinatePoints.every(
+					(point) =>
+						point.properties[COMMON_PROPERTIES.COORDINATE_POINT_FEATURE_ID] ===
+						featureId,
+				),
+			).toBe(true);
 		});
 
 		it("createOrUpdate creates new points if previous ones have been deleted", () => {
@@ -71,6 +93,23 @@ describe("CoordinatePointBehavior", () => {
 
 			// Ensure they have changed
 			expect(coordinatePointIdsAfterDelete).not.toEqual(coordinatePointIds);
+
+			// Ensure all coordinate points are created
+			const coordinatePoints = config.store.copyAllWhere((properties) =>
+				Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+			);
+
+			expect(coordinatePoints.length).toBe(4);
+			expect(
+				coordinatePoints.every((point) => point.geometry.type === "Point"),
+			).toBe(true);
+			expect(
+				coordinatePoints.every(
+					(point) =>
+						point.properties[COMMON_PROPERTIES.COORDINATE_POINT_FEATURE_ID] ===
+						featureId,
+				),
+			).toBe(true);
 		});
 
 		it("deletePointsByFeatureIds", () => {

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
@@ -32,6 +32,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 			const coordinatePointIds = this.createPoints(
 				coordinates,
 				existingProperties.mode as string,
+				featureId,
 			);
 			this.setFeatureCoordinatePoints(featureId, coordinatePointIds);
 		}
@@ -54,6 +55,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 				const coordinatePointIds = this.createPoints(
 					coordinates,
 					existingProperties.mode as string,
+					featureId,
 				);
 				this.setFeatureCoordinatePoints(featureId, coordinatePointIds);
 			} else {
@@ -93,6 +95,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 			const coordinatePointIds = this.createPoints(
 				coordinates,
 				existingProperties.mode as string,
+				featureId,
 			);
 			this.setFeatureCoordinatePoints(featureId, coordinatePointIds);
 		}
@@ -127,7 +130,11 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 		}[];
 	}
 
-	private createPoints(coordinates: Position[], mode: string) {
+	private createPoints(
+		coordinates: Position[],
+		mode: string,
+		featureId: FeatureId,
+	) {
 		return this.store.create(
 			coordinates.map((coordinate) => ({
 				geometry: {
@@ -137,6 +144,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 				properties: {
 					mode,
 					[COMMON_PROPERTIES.COORDINATE_POINT]: true,
+					[COMMON_PROPERTIES.COORDINATE_POINT_FEATURE_ID]: featureId,
 				},
 			})),
 		);


### PR DESCRIPTION
## Description of Changes

- Adds a property to the coordinate point features to determine which feature they are associated to. This is useful if you want to style them based on a specific feature id for example.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 