### PR TITLE
docs(terra-draw): add style-load event to guides for Mapbox/MapLibre

### DIFF
--- a/docs/media/3.ADAPTERS.md
+++ b/docs/media/3.ADAPTERS.md
@@ -169,15 +169,21 @@ const map = new MapLibreGL.Map({
   zoom: zoom,
 });
 
-// Create Terra Draw
-const draw = new TerraDraw({
-  adapter: new TerraDrawMapLibreGLAdapter({ map }),
-  modes: [new TerraDrawFreehandMode()],
+// It is important the base styles are loaded before
+map.on("style.load", () => {
+
+  // Create Terra Draw
+  const draw = new TerraDraw({
+    adapter: new TerraDrawMapLibreGLAdapter({ map }),
+    modes: [new TerraDrawFreehandMode()],
+  });
+
+  // Start drawing
+  draw.start();
+  draw.setMode("freehand");
+
 });
 
-// Start drawing
-draw.start();
-draw.setMode("freehand");
 ```
 
 ### Google Maps
@@ -344,17 +350,22 @@ const map = new mapboxgl.Map({
   zoom: zoom,
 });
 
-// Create Terra Draw
-const draw = new TerraDraw({
-  adapter: new TerraDrawMapboxGLAdapter({
-    map,
-  }),
-  modes: [new TerraDrawFreehandMode()],
-});
+// It is important the base styles are loaded before
+map.on("style.load", () => {
 
-// Start drawing
-draw.start();
-draw.setMode("freehand");
+  // Create Terra Draw
+  const draw = new TerraDraw({
+    adapter: new TerraDrawMapboxGLAdapter({
+      map,
+    }),
+    modes: [new TerraDrawFreehandMode()],
+  });
+
+  // Start drawing
+  draw.start();
+  draw.setMode("freehand");
+
+});
 ```
 
 ### ArcGIS


### PR DESCRIPTION
## Description of Changes

Makes a small change to the code example for MapLibre/Mapbox in the adapters guide to make sure the base map styles are properly loaded first.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/533

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 