### PR TITLE
feat(terra-draw): allow coordinate deletions with contextmenu events

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -43,6 +43,7 @@ export interface TerraDrawMouseEvent {
 	containerY: number;
 	button: "neither" | "left" | "middle" | "right";
 	heldKeys: string[];
+	isContextMenu: boolean;
 }
 
 export interface TerraDrawKeyboardEvent {

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -917,6 +917,63 @@ describe("TerraDrawPolygonMode", () => {
 			expect(onFinish).toHaveBeenCalledTimes(2);
 		});
 
+		it("context menu click can delete a point if editable is true", () => {
+			polygonMode.updateOptions({
+				pointerEvents: {
+					contextMenu: true,
+					rightClick: false,
+				},
+			});
+
+			polygonMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			polygonMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			polygonMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			polygonMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			polygonMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			polygonMode.onMouseMove(MockCursorEvent({ lng: 3, lat: 3 }));
+
+			polygonMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
+
+			polygonMode.onClick(MockCursorEvent({ lng: 3, lat: 3 }));
+
+			let features = store.copyAll();
+			expect(features.length).toBe(1);
+
+			expect(onFinish).toHaveBeenCalledTimes(1);
+			// Extra call because of the right hand rule fixing
+			expect(onChange).toHaveBeenCalledTimes(13);
+
+			// Delete a coordinate
+			polygonMode.onClick(
+				MockCursorEvent({
+					lng: 1,
+					lat: 1,
+					button: "left",
+					isContextMenu: true,
+				}),
+			);
+
+			expect(onChange).toHaveBeenNthCalledWith(
+				13,
+				[expect.any(String), expect.any(String)],
+				"delete",
+				undefined,
+			);
+
+			const featuresAfter = store.copyAll();
+			expect(featuresAfter.length).toBe(1);
+			expect(featuresAfter[0].geometry.coordinates[0]).not.toEqual(
+				features[0].geometry.coordinates[0],
+			);
+
+			expect(onFinish).toHaveBeenCalledTimes(2);
+		});
+
 		describe("validate", () => {
 			it("does not create a polygon if it has intersections and there is a validation that returns false", () => {
 				polygonMode = new TerraDrawPolygonMode({

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -94,11 +94,17 @@ interface Snapping {
 	) => Position | undefined;
 }
 
+interface PolygonPointerEvents {
+	rightClick?: boolean;
+	contextMenu?: boolean;
+}
+
 interface TerraDrawPolygonModeOptions<T extends CustomStyling>
 	extends BaseModeOptions<T> {
 	snapping?: Snapping;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
+	pointerEvents?: PolygonPointerEvents;
 	cursors?: Cursors;
 	editable?: boolean;
 	showCoordinatePoints?: boolean;
@@ -119,6 +125,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private snappedPointId: FeatureId | undefined;
 
 	// Editable
+	private pointerEvents: PolygonPointerEvents = {
+		rightClick: true,
+		contextMenu: false,
+	};
 	private editable: boolean = false;
 	private editedFeatureId: FeatureId | undefined;
 	private editedFeatureCoordinateIndex: number | undefined;
@@ -161,6 +171,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 		if (options?.editable !== undefined) {
 			this.editable = options.editable;
+		}
+
+		if (options?.pointerEvents !== undefined) {
+			this.pointerEvents = options.pointerEvents;
 		}
 
 		if (options?.showCoordinatePoints !== undefined) {
@@ -749,7 +763,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		}
 		this.mouseMove = false;
 
-		if (event.button === "right") {
+		if (
+			(this.pointerEvents.rightClick && event.button === "right") ||
+			(this.pointerEvents.contextMenu && event.isContextMenu)
+		) {
 			this.onRightClick(event);
 			return;
 		} else if (event.button === "left") {

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -4,7 +4,7 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawSelectMode } from "./select.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
-import { TerraDrawGeoJSONStore } from "../../common";
+import { TerraDrawGeoJSONStore, TerraDrawMouseEvent } from "../../common";
 
 describe("TerraDrawSelectMode", () => {
 	let selectMode: TerraDrawSelectMode;
@@ -880,6 +880,11 @@ describe("TerraDrawSelectMode", () => {
 		});
 
 		describe("right click", () => {
+			let event: Partial<TerraDrawMouseEvent> = {
+				button: "right",
+				isContextMenu: false,
+			};
+
 			it("does not select if no features", () => {
 				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
@@ -940,14 +945,13 @@ describe("TerraDrawSelectMode", () => {
 				jest.spyOn(store, "getGeometryCopy");
 				jest.spyOn(store, "getPropertiesCopy");
 
-				selectMode.onClick({
-					lng: 80.5,
-					lat: 80.5,
-					containerX: 80.5,
-					containerY: 80.5,
-					button: "right",
-					heldKeys: [],
-				});
+				selectMode.onClick(
+					MockCursorEvent({
+						lng: 80.5,
+						lat: 80.5,
+						...event,
+					}),
+				);
 
 				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
 				expect(onDeselect).toHaveBeenCalledTimes(0);
@@ -995,9 +999,7 @@ describe("TerraDrawSelectMode", () => {
 				jest.spyOn(store, "delete");
 
 				// Deselect first polygon, select second
-				selectMode.onClick(
-					MockCursorEvent({ lng: 0, lat: 0, button: "right" }),
-				);
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
 
 				expect(store.delete).toHaveBeenCalledTimes(0);
 				expect(store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -1051,9 +1053,7 @@ describe("TerraDrawSelectMode", () => {
 				jest.spyOn(store, "updateGeometry");
 
 				// Deselect first polygon, select second
-				selectMode.onClick(
-					MockCursorEvent({ lng: 0, lat: 0, button: "right" }),
-				);
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
 
 				expect(store.delete).toHaveBeenCalledTimes(0);
 				expect(store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -1099,9 +1099,257 @@ describe("TerraDrawSelectMode", () => {
 				jest.spyOn(store, "updateGeometry");
 
 				// Deselect first polygon, select second
-				selectMode.onClick(
-					MockCursorEvent({ lng: 0, lat: 0, button: "right" }),
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
+
+				expect(store.delete).toHaveBeenCalledTimes(1);
+				expect(store.updateGeometry).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("context menu", () => {
+			let event: Partial<TerraDrawMouseEvent> = {
+				button: "left",
+				isContextMenu: true,
+			};
+
+			it("does not select if no features", () => {
+				selectMode.updateOptions({
+					pointerEvents: {
+						rightClick: false,
+						contextMenu: true,
+					},
+				});
+
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				expect(onChange).not.toHaveBeenCalled();
+				expect(onDeselect).not.toHaveBeenCalled();
+				expect(onSelect).not.toHaveBeenCalled();
+			});
+
+			it("returns if different feature than selected is clicked on", () => {
+				setSelectMode({
+					pointerEvents: {
+						rightClick: false,
+						contextMenu: true,
+					},
+					flags: {
+						polygon: { feature: { draggable: false, coordinates: {} } },
+					},
+				});
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					1,
+					[expect.any(String)],
+					"create",
+					undefined,
 				);
+
+				addPolygonToStore([
+					[80, 80],
+					[80, 81],
+					[81, 81],
+					[81, 80],
+					[81, 81],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					2,
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
+
+				// Store the ids of the created features
+				const idOne = onChange.mock.calls[0][0] as string[];
+
+				// Select polygon
+				selectMode.onClick(MockCursorEvent({ lng: 0.5, lat: 0.5 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
+
+				// First polygon selected set to true
+				expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", undefined);
+
+				jest.spyOn(store, "getGeometryCopy");
+				jest.spyOn(store, "getPropertiesCopy");
+
+				selectMode.onClick(
+					MockCursorEvent({
+						lng: 80.5,
+						lat: 80.5,
+						...event,
+					}),
+				);
+
+				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
+				expect(onDeselect).toHaveBeenCalledTimes(0);
+				expect(store.getPropertiesCopy).toHaveBeenCalledTimes(0);
+			});
+
+			it("does not delete coordinate if coordinate is clicked on but deletable is set to false", () => {
+				setSelectMode({
+					pointerEvents: {
+						rightClick: false,
+						contextMenu: true,
+					},
+					flags: {
+						polygon: {
+							feature: { draggable: false, coordinates: { deletable: false } },
+						},
+					},
+				});
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					1,
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
+
+				// Store the ids of the created features
+				const idOne = onChange.mock.calls[0][0] as string[];
+
+				// Select polygon
+				selectMode.onClick(MockCursorEvent({ lng: 0.5, lat: 0.5 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
+
+				// First polygon selected set to true
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
+
+				jest.spyOn(store, "getGeometryCopy");
+				jest.spyOn(store, "updateGeometry");
+				jest.spyOn(store, "delete");
+
+				// Deselect first polygon, select second
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
+
+				expect(store.delete).toHaveBeenCalledTimes(0);
+				expect(store.updateGeometry).toHaveBeenCalledTimes(0);
+
+				// Only called for checking distance to selection points,
+				// should hit early return otherwise
+				expect(store.getGeometryCopy).toHaveBeenCalledTimes(4);
+			});
+
+			it("returns early if creates a invalid polygon by deleting coordinate", () => {
+				setSelectMode({
+					pointerEvents: {
+						rightClick: false,
+						contextMenu: true,
+					},
+					flags: {
+						polygon: {
+							feature: { draggable: false, coordinates: { deletable: true } },
+						},
+					},
+				});
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[0, 0],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					1,
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
+
+				// Store the ids of the created features
+				const idOne = onChange.mock.calls[0][0] as string[];
+
+				// Select polygon
+				selectMode.onClick(
+					MockCursorEvent({
+						lng: 0.322723,
+						lat: 0.672897,
+					}),
+				);
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
+
+				// First polygon selected set to true
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
+
+				jest.spyOn(store, "delete");
+				jest.spyOn(store, "updateGeometry");
+
+				// Deselect first polygon, select second
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
+
+				expect(store.delete).toHaveBeenCalledTimes(0);
+				expect(store.updateGeometry).toHaveBeenCalledTimes(0);
+			});
+
+			it("deletes a coordinate in deletable set to true and a coordinate is clicked on", () => {
+				setSelectMode({
+					pointerEvents: {
+						rightClick: false,
+						contextMenu: true,
+					},
+					flags: {
+						polygon: {
+							feature: { draggable: false, coordinates: { deletable: true } },
+						},
+					},
+				});
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				expect(onChange).toHaveBeenNthCalledWith(
+					1,
+					[expect.any(String)],
+					"create",
+					undefined,
+				);
+
+				// Store the ids of the created features
+				const idOne = onChange.mock.calls[0][0] as string[];
+
+				// Select polygon
+				selectMode.onClick(MockCursorEvent({ lng: 0.5, lat: 0.5 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onSelect).toHaveBeenNthCalledWith(1, idOne[0]);
+
+				// First polygon selected set to true
+				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", undefined);
+
+				jest.spyOn(store, "delete");
+				jest.spyOn(store, "updateGeometry");
+
+				// Deselect first polygon, select second
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0, ...event }));
 
 				expect(store.delete).toHaveBeenCalledTimes(1);
 				expect(store.updateGeometry).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -115,6 +115,11 @@ const defaultCursors = {
 	insertMidpoint: "crosshair",
 } as Required<Cursors>;
 
+interface SelectPointerEvents {
+	rightClick?: boolean;
+	contextMenu?: boolean;
+}
+
 interface TerraDrawSelectModeOptions<T extends CustomStyling>
 	extends BaseModeOptions<T> {
 	pointerDistance?: number;
@@ -123,6 +128,7 @@ interface TerraDrawSelectModeOptions<T extends CustomStyling>
 	dragEventThrottle?: number;
 	cursors?: Cursors;
 	allowManualDeselection?: boolean;
+	pointerEvents?: SelectPointerEvents;
 }
 
 export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStyling> {
@@ -137,6 +143,10 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 	private keyEvents: TerraDrawSelectModeKeyEvents = defaultKeyEvents;
 	private cursors: Required<Cursors> = defaultCursors;
 	private validations: Record<string, Validation> = {};
+	private pointerEvents: SelectPointerEvents = {
+		rightClick: true,
+		contextMenu: false,
+	};
 
 	// Behaviors
 	private selectionPoints!: SelectionPointBehavior;
@@ -166,6 +176,10 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			this.cursors = { ...this.cursors, ...options.cursors };
 		} else {
 			this.cursors = defaultCursors;
+		}
+
+		if (options?.pointerEvents !== undefined) {
+			this.pointerEvents = options.pointerEvents;
 		}
 
 		// We want to have some defaults, but also allow key bindings
@@ -592,9 +606,11 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		if (event.button === "right") {
+		if (
+			(this.pointerEvents.rightClick && event.button === "right") ||
+			(this.pointerEvents.contextMenu && event.isContextMenu)
+		) {
 			this.onRightClick(event);
-			return;
 		} else if (event.button === "left") {
 			this.onLeftClick(event);
 		}

--- a/packages/terra-draw/src/test/mock-cursor-event.ts
+++ b/packages/terra-draw/src/test/mock-cursor-event.ts
@@ -4,10 +4,12 @@ export const MockCursorEvent = ({
 	lng,
 	lat,
 	button,
+	isContextMenu,
 }: {
 	lng: TerraDrawMouseEvent["lng"];
 	lat: TerraDrawMouseEvent["lat"];
 	button?: TerraDrawMouseEvent["button"];
+	isContextMenu?: TerraDrawMouseEvent["isContextMenu"];
 }) =>
 	({
 		lng,
@@ -16,4 +18,5 @@ export const MockCursorEvent = ({
 		containerY: lat * 40,
 		button: button ? button : ("left" as const),
 		heldKeys: [],
+		isContextMenu: isContextMenu ? isContextMenu : false,
 	}) as TerraDrawMouseEvent;


### PR DESCRIPTION
## Description of Changes

Some users would like to be able to delete via the contextmenu event (i.e. Ctrl + Click on MacOS, long press on Android/iOS). This PR provides a way to enable this and allow deleting coordinates via this method.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/528

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 