### PR TITLE
chore(terra-draw-maplibre-gl-adapter): use sort-key rather than extra  point layer ordering

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -301,13 +301,13 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			const rAFCallback = (requestAnimationFrame as jest.Mock).mock.calls[0][0];
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(4);
-			expect(map.addLayer).toHaveBeenCalledTimes(5);
+			expect(map.addSource).toHaveBeenCalledTimes(3);
+			expect(map.addLayer).toHaveBeenCalledTimes(4);
 
 			adapter.clear();
 
-			expect(map.removeLayer).toHaveBeenCalledTimes(5);
-			expect(map.removeSource).toHaveBeenCalledTimes(4);
+			expect(map.removeLayer).toHaveBeenCalledTimes(4);
+			expect(map.removeSource).toHaveBeenCalledTimes(3);
 		});
 	});
 
@@ -338,8 +338,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(4);
-			expect(map.addLayer).toHaveBeenCalledTimes(5);
+			expect(map.addSource).toHaveBeenCalledTimes(3);
+			expect(map.addLayer).toHaveBeenCalledTimes(4);
 		});
 
 		it("updates layers and sources when data is passed", () => {
@@ -355,8 +355,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			adapter.register(MockCallbacks());
 
-			expect(map.addSource).toHaveBeenCalledTimes(4);
-			expect(map.addLayer).toHaveBeenCalledTimes(5);
+			expect(map.addSource).toHaveBeenCalledTimes(3);
+			expect(map.addLayer).toHaveBeenCalledTimes(4);
 
 			adapter.render(
 				{
@@ -374,8 +374,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.addSource).toHaveBeenCalledTimes(4);
-			expect(map.addLayer).toHaveBeenCalledTimes(5);
+			expect(map.addSource).toHaveBeenCalledTimes(3);
+			expect(map.addLayer).toHaveBeenCalledTimes(4);
 
 			adapter.render(
 				{
@@ -440,7 +440,7 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			rAFCallback();
 
-			expect(map.getSource).toHaveBeenCalledTimes(8);
+			expect(map.getSource).toHaveBeenCalledTimes(6);
 
 			adapter.render(
 				{
@@ -461,7 +461,7 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			rAFCallback();
 
 			// Force update because of the deletion
-			expect(map.getSource).toHaveBeenCalledTimes(12);
+			expect(map.getSource).toHaveBeenCalledTimes(9);
 		});
 	});
 
@@ -520,8 +520,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			adapter.unregister();
 
 			// Clears any set data
-			expect(map.removeLayer).toHaveBeenCalledTimes(5);
-			expect(map.removeSource).toHaveBeenCalledTimes(4);
+			expect(map.removeLayer).toHaveBeenCalledTimes(4);
+			expect(map.removeSource).toHaveBeenCalledTimes(3);
 		});
 	});
 });


### PR DESCRIPTION
## Description of Changes

Here we can remove an unnecessary layer for the points and instead use the sort-key layout property. We can't do full zIndexing as I would like because we h

## Link to Issue

Partially related to https://github.com/JamesLMilner/terra-draw/issues/394 but doesn't fully resolve it

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 