### PR TITLE
fix(terra-draw-maplibre-gl-adapter): fix clear and unregister methods

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -303,11 +303,13 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 
 			expect(map.addSource).toHaveBeenCalledTimes(3);
 			expect(map.addLayer).toHaveBeenCalledTimes(4);
+			expect(map.getSource).toHaveBeenCalledTimes(3);
 
 			adapter.clear();
 
-			expect(map.removeLayer).toHaveBeenCalledTimes(4);
-			expect(map.removeSource).toHaveBeenCalledTimes(3);
+			expect(map.removeLayer).toHaveBeenCalledTimes(0);
+			expect(map.removeSource).toHaveBeenCalledTimes(0);
+			expect(map.getSource).toHaveBeenCalledTimes(6);
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

At the moment clear removes layers and unregister does not (although unregister would have been calling clear which removes the layers!). This means that clear could never be called more than once, and also once you cleared you could no longer draw.

We now just empty out the layers on clear and then on unregister actually remove the sources and layers.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 