### PR TITLE
feat(terra-draw): allow filtering of pointer events with a function or boolean

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -511,6 +511,34 @@ draw.setMode("freehand");
 
 For guidance around adding pre-existing data to a specific mode, please see the [Store guide on adding features](./2.STORE.md#adding-data).
 
+
+## Filtering Pointer Events in Modes
+
+There are times when a click or tap, and the corresponding behaviour may be undesirable for a given reason. For the built-in modes (i.e. modes provided in the `terra-draw` module) it is possible to filter out these pointer events, which can be achieved like so:
+
+```typescript
+new TerraDrawPolygonMode({
+    pointerEvents: {
+        rightClick: true,
+        contextMenu: true,
+        leftClick: (event) => {
+            if (event.lat < 5) {
+                console.log('event is triggered in the mode')
+                return false
+            }
+
+            console.log('event is not triggered in the mode)
+            return true;
+        },
+        onDragStart: true,
+        onDrag: true,
+        onDragEnd: true,
+    }
+})
+```
+
+In this case we are putting in a arbitrary reason to filter, where if the click occurs at latitude less than 5 we do not count the click. You can put any logic you so wish here, even potentially performing your own logic instead when the event is filtered.
+
 ## Creating Custom Modes
 
 See the [Development](./6.DEVELOPMENT.md) guide for more information on creating custom Modes.

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -176,6 +176,14 @@ class TestMap {
 							: undefined),
 				}),
 				new TerraDrawPolygonMode({
+					pointerEvents: {
+						rightClick: true,
+						contextMenu: false,
+						onDragStart: true,
+						onDrag: true,
+						onDragEnd: true,
+						leftClick: this.config?.includes("disableLeftClick") ? false : true,
+					},
 					validation:
 						this.config?.includes("validationSuccess") ||
 						this.config?.includes("validationFailure")

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -9,7 +9,6 @@ import {
 	pageUrl,
 	setupMap,
 	TestConfigOptions,
-	expectNthPathDimensions,
 } from "./setup";
 
 test.describe("page setup", () => {
@@ -757,7 +756,7 @@ test.describe("polygon mode", () => {
 		await expectPathDimensions({ page, width: 204, height: 114 });
 	});
 
-	test("can use  showCoordinatePoints alongside editable to delete a coordinate with right click", async ({
+	test("can use showCoordinatePoints alongside editable to delete a coordinate with right click", async ({
 		page,
 	}) => {
 		const mapDiv = await setupMap({
@@ -805,6 +804,32 @@ test.describe("polygon mode", () => {
 		// The dimensions should have changed due to the deletion
 		await expectPaths({ page, count: 4 });
 		await expectPathDimensions({ page, width: 104, height: 104 });
+	});
+
+	test("can use the pointerEvents object to disable left click events", async ({
+		page,
+	}) => {
+		const mapDiv = await setupMap({
+			page,
+			configQueryParam: ["disableLeftClick"],
+		});
+		await changeMode({ page, mode });
+
+		// The length of the square sides in pixels
+		const sideLength = 100;
+
+		// Calculating the half of the side length
+		const halfLength = sideLength / 2;
+
+		// Coordinates of the center
+		const centerX = mapDiv.width / 2;
+		const centerY = mapDiv.height / 2;
+
+		const topLeft = { x: centerX - halfLength, y: centerY - halfLength };
+
+		await page.mouse.click(topLeft.x, topLeft.y);
+
+		await expectPaths({ page, count: 0 });
 	});
 });
 

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -14,7 +14,8 @@ export type TestConfigOptions =
 	| "globeSelect"
 	| "snappingCoordinate"
 	| "showCoordinatePoints"
-	| "selectDragSnapping";
+	| "selectDragSnapping"
+	| "disableLeftClick";
 
 export const setupMap = async ({
 	page,

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
@@ -6,6 +6,7 @@ import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawAngledRectangleMode", () => {
 	describe("constructor", () => {
@@ -319,6 +320,33 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 				features = store.copyAll();
 				expect(features.length).toBe(1);
+			});
+		});
+
+		describe("with leftClick pointer event set to false", () => {
+			beforeEach(() => {
+				angledRectangleMode = new TerraDrawAngledRectangleMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(angledRectangleMode.mode);
+
+				store = mockConfig.store;
+				angledRectangleMode.register(mockConfig);
+				angledRectangleMode.start();
+			});
+
+			it("should not allow click", () => {
+				angledRectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				angledRectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				angledRectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(0);
 			});
 		});
 	});

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -275,70 +275,79 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		// We want pointer devices (mobile/tablet) to have
-		// similar behaviour to mouse based devices so we
-		// trigger a mousemove event before every click
-		// if one has not been triggered to emulate this
-		if (this.currentCoordinate > 0 && !this.mouseMove) {
-			this.onMouseMove(event);
-		}
-		this.mouseMove = false;
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			// We want pointer devices (mobile/tablet) to have
+			// similar behaviour to mouse based devices so we
+			// trigger a mousemove event before every click
+			// if one has not been triggered to emulate this
+			if (this.currentCoordinate > 0 && !this.mouseMove) {
+				this.onMouseMove(event);
+			}
+			this.mouseMove = false;
 
-		if (this.currentCoordinate === 0) {
-			const [newId] = this.store.create([
-				{
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
+			if (this.currentCoordinate === 0) {
+				const [newId] = this.store.create([
+					{
+						geometry: {
+							type: "Polygon",
+							coordinates: [
+								[
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+								],
 							],
-						],
+						},
+						properties: { mode: this.mode },
 					},
-					properties: { mode: this.mode },
-				},
-			]);
-			this.currentId = newId;
-			this.currentCoordinate++;
+				]);
+				this.currentId = newId;
+				this.currentCoordinate++;
 
-			// Ensure the state is updated to reflect drawing has started
-			this.setDrawing();
-		} else if (this.currentCoordinate === 1 && this.currentId) {
-			const currentPolygonGeometry = this.store.getGeometryCopy<Polygon>(
-				this.currentId,
-			);
+				// Ensure the state is updated to reflect drawing has started
+				this.setDrawing();
+			} else if (this.currentCoordinate === 1 && this.currentId) {
+				const currentPolygonGeometry = this.store.getGeometryCopy<Polygon>(
+					this.currentId,
+				);
 
-			const previousCoordinate = currentPolygonGeometry.coordinates[0][0];
-			const isIdentical = coordinatesIdentical(
-				[event.lng, event.lat],
-				previousCoordinate,
-			);
-
-			if (isIdentical) {
-				return;
-			}
-
-			const updated = this.updatePolygonGeometry(
-				this.currentId,
-				[
-					currentPolygonGeometry.coordinates[0][0],
+				const previousCoordinate = currentPolygonGeometry.coordinates[0][0];
+				const isIdentical = coordinatesIdentical(
 					[event.lng, event.lat],
-					[event.lng, event.lat],
-					currentPolygonGeometry.coordinates[0][0],
-				],
-				UpdateTypes.Commit,
-			);
+					previousCoordinate,
+				);
 
-			if (!updated) {
-				return;
+				if (isIdentical) {
+					return;
+				}
+
+				const updated = this.updatePolygonGeometry(
+					this.currentId,
+					[
+						currentPolygonGeometry.coordinates[0][0],
+						[event.lng, event.lat],
+						[event.lng, event.lat],
+						currentPolygonGeometry.coordinates[0][0],
+					],
+					UpdateTypes.Commit,
+				);
+
+				if (!updated) {
+					return;
+				}
+
+				this.currentCoordinate++;
+			} else if (this.currentCoordinate === 2 && this.currentId) {
+				this.close();
 			}
-
-			this.currentCoordinate++;
-		} else if (this.currentCoordinate === 2 && this.currentId) {
-			this.close();
 		}
 	}
 

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -15,7 +15,6 @@ import {
 } from "../common";
 import {
 	FeatureId,
-	GeoJSONStore,
 	GeoJSONStoreFeatures,
 	StoreChangeHandler,
 } from "../store/store";
@@ -37,11 +36,32 @@ export enum ModeTypes {
 	Render = "render",
 }
 
+export const DefaultPointerEvents = {
+	rightClick: true,
+	contextMenu: false,
+	leftClick: true,
+	onDragStart: true,
+	onDrag: true,
+	onDragEnd: true,
+} as const;
+
+type AllowPointerEvent = boolean | ((event: TerraDrawMouseEvent) => boolean);
+
+export interface PointerEvents {
+	leftClick: AllowPointerEvent;
+	rightClick: AllowPointerEvent;
+	contextMenu: AllowPointerEvent;
+	onDragStart: AllowPointerEvent;
+	onDrag: AllowPointerEvent;
+	onDragEnd: AllowPointerEvent;
+}
+
 export type BaseModeOptions<Styling extends CustomStyling> = {
 	styles?: Partial<Styling>;
 	pointerDistance?: number;
 	validation?: Validation;
 	projection?: Projection;
+	pointerEvents?: PointerEvents;
 };
 
 export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
@@ -71,6 +91,7 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 		this._styles = styling;
 	}
 
+	protected pointerEvents: PointerEvents = DefaultPointerEvents;
 	protected behaviors: TerraDrawModeBehavior[] = [];
 	protected validate: Validation | undefined;
 	protected pointerDistance: number = 40;
@@ -112,6 +133,23 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 		if (options?.projection) {
 			this.projection = options.projection;
 		}
+
+		if (options?.pointerEvents !== undefined) {
+			this.pointerEvents = options.pointerEvents;
+		}
+	}
+
+	protected allowPointerEvent(
+		pointerEvent: AllowPointerEvent,
+		event: TerraDrawMouseEvent,
+	) {
+		if (typeof pointerEvent === "boolean") {
+			return pointerEvent;
+		}
+		if (typeof pointerEvent === "function") {
+			return pointerEvent(event);
+		}
+		return true;
 	}
 
 	type = ModeTypes.Drawing;

--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -6,6 +6,7 @@ import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawCircleMode", () => {
 	describe("constructor", () => {
@@ -364,6 +365,33 @@ describe("TerraDrawCircleMode", () => {
 						action: "draw",
 						mode: "circle",
 					});
+				});
+			});
+
+			describe("with leftClick pointer event set to false", () => {
+				beforeEach(() => {
+					circleMode = new TerraDrawCircleMode({
+						pointerEvents: {
+							...DefaultPointerEvents,
+							leftClick: false,
+						},
+					});
+					const mockConfig = MockModeConfig(circleMode.mode);
+
+					store = mockConfig.store;
+					circleMode.register(mockConfig);
+					circleMode.start();
+				});
+
+				it("should not allow click", () => {
+					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+					circleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					circleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					let features = store.copyAll();
+					expect(features.length).toBe(0);
 				});
 			});
 		});

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -158,39 +158,48 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		if (this.clickCount === 0) {
-			this.center = [event.lng, event.lat];
-			const startingCircle = circle({
-				center: this.center,
-				radiusKilometers: this.startingRadiusKilometers,
-				coordinatePrecision: this.coordinatePrecision,
-			});
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			if (this.clickCount === 0) {
+				this.center = [event.lng, event.lat];
+				const startingCircle = circle({
+					center: this.center,
+					radiusKilometers: this.startingRadiusKilometers,
+					coordinatePrecision: this.coordinatePrecision,
+				});
 
-			const [createdId] = this.store.create([
-				{
-					geometry: startingCircle.geometry,
-					properties: {
-						mode: this.mode,
-						radiusKilometers: this.startingRadiusKilometers,
+				const [createdId] = this.store.create([
+					{
+						geometry: startingCircle.geometry,
+						properties: {
+							mode: this.mode,
+							radiusKilometers: this.startingRadiusKilometers,
+						},
 					},
-				},
-			]);
-			this.currentCircleId = createdId;
-			this.clickCount++;
-			this.cursorMovedAfterInitialCursorDown = false;
-			this.setDrawing();
-		} else {
-			if (
-				this.clickCount === 1 &&
-				this.center &&
-				this.currentCircleId !== undefined &&
-				this.cursorMovedAfterInitialCursorDown
-			) {
-				this.updateCircle(event);
-			}
+				]);
+				this.currentCircleId = createdId;
+				this.clickCount++;
+				this.cursorMovedAfterInitialCursorDown = false;
+				this.setDrawing();
+			} else {
+				if (
+					this.clickCount === 1 &&
+					this.center &&
+					this.currentCircleId !== undefined &&
+					this.cursorMovedAfterInitialCursorDown
+				) {
+					this.updateCircle(event);
+				}
 
-			// Finish drawing
-			this.close();
+				// Finish drawing
+				this.close();
+			}
 		}
 	}
 

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
@@ -6,6 +6,7 @@ import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawFreehandMode", () => {
 	describe("constructor", () => {
@@ -235,6 +236,33 @@ describe("TerraDrawFreehandMode", () => {
 					undefined,
 				);
 				expect(onFinish).toHaveBeenCalledTimes(1);
+			});
+
+			describe("with leftClick pointer event set to false", () => {
+				beforeEach(() => {
+					freehandMode = new TerraDrawFreehandMode({
+						pointerEvents: {
+							...DefaultPointerEvents,
+							leftClick: false,
+						},
+					});
+					const mockConfig = MockModeConfig(freehandMode.mode);
+
+					store = mockConfig.store;
+					freehandMode.register(mockConfig);
+					freehandMode.start();
+				});
+
+				it("should not allow click", () => {
+					freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+					freehandMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+					let features = store.copyAll();
+					expect(features.length).toBe(0);
+				});
 			});
 		});
 

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -289,47 +289,56 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		if (this.preventNewFeature) {
-			return;
-		}
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			if (this.preventNewFeature) {
+				return;
+			}
 
-		if (this.startingClick === false) {
-			const [createdId, closingPointId] = this.store.create([
-				{
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
+			if (this.startingClick === false) {
+				const [createdId, closingPointId] = this.store.create([
+					{
+						geometry: {
+							type: "Polygon",
+							coordinates: [
+								[
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+								],
 							],
-						],
+						},
+						properties: { mode: this.mode },
 					},
-					properties: { mode: this.mode },
-				},
-				{
-					geometry: {
-						type: "Point",
-						coordinates: [event.lng, event.lat],
+					{
+						geometry: {
+							type: "Point",
+							coordinates: [event.lng, event.lat],
+						},
+						properties: {
+							mode: this.mode,
+							[COMMON_PROPERTIES.CLOSING_POINT]: true,
+						},
 					},
-					properties: {
-						mode: this.mode,
-						[COMMON_PROPERTIES.CLOSING_POINT]: true,
-					},
-				},
-			]);
+				]);
 
-			this.currentId = createdId;
-			this.closingPointId = closingPointId;
-			this.startingClick = true;
-			this.setDrawing();
+				this.currentId = createdId;
+				this.closingPointId = closingPointId;
+				this.startingClick = true;
+				this.setDrawing();
 
-			return;
+				return;
+			}
+
+			this.close();
 		}
-
-		this.close();
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -5,6 +5,7 @@ import { ValidateNotSelfIntersecting } from "../../validations/not-self-intersec
 import { TerraDrawLineStringMode } from "./linestring.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawLineStringMode", () => {
 	describe("constructor", () => {
@@ -516,6 +517,33 @@ describe("TerraDrawLineStringMode", () => {
 			expect(featuresAfter[0].geometry.coordinates).not.toEqual(
 				features[0].geometry.coordinates,
 			);
+		});
+
+		describe("with leftClick pointer event set to false", () => {
+			beforeEach(() => {
+				lineStringMode = new TerraDrawLineStringMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(lineStringMode.mode);
+
+				store = mockConfig.store;
+				lineStringMode.register(mockConfig);
+				lineStringMode.start();
+			});
+
+			it("should not allow click", () => {
+				lineStringMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				lineStringMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				lineStringMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(0);
+			});
 		});
 
 		describe("validations", () => {

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -620,19 +620,28 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		// We want pointer devices (mobile/tablet) to have
-		// similar behaviour to mouse based devices so we
-		// trigger a mousemove event before every click
-		// if one has not been triggered to emulate this
-		if (this.currentCoordinate > 0 && !this.mouseMove) {
-			this.onMouseMove(event);
-		}
-		this.mouseMove = false;
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			// We want pointer devices (mobile/tablet) to have
+			// similar behaviour to mouse based devices so we
+			// trigger a mousemove event before every click
+			// if one has not been triggered to emulate this
+			if (this.currentCoordinate > 0 && !this.mouseMove) {
+				this.onMouseMove(event);
+			}
+			this.mouseMove = false;
 
-		if (event.button === "right") {
-			this.onRightClick(event);
-		} else if (event.button === "left") {
-			this.onLeftClick(event);
+			if (event.button === "right") {
+				this.onRightClick(event);
+			} else if (event.button === "left") {
+				this.onLeftClick(event);
+			}
 		}
 	}
 
@@ -655,6 +664,10 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDragStart, event)) {
+			return;
+		}
+
 		if (!this.editable) {
 			return;
 		}
@@ -722,6 +735,10 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDrag, event)) {
+			return;
+		}
+
 		if (
 			this.editedFeatureId === undefined ||
 			this.editedFeatureCoordinateIndex === undefined
@@ -823,9 +840,13 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 	/** @internal */
 	onDragEnd(
-		_: TerraDrawMouseEvent,
+		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDragEnd, event)) {
+			return;
+		}
+
 		if (this.editedFeatureId === undefined) {
 			return;
 		}

--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -2,6 +2,7 @@ import { Point } from "geojson";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawPointMode } from "./point.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawPointMode", () => {
 	describe("constructor", () => {
@@ -181,6 +182,28 @@ describe("TerraDrawPointMode", () => {
 				"delete",
 				undefined,
 			);
+		});
+
+		describe("with leftClick pointer event set to false", () => {
+			it("should not allow click", () => {
+				const pointMode = new TerraDrawPointMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(pointMode.mode);
+
+				pointMode.register(mockConfig);
+				pointMode.start();
+
+				pointMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				pointMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = mockConfig.store.copyAll();
+				expect(features.length).toBe(0);
+			});
 		});
 
 		describe("validate", () => {

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -107,10 +107,20 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			throw new Error("Mode must be registered first");
 		}
 
-		if (event.button === "right") {
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
 			this.onRightClick(event);
-		} else if (event.button === "left") {
+			return;
+		} else if (
+			event.button === "left" &&
+			this.allowPointerEvent(this.pointerEvents.leftClick, event)
+		) {
 			this.onLeftClick(event);
+			return;
 		}
 	}
 
@@ -132,6 +142,10 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDragStart, event)) {
+			return;
+		}
+
 		if (this.editable) {
 			const nearestPointFeature = this.getNearestPointFeature(event);
 			this.editedFeatureId = nearestPointFeature?.id;
@@ -154,6 +168,10 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDrag, event)) {
+			return;
+		}
+
 		if (this.editedFeatureId === undefined) {
 			return;
 		}
@@ -208,9 +226,13 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 
 	/** @internal */
 	onDragEnd(
-		_: TerraDrawMouseEvent,
+		event: TerraDrawMouseEvent,
 		setMapDraggability: (enabled: boolean) => void,
 	) {
+		if (!this.allowPointerEvent(this.pointerEvents.onDragEnd, event)) {
+			return;
+		}
+
 		if (this.editedFeatureId === undefined) {
 			return;
 		}

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -11,6 +11,7 @@ import { ValidateNotSelfIntersecting } from "../../validations/not-self-intersec
 import { TerraDrawPolygonMode } from "./polygon.mode";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { MockPolygonSquare } from "../../test/mock-features";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawPolygonMode", () => {
 	describe("constructor", () => {
@@ -920,6 +921,7 @@ describe("TerraDrawPolygonMode", () => {
 		it("context menu click can delete a point if editable is true", () => {
 			polygonMode.updateOptions({
 				pointerEvents: {
+					...DefaultPointerEvents,
 					contextMenu: true,
 					rightClick: false,
 				},
@@ -972,6 +974,33 @@ describe("TerraDrawPolygonMode", () => {
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(2);
+		});
+
+		describe("with leftClick pointer event set to false", () => {
+			beforeEach(() => {
+				polygonMode = new TerraDrawPolygonMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(polygonMode.mode);
+
+				store = mockConfig.store;
+				polygonMode.register(mockConfig);
+				polygonMode.start();
+			});
+
+			it("should not allow click", () => {
+				polygonMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				polygonMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				polygonMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(0);
+			});
 		});
 
 		describe("validate", () => {

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -6,6 +6,7 @@ import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawRectangleMode", () => {
 	describe("constructor", () => {
@@ -176,6 +177,29 @@ describe("TerraDrawRectangleMode", () => {
 					action: "draw",
 					mode: "rectangle",
 				});
+			});
+
+			it("with leftClick pointer event set to false should not allow click", () => {
+				rectangleMode = new TerraDrawRectangleMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(rectangleMode.mode);
+
+				store = mockConfig.store;
+				rectangleMode.register(mockConfig);
+				rectangleMode.start();
+
+				rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				rectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				rectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(0);
 			});
 		});
 	});

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -172,33 +172,42 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		if (this.clickCount === 0) {
-			this.center = [event.lng, event.lat];
-			const [createdId] = this.store.create([
-				{
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			if (this.clickCount === 0) {
+				this.center = [event.lng, event.lat];
+				const [createdId] = this.store.create([
+					{
+						geometry: {
+							type: "Polygon",
+							coordinates: [
+								[
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+								],
 							],
-						],
+						},
+						properties: {
+							mode: this.mode,
+						},
 					},
-					properties: {
-						mode: this.mode,
-					},
-				},
-			]);
-			this.currentRectangleId = createdId;
-			this.clickCount++;
-			this.setDrawing();
-		} else {
-			this.updateRectangle(event, UpdateTypes.Finish);
-			// Finish drawing
-			this.close();
+				]);
+				this.currentRectangleId = createdId;
+				this.clickCount++;
+				this.setDrawing();
+			} else {
+				this.updateRectangle(event, UpdateTypes.Finish);
+				// Finish drawing
+				this.close();
+			}
 		}
 	}
 

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -321,70 +321,79 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		// We want pointer devices (mobile/tablet) to have
-		// similar behaviour to mouse based devices so we
-		// trigger a mousemove event before every click
-		// if one has not been triggered to emulate this
-		if (this.currentCoordinate > 0 && !this.mouseMove) {
-			this.onMouseMove(event);
-		}
-		this.mouseMove = false;
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			// We want pointer devices (mobile/tablet) to have
+			// similar behaviour to mouse based devices so we
+			// trigger a mousemove event before every click
+			// if one has not been triggered to emulate this
+			if (this.currentCoordinate > 0 && !this.mouseMove) {
+				this.onMouseMove(event);
+			}
+			this.mouseMove = false;
 
-		if (this.currentCoordinate === 0) {
-			const [newId] = this.store.create([
-				{
-					geometry: {
-						type: "Polygon",
-						coordinates: [
-							[
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
-								[event.lng, event.lat],
+			if (this.currentCoordinate === 0) {
+				const [newId] = this.store.create([
+					{
+						geometry: {
+							type: "Polygon",
+							coordinates: [
+								[
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+									[event.lng, event.lat],
+								],
 							],
-						],
+						},
+						properties: { mode: this.mode },
 					},
-					properties: { mode: this.mode },
-				},
-			]);
-			this.currentId = newId;
-			this.currentCoordinate++;
+				]);
+				this.currentId = newId;
+				this.currentCoordinate++;
 
-			// Ensure the state is updated to reflect drawing has started
-			this.setDrawing();
-		} else if (this.currentCoordinate === 1 && this.currentId) {
-			const currentPolygonGeometry = this.store.getGeometryCopy<Polygon>(
-				this.currentId,
-			);
+				// Ensure the state is updated to reflect drawing has started
+				this.setDrawing();
+			} else if (this.currentCoordinate === 1 && this.currentId) {
+				const currentPolygonGeometry = this.store.getGeometryCopy<Polygon>(
+					this.currentId,
+				);
 
-			const previousCoordinate = currentPolygonGeometry.coordinates[0][0];
-			const isIdentical = coordinatesIdentical(
-				[event.lng, event.lat],
-				previousCoordinate,
-			);
-
-			if (isIdentical) {
-				return;
-			}
-
-			const updated = this.updatePolygonGeometry(
-				this.currentId,
-				[
-					currentPolygonGeometry.coordinates[0][0],
+				const previousCoordinate = currentPolygonGeometry.coordinates[0][0];
+				const isIdentical = coordinatesIdentical(
 					[event.lng, event.lat],
-					[event.lng, event.lat],
-					currentPolygonGeometry.coordinates[0][0],
-				],
-				UpdateTypes.Commit,
-			);
+					previousCoordinate,
+				);
 
-			if (!updated) {
-				return;
+				if (isIdentical) {
+					return;
+				}
+
+				const updated = this.updatePolygonGeometry(
+					this.currentId,
+					[
+						currentPolygonGeometry.coordinates[0][0],
+						[event.lng, event.lat],
+						[event.lng, event.lat],
+						currentPolygonGeometry.coordinates[0][0],
+					],
+					UpdateTypes.Commit,
+				);
+
+				if (!updated) {
+					return;
+				}
+
+				this.currentCoordinate++;
+			} else if (this.currentCoordinate === 2 && this.currentId) {
+				this.close();
 			}
-
-			this.currentCoordinate++;
-		} else if (this.currentCoordinate === 2 && this.currentId) {
-			this.close();
 		}
 	}
 

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -1,10 +1,10 @@
 import { Position } from "geojson";
-import { GeoJSONStore } from "../../store/store";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawSelectMode } from "./select.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { TerraDrawGeoJSONStore, TerraDrawMouseEvent } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawSelectMode", () => {
 	let selectMode: TerraDrawSelectMode;
@@ -1115,6 +1115,7 @@ describe("TerraDrawSelectMode", () => {
 			it("does not select if no features", () => {
 				selectMode.updateOptions({
 					pointerEvents: {
+						...DefaultPointerEvents,
 						rightClick: false,
 						contextMenu: true,
 					},
@@ -1130,6 +1131,7 @@ describe("TerraDrawSelectMode", () => {
 			it("returns if different feature than selected is clicked on", () => {
 				setSelectMode({
 					pointerEvents: {
+						...DefaultPointerEvents,
 						rightClick: false,
 						contextMenu: true,
 					},
@@ -1199,6 +1201,7 @@ describe("TerraDrawSelectMode", () => {
 			it("does not delete coordinate if coordinate is clicked on but deletable is set to false", () => {
 				setSelectMode({
 					pointerEvents: {
+						...DefaultPointerEvents,
 						rightClick: false,
 						contextMenu: true,
 					},
@@ -1256,6 +1259,10 @@ describe("TerraDrawSelectMode", () => {
 					pointerEvents: {
 						rightClick: false,
 						contextMenu: true,
+						leftClick: true,
+						onDragStart: true,
+						onDrag: true,
+						onDragEnd: true,
 					},
 					flags: {
 						polygon: {
@@ -1308,6 +1315,7 @@ describe("TerraDrawSelectMode", () => {
 			it("deletes a coordinate in deletable set to true and a coordinate is clicked on", () => {
 				setSelectMode({
 					pointerEvents: {
+						...DefaultPointerEvents,
 						rightClick: false,
 						contextMenu: true,
 					},

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.spec.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.spec.ts
@@ -6,6 +6,7 @@ import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { Polygon } from "geojson";
 import { followsRightHandRule } from "../../geometry/boolean/right-hand-rule";
 import { TerraDrawGeoJSONStore } from "../../common";
+import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawSensorMode", () => {
 	describe("constructor", () => {
@@ -471,6 +472,33 @@ describe("TerraDrawSensorMode", () => {
 				undefined,
 			);
 			expect(onFinish).toHaveBeenCalledTimes(0);
+		});
+
+		describe("with leftClick pointer event set to false", () => {
+			beforeEach(() => {
+				sensorMode = new TerraDrawSensorMode({
+					pointerEvents: {
+						...DefaultPointerEvents,
+						leftClick: false,
+					},
+				});
+				const mockConfig = MockModeConfig(sensorMode.mode);
+
+				store = mockConfig.store;
+				sensorMode.register(mockConfig);
+				sensorMode.start();
+			});
+
+			it("should not allow click", () => {
+				sensorMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				sensorMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				sensorMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(0);
+			});
 		});
 	});
 

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -504,47 +504,56 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		// We want pointer devices (mobile/tablet) to have
-		// similar behaviour to mouse based devices so we
-		// trigger a mousemove event before every click
-		// if one has not been triggered to emulate this
-		if (this.currentCoordinate > 0 && !this.mouseMove) {
-			this.onMouseMove(event);
-		}
-		this.mouseMove = false;
+		if (
+			(event.button === "right" &&
+				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||
+			(event.button === "left" &&
+				this.allowPointerEvent(this.pointerEvents.leftClick, event)) ||
+			(event.isContextMenu &&
+				this.allowPointerEvent(this.pointerEvents.contextMenu, event))
+		) {
+			// We want pointer devices (mobile/tablet) to have
+			// similar behaviour to mouse based devices so we
+			// trigger a mousemove event before every click
+			// if one has not been triggered to emulate this
+			if (this.currentCoordinate > 0 && !this.mouseMove) {
+				this.onMouseMove(event);
+			}
+			this.mouseMove = false;
 
-		if (this.currentCoordinate === 0) {
-			const [newId] = this.store.create([
-				{
-					geometry: { type: "Point", coordinates: [event.lng, event.lat] },
-					properties: { mode: this.mode },
-				},
-			]);
-			this.currentStartingPointId = newId;
-			this.currentCoordinate++;
-
-			// Ensure the state is updated to reflect drawing has started
-			this.setDrawing();
-		} else if (this.currentCoordinate === 1 && this.currentStartingPointId) {
-			const [newId] = this.store.create([
-				{
-					geometry: {
-						type: "LineString",
-						coordinates: [
-							[event.lng, event.lat],
-							[event.lng, event.lat],
-						],
+			if (this.currentCoordinate === 0) {
+				const [newId] = this.store.create([
+					{
+						geometry: { type: "Point", coordinates: [event.lng, event.lat] },
+						properties: { mode: this.mode },
 					},
-					properties: { mode: this.mode },
-				},
-			]);
-			this.currentInitialArcId = newId;
-			this.currentCoordinate++;
-		} else if (this.currentCoordinate === 2 && this.currentStartingPointId) {
-			this.currentCoordinate++;
-			// pass
-		} else if (this.currentCoordinate === 3 && this.currentStartingPointId) {
-			this.close();
+				]);
+				this.currentStartingPointId = newId;
+				this.currentCoordinate++;
+
+				// Ensure the state is updated to reflect drawing has started
+				this.setDrawing();
+			} else if (this.currentCoordinate === 1 && this.currentStartingPointId) {
+				const [newId] = this.store.create([
+					{
+						geometry: {
+							type: "LineString",
+							coordinates: [
+								[event.lng, event.lat],
+								[event.lng, event.lat],
+							],
+						},
+						properties: { mode: this.mode },
+					},
+				]);
+				this.currentInitialArcId = newId;
+				this.currentCoordinate++;
+			} else if (this.currentCoordinate === 2 && this.currentStartingPointId) {
+				this.currentCoordinate++;
+				// pass
+			} else if (this.currentCoordinate === 3 && this.currentStartingPointId) {
+				this.close();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description of Changes

This aims to allow interception of pointer events for modes. There may be reasons that users do not want an pointer event to perform any actual state changes, and as such providing a way to conditionally disable these is useful

## Link to Issue

This is partially related to https://github.com/JamesLMilner/terra-draw/issues/169 although it tackles it at the mode level rather than at the adapter level. It should be able to resolve the issue mentioned in that issue however.

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 