### PR TITLE
fix(terra-draw):  when editable is true in supported modes do not enable draggability on drag

### DIFF
--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -834,8 +834,6 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				value: true,
 			},
 		]);
-
-		setMapDraggability(true);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -220,8 +220,6 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 				value: true,
 			},
 		]);
-
-		setMapDraggability(true);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -976,8 +976,6 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				value: true,
 			},
 		]);
-
-		setMapDraggability(true);
 	}
 
 	/** @internal */


### PR DESCRIPTION
## Description of Changes

Ensures draggability isn't set to true whilst dragging to edit a polygons, linestrings or points when `editable` is enabled in those modes. This fixes the `editable` behaviour for a few adapters.

## Link to Issue

[[Bug] Editable polygon coordinates are not working in OpenLayers, Google Maps and ArcGIS adapters](https://github.com/JamesLMilner/terra-draw/issues/510)

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 