### PR TITLE
fix(terra-draw): improve rotating behaviour for geographically small geometries

### DIFF
--- a/packages/terra-draw/src/geometry/measure/bearing.spec.ts
+++ b/packages/terra-draw/src/geometry/measure/bearing.spec.ts
@@ -1,4 +1,4 @@
-import { bearing } from "./bearing";
+import { bearing, webMercatorBearing } from "./bearing";
 
 describe("bearing", () => {
 	it("bearing between two identical points is zero", () => {
@@ -7,5 +7,15 @@ describe("bearing", () => {
 
 	it("bearing should return positive value", () => {
 		expect(bearing([0, 0], [1, 1])).toBe(44.99563645534486);
+	});
+});
+
+describe("webMercatorBearing", () => {
+	it("bearing between two identical points is zero", () => {
+		expect(webMercatorBearing({ x: 0, y: 0 }, { x: 0, y: 0 })).toBe(0);
+	});
+
+	it("bearing should return positive value", () => {
+		expect(webMercatorBearing({ x: 0, y: 0 }, { x: 1, y: 1 })).toBe(45);
 	});
 });

--- a/packages/terra-draw/src/geometry/measure/bearing.ts
+++ b/packages/terra-draw/src/geometry/measure/bearing.ts
@@ -25,6 +25,10 @@ export function webMercatorBearing(
 	const deltaX = x2 - x1;
 	const deltaY = y2 - y1;
 
+	if (deltaX === 0 && deltaY === 0) {
+		return 0; // No movement
+	}
+
 	// Calculate the angle in radians
 	let angle = Math.atan2(deltaY, deltaX);
 

--- a/packages/terra-draw/src/geometry/web-mercator-centroid.spec.ts
+++ b/packages/terra-draw/src/geometry/web-mercator-centroid.spec.ts
@@ -1,6 +1,7 @@
+import { Feature, Polygon } from "geojson";
 import { webMercatorCentroid } from "./web-mercator-centroid";
 
-describe("webMercatorCenter", () => {
+describe("webMercatorCentroid", () => {
 	it("returns the web mercator center correctly for polygon", () => {
 		const result = webMercatorCentroid({
 			type: "Feature",
@@ -19,8 +20,32 @@ describe("webMercatorCenter", () => {
 			},
 		});
 
-		expect(result.x).toBeCloseTo(6896389.694243925);
+		expect(result.x).toBeCloseTo(6896389.694243949);
 		expect(result.y).toBeCloseTo(1778084.1594212381);
+	});
+
+	it("returns the web mercator center correctly for polygon deterministically for the environment", () => {
+		const polygon = {
+			type: "Feature",
+			properties: {},
+			geometry: {
+				coordinates: [
+					[
+						[60.15177901043299, 18.599398042438764],
+						[60.15177901043299, 12.900268744312697],
+						[63.75086634124065, 12.900268744312697],
+						[63.75086634124065, 18.599398042438764],
+						[60.15177901043299, 18.599398042438764],
+					],
+				],
+				type: "Polygon",
+			},
+		} as Feature<Polygon>;
+		const result = webMercatorCentroid(polygon);
+		const result2 = webMercatorCentroid(polygon);
+
+		expect(result.x).toEqual(result2.x);
+		expect(result.y).toEqual(result2.y);
 	});
 
 	it("returns the web mercator center correctly for linestring", () => {

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -52,6 +52,7 @@ describe("RotateFeatureBehavior", () => {
 			);
 
 			jest.spyOn(config.store, "updateGeometry");
+			jest.spyOn(config.store, "getGeometryCopy");
 		});
 
 		describe("rotate", () => {
@@ -76,6 +77,10 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
 				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+
+				// We cache the geometry in the first event
+				// and then use it in the second event
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
@@ -84,6 +89,10 @@ describe("RotateFeatureBehavior", () => {
 
 				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
 				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+
+				// We cache the geometry in the first event
+				// and then use it in the second event
+				expect(config.store.getGeometryCopy).toHaveBeenCalledTimes(1);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});


### PR DESCRIPTION
## Description of Changes

Currently we retrieve the updated geometry on every rotation and recalculate it's centroid from the store every time. This causes strange rotation behaviours for very small geometries. We can avoid this and for rotation as the center should remain the same on rotation.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/548

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 