### PR TITLE
docs(terra-draw): ensure style.load event is wrapping MapLibre and Mapbox examples

### DIFF
--- a/guides/3.ADAPTERS.md
+++ b/guides/3.ADAPTERS.md
@@ -166,15 +166,19 @@ const map = new MapLibreGL.Map({
   zoom: zoom,
 });
 
-// Create Terra Draw
-const draw = new TerraDraw({
-  adapter: new TerraDrawMapLibreGLAdapter({ map }),
-  modes: [new TerraDrawFreehandMode()],
-});
+// It is important the base styles are loaded before
+map.on("style.load", () => {
 
-// Start drawing
-draw.start();
-draw.setMode("freehand");
+  // Create Terra Draw
+  const draw = new TerraDraw({
+    adapter: new TerraDrawMapLibreGLAdapter({ map }),
+    modes: [new TerraDrawFreehandMode()],
+  });
+
+  // Start drawing
+  draw.start();
+  draw.setMode("freehand");
+});
 ```
 
 ### Google Maps
@@ -341,17 +345,19 @@ const map = new mapboxgl.Map({
   zoom: zoom,
 });
 
-// Create Terra Draw
-const draw = new TerraDraw({
-  adapter: new TerraDrawMapboxGLAdapter({
-    map,
-  }),
-  modes: [new TerraDrawFreehandMode()],
-});
+map.on("style.load", () => {
+  // Create Terra Draw
+  const draw = new TerraDraw({
+    adapter: new TerraDrawMapboxGLAdapter({
+      map,
+    }),
+    modes: [new TerraDrawFreehandMode()],
+  });
 
-// Start drawing
-draw.start();
-draw.setMode("freehand");
+  // Start drawing
+  draw.start();
+  draw.setMode("freehand");
+});
 ```
 
 ### ArcGIS


### PR DESCRIPTION
## Description of Changes

This change was already made in https://github.com/JamesLMilner/terra-draw/pull/537 but looks like it wasn't made to the source file. This PR fixes that and wraps the MapbLibre and Mapbox examples in the style.load event as is required.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/547

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 