### PR TITLE
fix(terra-draw): resolve  scaling in select mode not tracking cursor correctly

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -12,10 +12,7 @@ import { SelectionPointBehavior } from "./selection-point.behavior";
 import { FeatureId, GeoJSONStoreGeometries } from "../../../store/store";
 import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 import { cartesianDistance } from "../../../geometry/measure/pixel-distance";
-import {
-	coordinateIsValid,
-	coordinatePrecisionIsValid,
-} from "../../../geometry/boolean/is-valid-coordinate";
+import { coordinatePrecisionIsValid } from "../../../geometry/boolean/is-valid-coordinate";
 import {
 	lngLatToWebMercatorXY,
 	webMercatorXYToLngLat,

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -1,181 +1,33 @@
-import {
-	CartesianPoint,
-	TerraDrawMouseEvent,
-	UpdateTypes,
-	Validation,
-} from "../../../common";
+import { TerraDrawMouseEvent, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
-import { Feature, LineString, Polygon, Position } from "geojson";
-import { SelectionPointBehavior } from "./selection-point.behavior";
-import { MidPointBehavior } from "./midpoint.behavior";
-import { centroid } from "../../../geometry/centroid";
-import { haversineDistanceKilometers } from "../../../geometry/measure/haversine-distance";
-import {
-	transformScale,
-	transformScaleWebMercator,
-} from "../../../geometry/transform/scale";
-import { limitPrecision } from "../../../geometry/limit-decimal-precision";
 import { FeatureId } from "../../../store/store";
-import { webMercatorCentroid } from "../../../geometry/web-mercator-centroid";
-import {
-	lngLatToWebMercatorXY,
-	webMercatorXYToLngLat,
-} from "../../../geometry/project/web-mercator";
-import { cartesianDistance } from "../../../geometry/measure/pixel-distance";
-import { CoordinatePointBehavior } from "./coordinate-point.behavior";
+import { DragCoordinateResizeBehavior } from "./drag-coordinate-resize.behavior";
 
 export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 	constructor(
 		readonly config: BehaviorConfig,
-		private readonly selectionPoints: SelectionPointBehavior,
-		private readonly midPoints: MidPointBehavior,
-		private readonly coordinatePoints: CoordinatePointBehavior,
+		private readonly dragCoordinateResizeBehavior: DragCoordinateResizeBehavior,
 	) {
 		super(config);
 	}
 
-	private lastDistance: number | undefined;
-	private selectedGeometryCentroid: Position | undefined;
-	private selectedGeometryWebMercatorCentroid: CartesianPoint | undefined;
+	public scale(
+		event: TerraDrawMouseEvent,
+		featureId: FeatureId,
+		validation?: Validation,
+	) {
+		if (!this.dragCoordinateResizeBehavior.isDragging()) {
+			const index = this.dragCoordinateResizeBehavior.getDraggableIndex(
+				event,
+				featureId,
+			);
+			this.dragCoordinateResizeBehavior.startDragging(featureId, index);
+		}
 
-	reset() {
-		this.lastDistance = undefined;
-		this.selectedGeometryCentroid = undefined;
-		this.selectedGeometryWebMercatorCentroid = undefined;
+		this.dragCoordinateResizeBehavior.drag(event, "center-fixed", validation);
 	}
 
-	scale(
-		event: TerraDrawMouseEvent,
-		selectedId: FeatureId,
-		validateFeature?: Validation,
-	) {
-		const geometry = this.store.getGeometryCopy<LineString | Polygon>(
-			selectedId,
-		);
-
-		// Update the geometry of the dragged feature
-		if (geometry.type !== "Polygon" && geometry.type !== "LineString") {
-			return;
-		}
-
-		const mouseCoord = [event.lng, event.lat];
-
-		const feature = { type: "Feature", geometry, properties: {} } as Feature<
-			Polygon | LineString
-		>;
-
-		let distance;
-
-		if (this.config.projection === "web-mercator") {
-			if (!this.selectedGeometryWebMercatorCentroid) {
-				this.selectedGeometryWebMercatorCentroid = webMercatorCentroid(feature);
-			}
-
-			const selectedWebMercator = lngLatToWebMercatorXY(event.lng, event.lat);
-			distance = cartesianDistance(
-				this.selectedGeometryWebMercatorCentroid,
-				selectedWebMercator,
-			);
-		} else if (this.config.projection === "globe") {
-			// Cache the centroid of the selected geometry
-			// to avoid recalculating it on every cursor move
-			if (!this.selectedGeometryCentroid) {
-				this.selectedGeometryCentroid = centroid({
-					type: "Feature",
-					geometry,
-					properties: {},
-				});
-			}
-
-			distance = haversineDistanceKilometers(
-				this.selectedGeometryCentroid,
-				mouseCoord,
-			);
-		} else {
-			throw new Error("Invalid projection");
-		}
-
-		// We need an original bearing to compare against
-		if (!this.lastDistance) {
-			this.lastDistance = distance;
-			return;
-		}
-
-		const scale = 1 - (this.lastDistance - distance) / distance;
-
-		if (this.config.projection === "web-mercator") {
-			if (!this.selectedGeometryWebMercatorCentroid) {
-				this.selectedGeometryWebMercatorCentroid = webMercatorCentroid(feature);
-			}
-
-			const { lng, lat } = webMercatorXYToLngLat(
-				this.selectedGeometryWebMercatorCentroid.x,
-				this.selectedGeometryWebMercatorCentroid.y,
-			);
-			transformScaleWebMercator(feature, scale, [lng, lat]);
-		} else if (this.config.projection === "globe") {
-			// Cache the centroid of the selected geometry
-			// to avoid recalculating it on every cursor move
-			if (!this.selectedGeometryCentroid) {
-				this.selectedGeometryCentroid = centroid({
-					type: "Feature",
-					geometry,
-					properties: {},
-				});
-			}
-
-			transformScale(feature, scale, this.selectedGeometryCentroid);
-		}
-
-		// Coordinates are either polygon or linestring at this point
-		const updatedCoords: Position[] =
-			geometry.type === "Polygon"
-				? geometry.coordinates[0]
-				: geometry.coordinates;
-
-		// Ensure that coordinate precision is maintained
-		updatedCoords.forEach((coordinate) => {
-			coordinate[0] = limitPrecision(coordinate[0], this.coordinatePrecision);
-			coordinate[1] = limitPrecision(coordinate[1], this.coordinatePrecision);
-		});
-
-		const updatedMidPoints = this.midPoints.getUpdated(updatedCoords) || [];
-
-		const updatedSelectionPoints =
-			this.selectionPoints.getUpdated(updatedCoords) || [];
-
-		const updatedCoordinatePoints =
-			this.coordinatePoints.getUpdated(selectedId, updatedCoords) || [];
-
-		if (validateFeature) {
-			if (
-				!validateFeature(
-					{
-						id: selectedId,
-						type: "Feature",
-						geometry,
-						properties: {},
-					},
-					{
-						project: this.config.project,
-						unproject: this.config.unproject,
-						coordinatePrecision: this.config.coordinatePrecision,
-						updateType: UpdateTypes.Provisional,
-					},
-				)
-			) {
-				return false;
-			}
-		}
-
-		// Issue the update to the selected feature
-		this.store.updateGeometry([
-			{ id: selectedId, geometry },
-			...updatedSelectionPoints,
-			...updatedMidPoints,
-			...updatedCoordinatePoints,
-		]);
-
-		this.lastDistance = distance;
+	public reset() {
+		this.dragCoordinateResizeBehavior.stopDragging();
 	}
 }

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -277,13 +277,6 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			this.coordinatePoints,
 		);
 
-		this.scaleFeature = new ScaleFeatureBehavior(
-			config,
-			this.selectionPoints,
-			this.midPoints,
-			this.coordinatePoints,
-		);
-
 		this.dragFeature = new DragFeatureBehavior(
 			config,
 			this.featuresAtMouseEvent,
@@ -305,6 +298,11 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			this.selectionPoints,
 			this.midPoints,
 			this.coordinatePoints,
+		);
+
+		this.scaleFeature = new ScaleFeatureBehavior(
+			config,
+			this.dragCoordinateResizeFeature,
 		);
 	}
 
@@ -842,6 +840,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			this.canScale(event)
 		) {
 			setMapDraggability(false);
+
 			this.scaleFeature.scale(event, selectedId, validation);
 			return;
 		}


### PR DESCRIPTION
## Description of Changes

Here we reuse the `center-fixed` behaviour from `DragCoordinateResizeBehavior` to fix an issue where scaling a polygon was not tracking the coordinate being dragged correctly. This has the added bonus of not maintaining two very similar code paths and the behaviour for both being consistent.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/551

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 