### PR TITLE
fix(terra-draw): ensure the initial click renders coordinate points when showCoordinatePoints true

### DIFF
--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -976,6 +976,27 @@ describe("TerraDrawPolygonMode", () => {
 			expect(onFinish).toHaveBeenCalledTimes(2);
 		});
 
+		it("creates an initial coordinate points on first click when showCoordinatePoints is true", () => {
+			polygonMode.updateOptions({
+				showCoordinatePoints: true,
+			});
+
+			polygonMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			let features = store.copyAll();
+			expect(features.length).toBe(4);
+
+			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[0].properties.coordinatePointIds).toEqual([
+				expect.any(String),
+				expect.any(String),
+				expect.any(String),
+			]);
+			expect(features[1].geometry.type).toBe("Point");
+			expect(features[2].geometry.type).toBe("Point");
+			expect(features[3].geometry.type).toBe("Point");
+		});
+
 		describe("with leftClick pointer event set to false", () => {
 			beforeEach(() => {
 				polygonMode = new TerraDrawPolygonMode({

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -608,6 +608,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.currentId = newId;
 			this.currentCoordinate++;
 
+			if (this.showCoordinatePoints) {
+				this.coordinatePoints.createOrUpdate(newId);
+			}
+
 			// Ensure the state is updated to reflect drawing has started
 			this.setDrawing();
 		} else if (this.currentCoordinate === 1 && this.currentId) {


### PR DESCRIPTION
## Description of Changes

When we do an initial pointer down (click) and `showCoordinatePoints` is set to `true` we want to ensure the coordinate points are rendered. This is especially an issue on mobile as the initial point(s) shows that something is being drawn.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 