### PR TITLE
feat(terra-draw): add updateFeatureGeometry to the API

### DIFF
--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -178,6 +178,37 @@ draw.clear();
 
 See the `TerraDraw` [API Docs](https://jameslmilner.github.io/terra-draw/classes/TerraDraw.html) for more information.
 
+### Updating Data
+
+Terra Draw currently supports the ability to update geometries programmatically. This can be achieved via the `updateFeatureGeometry` method. It works in the following way using the Terra Draw API:
+
+```javascript
+// add a feature to the Terra Draw instance
+const [result] = draw.addFeatures([
+  {
+    id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [0, 0],
+    },
+    properties: {
+      mode: "point",
+    },
+  },
+]);
+
+// Later on down the line we can update its geometry programmatically
+draw.updateFeatureGeometry(result.id as FeatureId, {
+  type: "Point",
+  coordinates: [1, 1],
+});
+```
+
+This can be useful if you want to control a specific geometry via some sort of UI element, like a button or an input for example. In the internals of Terra Draw `updateFeatureGeometry` calls a modes `afterFeatureUpdated` method which handles any tidy up necessary, for example updating guidance features like selection points or midpoints when a feature is selected in TerraDrawSelectMode. As a general rule, if you update a feature using `updateFeatureGeometry` which was currently being drawn, the drawing state will end and the new geometry will have been committed to the store.
+
+See the `TerraDraw` [API Docs](https://jameslmilner.github.io/terra-draw/classes/TerraDraw.html) for more information.
+
 ## Restoring Data 
 
 Terra Draw is agnostic to how you want to persist the data created with it. You can store data in a remote database, in [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), or any other storage mechanism you so wish. As a simple example of storing the data in `localStorage`, you could take a snapshot and restore it at a later date like so:

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -448,4 +448,16 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			),
 		);
 	}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		// If we are in the middle of drawing a rectangle and the feature being updated is the current rectangle,
+		// we need to reset the drawing state
+		if (this.currentId === feature.id) {
+			this.currentId = undefined;
+			this.currentCoordinate = 0;
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
 }

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -221,6 +221,8 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 
 	afterFeatureAdded(feature: GeoJSONStoreFeatures) {}
 
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures) {}
+
 	private performFeatureValidation(feature: unknown): ReturnType<Validation> {
 		if (this._state === "unregistered") {
 			throw new Error("Mode must be registered");

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -375,4 +375,18 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 			]);
 		}
 	}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		// If we are in the middle of drawing a circle and the feature being updated is the current circle,
+		// we need to reset the drawing state
+		if (this.currentCircleId === feature.id) {
+			this.cursorMovedAfterInitialCursorDown = false;
+			this.center = undefined;
+			this.currentCircleId = undefined;
+			this.clickCount = 0;
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
 }

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -384,4 +384,13 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 
 		return clickedFeature;
 	}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures) {
+		// If we are editing a point by dragging it we want to clear that state
+		// up as new point location might be completely  different in terms of it's location
+		if (this.editedFeatureId === feature.id) {
+			this.editedFeatureId = undefined;
+			this.setCursor(this.cursors.create);
+		}
+	}
 }

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -628,4 +628,55 @@ describe("TerraDrawRectangleMode", () => {
 			});
 		});
 	});
+
+	describe("afterFeatureUpdated", () => {
+		it("does nothing when update is not for the currently drawn polygon", () => {
+			const rectangleMode = new TerraDrawRectangleMode();
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			rectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			rectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);
+
+			const feature = mockConfig.store.copyAll()[0];
+
+			// Set the onChange count to 0
+			mockConfig.onChange.mockClear();
+			mockConfig.setDoubleClickToZoom.mockClear();
+
+			rectangleMode.afterFeatureUpdated({
+				...feature,
+			});
+
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(0);
+			expect(mockConfig.setDoubleClickToZoom).toHaveBeenCalledTimes(0);
+		});
+
+		it("sets drawing back to started", () => {
+			const rectangleMode = new TerraDrawRectangleMode();
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			rectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			const features = mockConfig.store.copyAll();
+			expect(features.length).toBe(1);
+			const feature = features[0];
+
+			// Set the onChange count to 0
+			mockConfig.setDoubleClickToZoom.mockClear();
+
+			rectangleMode.afterFeatureUpdated({
+				...feature,
+			});
+
+			expect(mockConfig.setDoubleClickToZoom).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -312,4 +312,17 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			),
 		);
 	}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		// If we are in the middle of drawing a rectangle and the feature being updated is the current rectangle,
+		// we need to reset the drawing state
+		if (this.currentRectangleId === feature.id) {
+			this.center = undefined;
+			this.currentRectangleId = undefined;
+			this.clickCount = 0;
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
 }

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -489,4 +489,17 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 			),
 		);
 	}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		// If we are in the middle of drawing a sector and the feature being updated is the current sector,
+		// we need to reset the drawing state
+		if (this.currentId === feature.id) {
+			this.currentId = undefined;
+			this.direction = undefined;
+			this.currentCoordinate = 0;
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
 }

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -697,6 +697,28 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 		);
 	}
 
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		// If we are in the middle of drawing a sensor and the feature being updated is the current sensor,
+		// we need to reset the drawing state
+		if (this.currentId === feature.id) {
+			if (this.currentStartingPointId) {
+				this.store.delete([this.currentStartingPointId]);
+			}
+			if (this.currentInitialArcId) {
+				this.store.delete([this.currentInitialArcId]);
+			}
+
+			this.currentStartingPointId = undefined;
+			this.direction = undefined;
+			this.currentId = undefined;
+			this.currentCoordinate = 0;
+
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
+
 	private getDeltaBearing(
 		direction: "anticlockwise" | "clockwise",
 		normalizedStart: number,

--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { COMMON_PROPERTIES } from "./common";
+import { COMMON_PROPERTIES, SELECT_PROPERTIES } from "./common";
 import { FeatureId } from "./extend";
 import {
 	GeoJSONStoreFeatures,
@@ -873,6 +873,534 @@ describe("Terra Draw", () => {
 			draw.addFeatures([polygon]);
 
 			expect(draw.getSnapshot()).toHaveLength(5);
+		});
+	});
+
+	describe("updateFeatureGeometry", () => {
+		it("correctly updates a point geometry", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPointMode(), new TerraDrawSelectMode()],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [25, 34],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+
+			onChange.mockClear();
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "Point",
+				coordinates: [-26, -34],
+			});
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([result.id], "update", {
+				origin: "api",
+			});
+
+			const snapshot = draw.getSnapshot();
+			expect(snapshot).toHaveLength(1);
+
+			const updatedFeature = snapshot[0];
+			expect(updatedFeature.id).toBe(result.id);
+
+			expect(updatedFeature.geometry.coordinates).toEqual([-26, -34]);
+		});
+
+		it("correctly updates a linestring geometry", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawLineStringMode(), new TerraDrawSelectMode()],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "LineString",
+						coordinates: [
+							[25, 34],
+							[26, 35],
+						],
+					},
+					properties: {
+						mode: "linestring",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+
+			onChange.mockClear();
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "LineString",
+				coordinates: [
+					[-25, -34],
+					[-26, -35],
+				],
+			});
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([result.id], "update", {
+				origin: "api",
+			});
+
+			const snapshot = draw.getSnapshot();
+			expect(snapshot).toHaveLength(1);
+
+			const updatedFeature = snapshot[0];
+			expect(updatedFeature.id).toBe(result.id);
+
+			expect(updatedFeature.geometry.coordinates).toEqual([
+				[-25, -34],
+				[-26, -35],
+			]);
+		});
+
+		it("correctly updates a polygon geometry", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPolygonMode(), new TerraDrawSelectMode()],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+
+			onChange.mockClear();
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "Polygon",
+				coordinates: [
+					[
+						[-25, -34],
+						[-26, -35],
+						[-27, -34],
+						[-25, -34],
+					],
+				],
+			});
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith([result.id], "update", {
+				origin: "api",
+			});
+
+			const snapshot = draw.getSnapshot();
+			expect(snapshot).toHaveLength(1);
+
+			const updatedFeature = snapshot[0];
+			expect(updatedFeature.id).toBe(result.id);
+
+			expect(updatedFeature.geometry.coordinates).toEqual([
+				[
+					[-25, -34],
+					[-26, -35],
+					[-27, -34],
+					[-25, -34],
+				],
+			]);
+		});
+
+		it("correctly updates a polygon geometry when it is selected", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPolygonMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							polygon: {
+								feature: {
+									draggable: true,
+									coordinates: {},
+								},
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+
+			draw.selectFeature(result.id as FeatureId);
+
+			const snapshotBefore = draw.getSnapshot();
+			expect(snapshotBefore).toHaveLength(4);
+
+			onChange.mockClear();
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "Polygon",
+				coordinates: [
+					[
+						[-25, -34],
+						[-26, -35],
+						[-27, -34],
+						[-25, -34],
+					],
+				],
+			});
+
+			expect(onChange).toHaveBeenCalledTimes(3);
+			expect(onChange).toHaveBeenCalledWith([result.id], "update", {
+				origin: "api",
+			});
+
+			const snapshot = draw.getSnapshot();
+			expect(snapshot).toHaveLength(4);
+
+			const updatedFeature = snapshot[0];
+			expect(updatedFeature.id).toBe(result.id);
+
+			expect(updatedFeature.geometry.coordinates).toEqual([
+				[
+					[-25, -34],
+					[-26, -35],
+					[-27, -34],
+					[-25, -34],
+				],
+			]);
+
+			// Coordinate points are also updated
+			const coordinatePoints = snapshot.filter(
+				(f) => f.properties[SELECT_PROPERTIES.SELECTION_POINT],
+			);
+			expect(coordinatePoints).toHaveLength(3);
+			expect(coordinatePoints[0].geometry.coordinates).toEqual([-25, -34]);
+			expect(coordinatePoints[1].geometry.coordinates).toEqual([-26, -35]);
+			expect(coordinatePoints[2].geometry.coordinates).toEqual([-27, -34]);
+		});
+
+		it("fails when geometry is malformed", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [25, 34],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			onChange.mockClear();
+
+			expect(() => {
+				draw.updateFeatureGeometry(result.id as FeatureId, {} as any);
+			}).toThrow("Invalid geometry provided");
+		});
+
+		it("fails when geometry types mismatch", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [25, 34],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			onChange.mockClear();
+
+			expect(() => {
+				draw.updateFeatureGeometry(result.id as FeatureId, {
+					type: "LineString",
+					coordinates: [
+						[-26, -34],
+						[-27, -35],
+					],
+				});
+			}).toThrow("Geometry type mismatch: expected Point, got LineString");
+		});
+
+		it("fails when geometry coordinates are empty", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [25, 34],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			onChange.mockClear();
+
+			expect(() => {
+				draw.updateFeatureGeometry(result.id as FeatureId, {
+					type: "Point",
+					coordinates: [],
+				});
+			}).toThrow("Feature validation failed: Feature has invalid coordinates");
+		});
+
+		it("fails when geometry coordinates are not in bounds", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPointMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							point: {
+								feature: { draggable: true },
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Point",
+						coordinates: [25, 34],
+					},
+					properties: {
+						mode: "point",
+					},
+				},
+			]);
+
+			onChange.mockClear();
+
+			expect(() => {
+				draw.updateFeatureGeometry(result.id as FeatureId, {
+					type: "Point",
+					coordinates: [-1000, 1000],
+				});
+			}).toThrow("Feature validation failed: Feature has invalid coordinates");
+		});
+
+		it("fails when feature is guidance feature", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPolygonMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							polygon: {
+								feature: {
+									coordinates: {
+										draggable: true,
+									},
+								},
+							},
+						},
+					}),
+				],
+			});
+
+			const onChange = jest.fn();
+			draw.on("change", onChange);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			draw.selectFeature(result.id as FeatureId);
+
+			onChange.mockClear();
+
+			const guidanceFeature = draw
+				.getSnapshot()
+				.find((f) => f.properties[SELECT_PROPERTIES.SELECTION_POINT]);
+
+			expect(guidanceFeature).toBeDefined();
+
+			expect(() => {
+				draw.updateFeatureGeometry(guidanceFeature!.id as FeatureId, {
+					type: "Point",
+					coordinates: [-26, -34],
+				});
+			}).toThrow("Guidance features are not allowed to be updated directly");
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

This adds a API method `updateFeatureGeometry` that allows developers to programmatically update the geometry of a feature. This can be useful if you want to avoid deleting and re-adding a feature, or if you want to mutate a geometry via some user input like a button or numeric input field. An example might be you want to be able to simplify a given polygon on demand.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/557

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 