### PR TITLE
feat(terra-draw): unify snapping functionality across polygon, linestring and select modes

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -139,7 +139,7 @@ Using these can help you write more customised behaviours, for example you may o
 
 #### Snapping
 
-Some specific modes support snapping, currently polygon and linestring mode. As of writing you can snap between features in the same mode. Currently polygon mode supports snapping to a the coordinates or line segments of existing features via the `toCoordinate` and/or `toLine` properties respectively:
+Some specific modes support snapping, currently polygon, linestring and select mode. As of writing you can snap between features in the same mode. Currently polygon mode supports snapping to a the coordinates or line segments of existing features via the `toCoordinate` and/or `toLine` properties respectively:
 
 ```typescript
   new TerraDrawPolygonMode({
@@ -167,6 +167,29 @@ We can also provide a `toCustom` function which allows snapping to some arbitrar
       }
     }
   })
+```
+
+In `TerraDrawSelectMode` we can similarly add snapping behaviours like so:
+
+```typescript
+new TerraDrawSelectMode({
+  projection: "web-mercator",
+  flags: {
+    polygon: {
+      feature: {
+        coordinates: {
+          snappable: {
+            toLine: false,
+            toCoordinate: false,
+            // toCustom: (event, context) => {
+            // 	return [-0.126, 51.509];
+            // }
+          },
+        }
+      }
+    }
+  }
+})
 ```
 
 #### Updating a Modes Options After Instantiation

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -105,7 +105,13 @@ class TestMap {
 								rotateable: true,
 								scaleable: true,
 								coordinates: {
-									snappable: this.config?.includes("selectDragSnapping"),
+									snappable: this.config?.includes("selectDragSnapping")
+										? true
+										: this.config?.includes("selectDragSnappingToCustom")
+											? {
+													toCustom: () => [-0.118092, 51.509865],
+												}
+											: false,
 									midpoints: true,
 									draggable: true,
 									deletable: true,

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -15,6 +15,7 @@ export type TestConfigOptions =
 	| "snappingCoordinate"
 	| "showCoordinatePoints"
 	| "selectDragSnapping"
+	| "selectDragSnappingToCustom"
 	| "disableLeftClick";
 
 export const setupMap = async ({

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -1,3 +1,4 @@
+import { LineString, Polygon, Position } from "geojson";
 import {
 	StoreChangeHandler,
 	GeoJSONStore,
@@ -117,6 +118,21 @@ export type Validation = (
 	valid: boolean;
 	reason?: string;
 };
+
+export interface Snapping {
+	toLine?: boolean;
+	toCoordinate?: boolean;
+	toCustom?: (
+		event: TerraDrawMouseEvent,
+		context: {
+			currentId?: FeatureId;
+			currentCoordinate?: number;
+			getCurrentGeometrySnapshot: () => (Polygon | LineString) | null;
+			project: Project;
+			unproject: Unproject;
+		},
+	) => Position | undefined;
+}
 
 export type TerraDrawModeState =
 	| "unregistered"

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -401,6 +401,44 @@ describe("TerraDrawLineStringMode", () => {
 			expect(features[1].geometry.coordinates).toStrictEqual([2, 2]);
 		});
 
+		it("can snap from existing line once finished with snapping toLine enabled", () => {
+			lineStringMode = new TerraDrawLineStringMode({
+				snapping: { toLine: true },
+			});
+			const mockConfig = MockModeConfig(lineStringMode.mode);
+			onChange = mockConfig.onChange;
+			onFinish = mockConfig.onFinish;
+			store = mockConfig.store;
+
+			lineStringMode.register(mockConfig);
+			lineStringMode.start();
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			expect(onFinish).toHaveBeenCalledTimes(1);
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2.1, lat: 2.1 }));
+
+			const features = store.copyAll();
+			expect(features.length).toBe(2);
+
+			expect(features[1].geometry.type).toBe("Point");
+			expect(features[1].properties.snappingPoint).toBe(true);
+			expect(features[1].geometry.coordinates).toStrictEqual([
+				2, 2.0000000000000027,
+			]);
+		});
+
 		it("can snap from existing line once finished with snapping toCustom enabled", () => {
 			const coordinates = [
 				[5, 5],

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -10,6 +10,7 @@ import {
 	Project,
 	Unproject,
 	Z_INDEX,
+	Snapping,
 } from "../../common";
 import { Feature, Polygon, Position } from "geojson";
 import {
@@ -79,21 +80,6 @@ const defaultCursors = {
 	dragStart: "grabbing",
 	dragEnd: "crosshair",
 } as Required<Cursors>;
-
-interface Snapping {
-	toLine?: boolean;
-	toCoordinate?: boolean;
-	toCustom?: (
-		event: TerraDrawMouseEvent,
-		context: {
-			currentId?: FeatureId;
-			currentCoordinate?: number;
-			getCurrentGeometrySnapshot: () => Polygon | null;
-			project: Project;
-			unproject: Unproject;
-		},
-	) => Position | undefined;
-}
 
 interface TerraDrawPolygonModeOptions<T extends CustomStyling>
 	extends BaseModeOptions<T> {

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -1809,7 +1809,7 @@ describe("TerraDrawSelectMode", () => {
 				);
 			});
 
-			it("can snap to nearby polygon coordinates if snappable is enabled", () => {
+			it("can snap to nearby polygon coordinates if snappable (toCoordinate) is enabled", () => {
 				setSelectMode({
 					flags: {
 						polygon: {
@@ -1915,7 +1915,7 @@ describe("TerraDrawSelectMode", () => {
 				);
 			});
 
-			it("can snap to nearby linestring coordinates if snappable is enabled", () => {
+			it("can snap to nearby linestring coordinates if snappable (toCoordinate) is enabled", () => {
 				setSelectMode({
 					flags: {
 						linestring: {
@@ -2007,6 +2007,340 @@ describe("TerraDrawSelectMode", () => {
 				]);
 
 				// Update linestring position and 1 selection points
+				// that gets moved
+				expect(onChange).toHaveBeenNthCalledWith(
+					6,
+					[expect.any(String), expect.any(String)],
+					"update",
+					undefined,
+				);
+			});
+
+			it("can snap to nearby polygon line if snappable toLine is enabled", () => {
+				setSelectMode({
+					flags: {
+						polygon: {
+							feature: {
+								coordinates: {
+									draggable: true,
+									snappable: {
+										toLine: true,
+									},
+								},
+							},
+						},
+					},
+				});
+
+				jest.spyOn(store, "updateGeometry");
+
+				// We want to account for ignoring points branch
+				addPointToStore([100, 89]);
+
+				expect(onChange).toHaveBeenCalledTimes(1);
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				addPolygonToStore([
+					[2, 2],
+					[2, 3],
+					[3, 3],
+					[3, 2],
+					[2, 2],
+				]);
+
+				expect(onChange).toHaveBeenCalledTimes(3);
+
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(5);
+
+				// Select feature
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[expect.any(String)],
+					"update",
+					undefined,
+				);
+
+				// Create selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					5,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+					undefined,
+				);
+
+				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					MockCursorEvent({ lng: 1.5, lat: 1.5 }),
+					setMapDraggability,
+				);
+
+				expect(onChange).toHaveBeenCalledTimes(6);
+
+				expect(store.updateGeometry).toHaveBeenCalledTimes(1);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
+					{
+						geometry: {
+							coordinates: [
+								[
+									[0, 0],
+									[0, 1],
+									[2, 2.0000000000000027],
+									[1, 0],
+									[0, 0],
+								],
+							],
+							type: "Polygon",
+						},
+						id: expect.any(String),
+					},
+					{
+						geometry: {
+							coordinates: [2, 2.0000000000000027],
+							type: "Point",
+						},
+						id: expect.any(String),
+					},
+				]);
+
+				// Update polygon position and 1 selection points
+				// that gets moved
+				expect(onChange).toHaveBeenNthCalledWith(
+					6,
+					[expect.any(String), expect.any(String)],
+					"update",
+					undefined,
+				);
+			});
+
+			it("can snap to nearby linestring coordinates if snappable toLine is enabled", () => {
+				setSelectMode({
+					flags: {
+						linestring: {
+							feature: {
+								coordinates: {
+									draggable: true,
+									snappable: {
+										toLine: true,
+									},
+								},
+							},
+						},
+					},
+				});
+
+				jest.spyOn(store, "updateGeometry");
+
+				// We want to account for ignoring points branch
+				addPointToStore([100, 89]);
+
+				expect(onChange).toHaveBeenCalledTimes(1);
+
+				addLineStringToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+				]);
+
+				addLineStringToStore([
+					[2, 2],
+					[2, 3],
+					[3, 3],
+					[3, 2],
+				]);
+
+				expect(onChange).toHaveBeenCalledTimes(3);
+
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(5);
+
+				// Select feature
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[expect.any(String)],
+					"update",
+					undefined,
+				);
+
+				// Create selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					5,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+					undefined,
+				);
+
+				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					MockCursorEvent({ lng: 1.5, lat: 1.5 }),
+					setMapDraggability,
+				);
+
+				expect(onChange).toHaveBeenCalledTimes(6);
+
+				expect(store.updateGeometry).toHaveBeenCalledTimes(1);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
+					{
+						geometry: {
+							coordinates: [
+								[0, 0],
+								[0, 1],
+								[2, 2.0000000000000027],
+								[1, 0],
+							],
+							type: "LineString",
+						},
+						id: expect.any(String),
+					},
+					{
+						geometry: {
+							coordinates: [2, 2.0000000000000027],
+							type: "Point",
+						},
+						id: expect.any(String),
+					},
+				]);
+
+				// Update linestring position and 1 selection points
+				// that gets moved
+				expect(onChange).toHaveBeenNthCalledWith(
+					6,
+					[expect.any(String), expect.any(String)],
+					"update",
+					undefined,
+				);
+			});
+
+			it("can snap to nearby polygon line if snappable toCustom is enabled", () => {
+				setSelectMode({
+					flags: {
+						polygon: {
+							feature: {
+								coordinates: {
+									draggable: true,
+									snappable: {
+										toCustom: () => [45, 45],
+									},
+								},
+							},
+						},
+					},
+				});
+
+				jest.spyOn(store, "updateGeometry");
+
+				// We want to account for ignoring points branch
+				addPointToStore([100, 89]);
+
+				expect(onChange).toHaveBeenCalledTimes(1);
+
+				addPolygonToStore([
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				]);
+
+				addPolygonToStore([
+					[2, 2],
+					[2, 3],
+					[3, 3],
+					[3, 2],
+					[2, 2],
+				]);
+
+				expect(onChange).toHaveBeenCalledTimes(3);
+
+				selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				expect(onSelect).toHaveBeenCalledTimes(1);
+				expect(onChange).toHaveBeenCalledTimes(5);
+
+				// Select feature
+				expect(onChange).toHaveBeenNthCalledWith(
+					4,
+					[expect.any(String)],
+					"update",
+					undefined,
+				);
+
+				// Create selection points
+				expect(onChange).toHaveBeenNthCalledWith(
+					5,
+					[
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+						expect.any(String),
+					],
+					"create",
+					undefined,
+				);
+
+				selectMode.onDragStart(MockCursorEvent({ lng: 1, lat: 1 }), jest.fn());
+
+				const setMapDraggability = jest.fn();
+				selectMode.onDrag(
+					MockCursorEvent({ lng: 1.5, lat: 1.5 }),
+					setMapDraggability,
+				);
+
+				expect(onChange).toHaveBeenCalledTimes(6);
+
+				expect(store.updateGeometry).toHaveBeenCalledTimes(1);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
+					{
+						geometry: {
+							coordinates: [
+								[
+									[0, 0],
+									[0, 1],
+									[45, 45],
+									[1, 0],
+									[0, 0],
+								],
+							],
+							type: "Polygon",
+						},
+						id: expect.any(String),
+					},
+					{
+						geometry: {
+							coordinates: [45, 45],
+							type: "Point",
+						},
+						id: expect.any(String),
+					},
+				]);
+
+				// Update polygon position and 1 selection points
 				// that gets moved
 				expect(onChange).toHaveBeenNthCalledWith(
 					6,


### PR DESCRIPTION
## Description of Changes

Unifies how snapping is handled across polygon, linestring and select modes. This will allow `toCoordinate`, `toLine` and `toCustom` behaviours in all 3 modes, powered by the same code.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/561
https://github.com/JamesLMilner/terra-draw/issues/343

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 