### PR TITLE
feat(terra-draw): add index property to coordinate points

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -176,6 +176,7 @@ export interface TerraDrawAdapter {
 export const SELECT_PROPERTIES = {
 	SELECTED: "selected",
 	MID_POINT: "midPoint",
+	SELECTION_POINT_FEATURE_ID: "selectionPointFeatureId",
 	SELECTION_POINT: "selectionPoint",
 } as const;
 
@@ -186,7 +187,7 @@ export const COMMON_PROPERTIES = {
 	COORDINATE_POINT: "coordinatePoint",
 	COORDINATE_POINT_FEATURE_ID: "coordinatePointFeatureId",
 	COORDINATE_POINT_IDS: "coordinatePointIds",
-};
+} as const;
 
 export const Z_INDEX = {
 	LAYER_ONE: 10,

--- a/packages/terra-draw/src/geometry/get-coordinates-as-points.ts
+++ b/packages/terra-draw/src/geometry/get-coordinates-as-points.ts
@@ -1,10 +1,10 @@
 import { Point, Position } from "geojson";
 import { JSONObject } from "../store/store";
 
-export function getCoordinatesAsPoints(
+export function getCoordinatesAsPoints<Properties extends JSONObject>(
 	selectedCoords: Position[],
 	geometryType: "Polygon" | "LineString",
-	properties: (index: number) => JSONObject,
+	properties: (index: number) => Properties,
 ) {
 	const selectionPoints = [];
 

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
@@ -136,7 +136,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 		featureId: FeatureId,
 	) {
 		return this.store.create(
-			coordinates.map((coordinate) => ({
+			coordinates.map((coordinate, i) => ({
 				geometry: {
 					type: "Point",
 					coordinates: coordinate,
@@ -145,6 +145,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 					mode,
 					[COMMON_PROPERTIES.COORDINATE_POINT]: true,
 					[COMMON_PROPERTIES.COORDINATE_POINT_FEATURE_ID]: featureId,
+					index: i,
 				},
 			})),
 		);

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
@@ -33,10 +33,9 @@ describe("SelectionPointBehavior", () => {
 			expect(selectionPointBehavior.ids).toStrictEqual([]);
 		});
 
-		it("create - for polygon", () => {
-			const selectionPointBehavior = new SelectionPointBehavior(
-				MockBehaviorConfig("test"),
-			);
+		it("create for Polygon", () => {
+			const config = MockBehaviorConfig("test");
+			const selectionPointBehavior = new SelectionPointBehavior(config);
 
 			selectionPointBehavior.create(
 				[
@@ -51,6 +50,14 @@ describe("SelectionPointBehavior", () => {
 			selectionPointBehavior.ids.forEach((id) =>
 				expect(isUUIDV4(id as string)),
 			);
+
+			selectionPointBehavior.ids.forEach((id, i) => {
+				const properties = config.store.getPropertiesCopy(id);
+				expect(properties.mode).toBe("test");
+				expect(properties.index).toBe(i);
+				expect(properties.selectionPoint).toBe(true);
+				expect(properties.selectionPointFeatureId).toBe("id");
+			});
 		});
 
 		it("delete", () => {
@@ -91,7 +98,7 @@ describe("SelectionPointBehavior", () => {
 				expect(result).toBe(undefined);
 			});
 
-			it("should get updated coordinates if lengths match", () => {
+			it("should get updated coordinates if lengths match for Polygon", () => {
 				const config = MockBehaviorConfig("test");
 
 				const selectionPointBehavior = new SelectionPointBehavior(config);
@@ -117,8 +124,58 @@ describe("SelectionPointBehavior", () => {
 
 				expect(Array.isArray(result)).toBe(true);
 
-				(result as any[]).forEach((point) => {
+				(result as any[]).forEach((point, i) => {
 					expect(isUUIDV4(point.id as string));
+
+					const properties = config.store.getPropertiesCopy(point.id);
+
+					expect(properties.mode).toBe("test");
+					expect(properties.index).toBe(i);
+					expect(properties.selectionPoint).toBe(true);
+					expect(properties.selectionPointFeatureId).toBe("id");
+
+					expect(point.geometry.type).toBe("Point");
+					expect(point.geometry.coordinates).toStrictEqual([
+						expect.any(Number),
+						expect.any(Number),
+					]);
+				});
+			});
+
+			it("should get updated coordinates if lengths match for LineString", () => {
+				const config = MockBehaviorConfig("test");
+
+				const selectionPointBehavior = new SelectionPointBehavior(config);
+
+				selectionPointBehavior.create(
+					[
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+					],
+					"LineString",
+					"id",
+				);
+
+				const result = selectionPointBehavior.getUpdated([
+					[2, 2],
+					[2, 3],
+					[2, 2],
+					[2, 3],
+				]);
+
+				expect(Array.isArray(result)).toBe(true);
+
+				(result as any[]).forEach((point, i) => {
+					expect(isUUIDV4(point.id as string));
+
+					const properties = config.store.getPropertiesCopy(point.id);
+
+					expect(properties.mode).toBe("test");
+					expect(properties.index).toBe(i);
+					expect(properties.selectionPoint).toBe(true);
+					expect(properties.selectionPointFeatureId).toBe("id");
 
 					expect(point.geometry.type).toBe("Point");
 					expect(point.geometry.coordinates).toStrictEqual([

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
@@ -2,6 +2,14 @@ import { LineString, Point, Polygon, Position } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { getCoordinatesAsPoints } from "../../../geometry/get-coordinates-as-points";
 import { FeatureId } from "../../../store/store";
+import { SELECT_PROPERTIES } from "../../../common";
+
+export type SelectionPointProperties = {
+	mode: string;
+	index: number;
+	[SELECT_PROPERTIES.SELECTION_POINT_FEATURE_ID]: string;
+	[SELECT_PROPERTIES.SELECTION_POINT]: true;
+};
 
 export class SelectionPointBehavior extends TerraDrawModeBehavior {
 	constructor(config: BehaviorConfig) {
@@ -24,9 +32,9 @@ export class SelectionPointBehavior extends TerraDrawModeBehavior {
 		this._selectionPoints = this.store.create(
 			getCoordinatesAsPoints(selectedCoords, type, (i) => ({
 				mode: this.mode,
-				selectionPoint: true,
-				selectionPointFeatureId: featureId,
 				index: i,
+				[SELECT_PROPERTIES.SELECTION_POINT]: true,
+				[SELECT_PROPERTIES.SELECTION_POINT_FEATURE_ID]: featureId,
 			})),
 		);
 	}

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -8,17 +8,19 @@ import {
 	Cursor,
 	Validation,
 	UpdateTypes,
-	COMMON_PROPERTIES,
 	Z_INDEX,
 } from "../../common";
-import { Point, Polygon, Position } from "geojson";
+import { Point, Position } from "geojson";
 import {
 	BaseModeOptions,
 	CustomStyling,
 	TerraDrawBaseSelectMode,
 } from "../base.mode";
 import { MidPointBehavior } from "./behaviors/midpoint.behavior";
-import { SelectionPointBehavior } from "./behaviors/selection-point.behavior";
+import {
+	SelectionPointBehavior,
+	SelectionPointProperties,
+} from "./behaviors/selection-point.behavior";
 import { FeatureAtPointerEventBehavior } from "./behaviors/feature-at-pointer-event.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
@@ -309,12 +311,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			return;
 		}
 
-		let clickedSelectionPointProps:
-			| {
-					selectionPointFeatureId: string;
-					index: number;
-			  }
-			| undefined;
+		let clickedSelectionPointProps: SelectionPointProperties | undefined;
 
 		let clickedFeatureDistance = Infinity;
 
@@ -327,10 +324,9 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 				distance < clickedFeatureDistance
 			) {
 				clickedFeatureDistance = distance;
-				clickedSelectionPointProps = this.store.getPropertiesCopy(id) as {
-					selectionPointFeatureId: string;
-					index: number;
-				};
+				clickedSelectionPointProps = this.store.getPropertiesCopy(
+					id,
+				) as SelectionPointProperties;
 			}
 		});
 


### PR DESCRIPTION
## Description of Changes

Add index to coordinate point properties, similar to how we do for selection points

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/567

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 