### PR TITLE
fix(terra-draw): avoid calling register/unregister when state is already enabled/disabled

### DIFF
--- a/packages/e2e/public/index.html
+++ b/packages/e2e/public/index.html
@@ -46,6 +46,7 @@
         <button id="sensor">Sensor</button>
         <button id="circle">Circle</button>
         <button id="clear">Clear</button>
+        <button id="toggle" data-testid="toggle">Toggle On/Off</button>
     </div>
 
 </body>

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -267,6 +267,17 @@ class TestMap {
 				draw.clear();
 			},
 		);
+
+		(document.getElementById("toggle") as HTMLButtonElement).addEventListener(
+			"click",
+			() => {
+				if (draw.enabled) {
+					draw.stop();
+				} else {
+					draw.start();
+				}
+			},
+		);
 	}
 }
 

--- a/packages/e2e/tests/leaflet.spec.ts
+++ b/packages/e2e/tests/leaflet.spec.ts
@@ -9,6 +9,7 @@ import {
 	pageUrl,
 	setupMap,
 	TestConfigOptions,
+	clickToggleOnOff,
 } from "./setup";
 
 test.describe("page setup", () => {
@@ -47,6 +48,27 @@ test.describe("page setup", () => {
 		await expect(
 			await page.locator("#webpack-dev-server-client-overlay").count(),
 		).toBe(0);
+	});
+
+	test("starting -> stopping -> starting draw instance produces no console errors", async ({
+		page,
+	}) => {
+		const errors: string[] = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "error") {
+				errors.push(msg.text());
+			}
+		});
+		await page.goto(pageUrl);
+		await expect(page.getByRole("application")).toBeVisible();
+
+		// Turn Terra Draw off
+		await clickToggleOnOff({ page });
+
+		// Turn Terra Draw on
+		await clickToggleOnOff({ page });
+
+		expect(errors).toEqual([]);
 	});
 });
 

--- a/packages/e2e/tests/setup.ts
+++ b/packages/e2e/tests/setup.ts
@@ -98,6 +98,12 @@ export const changeMode = async ({
 	).toBe("rgb(39, 204, 255)"); // We set hex but it gets computed to rgb
 };
 
+/** Click the toggle button to turn Terra Draw on or off */
+export const clickToggleOnOff = async ({ page }: { page: Page }) => {
+	const button = page.getByTestId("toggle");
+	await button.click();
+};
+
 export const expectPaths = async ({
 	page,
 	count,

--- a/packages/terra-draw/src/common/base.adapter.ts
+++ b/packages/terra-draw/src/common/base.adapter.ts
@@ -408,7 +408,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 		this._listeners.forEach((listener) => {
 			listener.unregister();
 		});
+
 		this.clear();
+
+		// This has to come last because we call this._currentModeCallbacks.onClear()
+		this._currentModeCallbacks = undefined;
 	}
 
 	public abstract clear(): void;

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -103,10 +103,6 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 
 	/** @internal */
 	onClick(event: TerraDrawMouseEvent) {
-		if (!this.store) {
-			throw new Error("Mode must be registered first");
-		}
-
 		if (
 			(event.button === "right" &&
 				this.allowPointerEvent(this.pointerEvents.rightClick, event)) ||

--- a/packages/terra-draw/src/terra-draw.extensions.spec.ts
+++ b/packages/terra-draw/src/terra-draw.extensions.spec.ts
@@ -158,6 +158,10 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 	public register(callbacks: TerraDrawExtend.TerraDrawCallbacks): void {
 		this._currentModeCallbacks = callbacks;
 	}
+
+	public unregister(): void {
+		super.unregister();
+	}
 }
 
 /**

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -722,6 +722,11 @@ class TerraDraw {
 	 * in registers the passed adapter giving it all the callbacks required to operate.
 	 */
 	start() {
+		// If the instance is already enabled, we do nothing
+		if (this._enabled) {
+			return;
+		}
+
 		this._enabled = true;
 		this._adapter.register({
 			onReady: () => {
@@ -812,6 +817,11 @@ class TerraDraw {
 	 * remove any rendered layers in the process.
 	 */
 	stop() {
+		// If the instance is already stopped, we do nothing
+		if (!this._enabled) {
+			return;
+		}
+
 		this._enabled = false;
 		this._adapter.unregister();
 	}


### PR DESCRIPTION
## Description of Changes

**Behavior**
* Only call register logic if `enabled` is currently `false`, only call unregister logic if `enabled` is current `true`. This avoids situations where the register logic is not idempotent and could cause errors or unpredictable state.
* In the base adapter we now set `_currentModeCallbacks` to `undefined` as in the adapter `clear` methods we are checking to ensure the adapter is registered correctly. Since `unregister` was never setting this, there are clear methods in the adapters that check that this value is true, assuming the adapter is registered when it is not.
* Remove inconsistent check in point mode where we check the store is present

**Tests**
* Improves unit testing around enabled/disabled logic
* Add an end-to-end test for stop and starting Terra Draw with a real adapter (Leaflet)



## Link to Issue

Could potentially resolve https://github.com/JamesLMilner/terra-draw/issues/563 if the issue is `clear` is being called after `stop` in some way.

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 