### PR TITLE
feat(terra-draw): get nearby polygons with getFeaturesAtLngLat/getFeaturesAtPointerEvent

### DIFF
--- a/guides/6.EVENTS.md
+++ b/guides/6.EVENTS.md
@@ -17,8 +17,21 @@ document.addEventListener("mousemove", (event) => {
     // The number pixels to search around input point
     pointerDistance: 40,
 
+    // By default polygons are only considered at the location if they are directly selected
+    // this option allows them to be returned if they are within the pointer distance 
+    includePolygonsWithinPointerDistance: true,
+
     // Ignore features that have been selected
     ignoreSelectFeatures: true,
+
+    // ignore coordinates
+    ignoreCoordinatePoints: true,
+
+    // Ignore the current feature if one is being drawn
+    ignoreCurrentlyDrawing: true,
+
+    // Ignore closing points 
+    ignoreClosingPoints: true 
   });
 
   // Do something with the features...


### PR DESCRIPTION
## Description of Changes

This PR allows for returning polygon features that are within the pointer distance if `includePolygonsWithinPointerDistance` is set true. Also provides some additional options for filtering out other guidance features that developers might find helpful.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 