### PR TITLE
fix(terra-draw): avoid allowing editing currently drawn polygon in polygon mode

### DIFF
--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -484,7 +484,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 	private onRightClick(event: TerraDrawMouseEvent) {
 		// Right click is only relevant when editable is true
-		if (!this.editable) {
+		if (!this.editable || this.state !== "started") {
 			return;
 		}
 


### PR DESCRIPTION
## Description of Changes

Aims to prevent allowing editing of currently drawn polygon when `editable` is true. This prevents the potential to get into a corrupt state.

## Link to Issue

 https://github.com/JamesLMilner/terra-draw/issues/579

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 