### PR TITLE
fix(terra-draw): ensure includePolygonsWithinPointerDistance works correctly

### DIFF
--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -453,24 +453,26 @@ class TerraDraw {
 					return true;
 				}
 
-				const rings: Position[][] = feature.geometry.coordinates;
+				if (options?.includePolygonsWithinPointerDistance) {
+					const rings: Position[][] = feature.geometry.coordinates;
 
-				for (const ring of rings) {
-					for (let i = 0; i < ring.length - 1; i++) {
-						const coord = ring[i];
-						const nextCoord = ring[i + 1];
+					for (const ring of rings) {
+						for (let i = 0; i < ring.length - 1; i++) {
+							const coord = ring[i];
+							const nextCoord = ring[i + 1];
 
-						const projectedStart = project(coord[0], coord[1]);
-						const projectedEnd = project(nextCoord[0], nextCoord[1]);
+							const projectedStart = project(coord[0], coord[1]);
+							const projectedEnd = project(nextCoord[0], nextCoord[1]);
 
-						const distanceToEdge = pixelDistanceToLine(
-							inputPoint,
-							projectedStart,
-							projectedEnd,
-						);
+							const distanceToEdge = pixelDistanceToLine(
+								inputPoint,
+								projectedStart,
+								projectedEnd,
+							);
 
-						if (distanceToEdge < pointerDistance) {
-							return true;
+							if (distanceToEdge < pointerDistance) {
+								return true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Description of Changes

A comment was raised on a previous PR about how this wasn't actually included in the code and only in the options argument. This is true and so with this PR we ensure that `includePolygonsWithinPointerDistance` actually controls the ability to include polygons within the pointer distance.

Original comment:
https://github.com/JamesLMilner/terra-draw/pull/576#issuecomment-3018577971

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 