### PR TITLE
fix(terra-draw): ensure snapping respects the configured coordinate precision

### DIFF
--- a/packages/terra-draw/src/modes/line-snapping.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/line-snapping.behavior.spec.ts
@@ -5,6 +5,7 @@ import { BehaviorConfig } from "./base.behavior";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
 import { LineSnappingBehavior } from "./line-snapping.behavior";
+import { coordinatePrecisionIsValid } from "../geometry/boolean/is-valid-coordinate";
 
 describe("LineSnappingBehavior", () => {
 	describe("constructor", () => {
@@ -68,8 +69,128 @@ describe("LineSnappingBehavior", () => {
 						);
 
 						expect(snappedCoord && snappedCoord[0]).toBeCloseTo(0);
-						expect(snappedCoord && snappedCoord[1]).toBeCloseTo(
-							0.5000190382262164,
+						expect(snappedCoord && snappedCoord[1]).toBeCloseTo(0.5);
+
+						expect(
+							coordinatePrecisionIsValid(
+								snappedCoord!,
+								config.coordinatePrecision,
+							),
+						).toBe(true);
+					});
+
+					it("returns a snappable coordinate if one exists, respecting the coordinate precision", () => {
+						config = MockBehaviorConfig("test", projection, 100);
+						lineSnappingBehavior = new LineSnappingBehavior(
+							config,
+							new PixelDistanceBehavior(config),
+							new ClickBoundingBoxBehavior(config),
+						);
+
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snapped = lineSnappingBehavior.getSnappableCoordinate(
+							MockCursorEvent({ lng: -0.5, lat: 0.5 }),
+							"currentId",
+						);
+
+						expect(snapped && snapped[0]).toBeCloseTo(0);
+						expect(snapped && snapped[1]).toBeCloseTo(
+							projection === "web-mercator"
+								? 0.4999999999999944
+								: 0.5000190382262164,
+							20,
+						);
+
+						expect(coordinatePrecisionIsValid(snapped!, 100)).toBe(true);
+					});
+				});
+
+				describe("getSnappable", () => {
+					it("returns undefined if not snappable", () => {
+						const snapped = lineSnappingBehavior.getSnappable(
+							MockCursorEvent({ lng: 0, lat: 0 }),
+						);
+
+						expect(snapped).toEqual({
+							coordinate: undefined,
+							featureCoordinateIndex: undefined,
+							featureId: undefined,
+							minDistance: Infinity,
+						});
+					});
+
+					it("returns a snappable coordinate if one exists", () => {
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snapped = lineSnappingBehavior.getSnappable(
+							MockCursorEvent({ lng: 0, lat: 0 }),
+						);
+
+						expect(snapped).toEqual({
+							coordinate: [0, 0],
+							featureCoordinateIndex: 0,
+							featureId: expect.any(String),
+							minDistance: 0,
+						});
+					});
+
+					it("returns a snappable coordinate if one exists", () => {
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snapped = lineSnappingBehavior.getSnappable(
+							MockCursorEvent({ lng: -0.5, lat: 0.5 }),
+						);
+
+						expect(snapped?.coordinate && snapped?.coordinate[0]).toBeCloseTo(
+							0,
+						);
+						expect(snapped?.coordinate && snapped?.coordinate[1]).toBeCloseTo(
+							0.5,
+						);
+
+						expect(
+							coordinatePrecisionIsValid(
+								snapped!.coordinate!,
+								config.coordinatePrecision,
+							),
+						).toBe(true);
+					});
+
+					it("returns a snappable coordinate if one exists, respecting the coordinate precision", () => {
+						config = MockBehaviorConfig("test", projection, 100);
+						lineSnappingBehavior = new LineSnappingBehavior(
+							config,
+							new PixelDistanceBehavior(config),
+							new ClickBoundingBoxBehavior(config),
+						);
+
+						// Ensure there is something to snap too by
+						// creating an existing polygon
+						createStorePolygon(config);
+
+						const snapped = lineSnappingBehavior.getSnappable(
+							MockCursorEvent({ lng: -0.5, lat: 0.5 }),
+						);
+
+						expect(snapped?.coordinate && snapped?.coordinate[0]).toBeCloseTo(
+							0,
+						);
+						expect(snapped?.coordinate && snapped?.coordinate[1]).toBeCloseTo(
+							projection === "web-mercator"
+								? 0.4999999999999944
+								: 0.5000190382262164,
+							20,
+						);
+
+						expect(coordinatePrecisionIsValid(snapped.coordinate!, 100)).toBe(
+							true,
 						);
 					});
 				});

--- a/packages/terra-draw/src/modes/line-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/line-snapping.behavior.ts
@@ -6,6 +6,7 @@ import { BBoxPolygon, FeatureId } from "../store/store";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
 import { nearestPointOnLine } from "../geometry/point-on-line";
 import { webMercatorNearestPointOnLine } from "../geometry/web-mercator-point-on-line";
+import { limitPrecision } from "../geometry/limit-decimal-precision";
 
 export class LineSnappingBehavior extends TerraDrawModeBehavior {
 	constructor(
@@ -24,7 +25,18 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 			);
 		});
 
-		return snappable.coordinate;
+		return snappable.coordinate
+			? [
+					limitPrecision(
+						snappable.coordinate[0],
+						this.config.coordinatePrecision,
+					),
+					limitPrecision(
+						snappable.coordinate[1],
+						this.config.coordinatePrecision,
+					),
+				]
+			: undefined;
 	};
 
 	public getSnappableCoordinate = (
@@ -39,7 +51,18 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 			);
 		});
 
-		return snappable.coordinate;
+		return snappable.coordinate
+			? [
+					limitPrecision(
+						snappable.coordinate[0],
+						this.config.coordinatePrecision,
+					),
+					limitPrecision(
+						snappable.coordinate[1],
+						this.config.coordinatePrecision,
+					),
+				]
+			: undefined;
 	};
 
 	public getSnappable(
@@ -98,7 +121,16 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 			const distance = this.pixelDistance.measure(event, nearest.coordinate);
 			if (distance < closest.minDistance && distance < this.pointerDistance) {
 				closest.featureId = feature.id;
-				closest.coordinate = nearest.coordinate;
+				closest.coordinate = [
+					limitPrecision(
+						nearest.coordinate[0],
+						this.config.coordinatePrecision,
+					),
+					limitPrecision(
+						nearest.coordinate[1],
+						this.config.coordinatePrecision,
+					),
+				];
 				closest.featureCoordinateIndex = nearest.lineIndex;
 				closest.minDistance = distance;
 			}

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -442,9 +442,7 @@ describe("TerraDrawLineStringMode", () => {
 
 			expect(features[1].geometry.type).toBe("Point");
 			expect(features[1].properties.snappingPoint).toBe(true);
-			expect(features[1].geometry.coordinates).toStrictEqual([
-				2, 2.0000000000000027,
-			]);
+			expect(features[1].geometry.coordinates).toStrictEqual([2, 2]);
 		});
 
 		it("can snap from existing line once finished with snapping toCustom enabled", () => {

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -384,11 +384,11 @@ describe("DragCoordinateBehavior", () => {
 						geometry: {
 							coordinates: [
 								[
-									[1, 1.0000000000000013],
+									[1, 1],
 									[0, 1],
 									[1, 1],
 									[1, 0],
-									[1, 1.0000000000000013],
+									[1, 1],
 								],
 							],
 							type: "Polygon",

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -2101,7 +2101,7 @@ describe("TerraDrawSelectMode", () => {
 								[
 									[0, 0],
 									[0, 1],
-									[2, 2.0000000000000027],
+									[2, 2],
 									[1, 0],
 									[0, 0],
 								],
@@ -2112,7 +2112,7 @@ describe("TerraDrawSelectMode", () => {
 					},
 					{
 						geometry: {
-							coordinates: [2, 2.0000000000000027],
+							coordinates: [2, 2],
 							type: "Point",
 						},
 						id: expect.any(String),
@@ -2211,7 +2211,7 @@ describe("TerraDrawSelectMode", () => {
 							coordinates: [
 								[0, 0],
 								[0, 1],
-								[2, 2.0000000000000027],
+								[2, 2],
 								[1, 0],
 							],
 							type: "LineString",
@@ -2220,7 +2220,7 @@ describe("TerraDrawSelectMode", () => {
 					},
 					{
 						geometry: {
-							coordinates: [2, 2.0000000000000027],
+							coordinates: [2, 2],
 							type: "Point",
 						},
 						id: expect.any(String),

--- a/packages/terra-draw/src/test/mock-behavior-config.ts
+++ b/packages/terra-draw/src/test/mock-behavior-config.ts
@@ -4,6 +4,7 @@ import { GeoJSONStore } from "../store/store";
 export const MockBehaviorConfig = (
 	mode: string,
 	projection?: "web-mercator" | "globe",
+	coordinatePrecision: number = 9,
 ) =>
 	({
 		store: new GeoJSONStore(),
@@ -11,6 +12,6 @@ export const MockBehaviorConfig = (
 		project: jest.fn((lng, lat) => ({ x: lng * 40, y: lat * 40 })),
 		unproject: jest.fn((x, y) => ({ lng: x / 40, lat: y / 40 })),
 		pointerDistance: 40,
-		coordinatePrecision: 9,
+		coordinatePrecision,
 		projection: projection ? projection : "web-mercator",
 	}) as BehaviorConfig;


### PR DESCRIPTION
## Description of Changes

We were not limiting precision coming back from the LineSnapping and CoordinateSnapping behaviors. This caused precision errors and required fixing

## Link to Issue

 https://github.com/JamesLMilner/terra-draw/issues/585#issuecomment-3025150862

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 