### PR TITLE
fix(terra-draw): export Terra Draw types using type keyword when exporting

### DIFF
--- a/packages/terra-draw/src/extend.ts
+++ b/packages/terra-draw/src/extend.ts
@@ -27,12 +27,12 @@ export {
 	SELECT_PROPERTIES,
 
 	// Types
-	FeatureId,
-	Cursor,
-	BaseModeOptions,
-	CustomStyling,
-	NumericStyling,
-	HexColorStyling,
-	TerraDrawCallbacks,
-	BaseAdapterConfig,
+	type FeatureId,
+	type Cursor,
+	type BaseModeOptions,
+	type CustomStyling,
+	type NumericStyling,
+	type HexColorStyling,
+	type TerraDrawCallbacks,
+	type BaseAdapterConfig,
 };

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -1028,9 +1028,9 @@ class TerraDraw {
 
 export {
 	TerraDraw,
-	IdStrategy,
-	TerraDrawEvents,
-	TerraDrawEventListeners,
+	type IdStrategy,
+	type TerraDrawEvents,
+	type TerraDrawEventListeners,
 
 	// Modes
 	TerraDrawSelectMode,
@@ -1050,21 +1050,21 @@ export {
 	TerraDrawExtend,
 
 	// TerraDrawBaseMode
-	BehaviorConfig,
-	GeoJSONStoreFeatures,
-	GeoJSONStoreGeometries,
-	HexColor,
-	TerraDrawMouseEvent,
-	TerraDrawAdapterStyling,
-	TerraDrawKeyboardEvent,
+	type BehaviorConfig,
+	type GeoJSONStoreFeatures,
+	type GeoJSONStoreGeometries,
+	type HexColor,
+	type TerraDrawMouseEvent,
+	type TerraDrawAdapterStyling,
+	type TerraDrawKeyboardEvent,
 
 	// TerraDrawBaseAdapter
-	TerraDrawChanges,
-	TerraDrawStylingFunction,
-	Project,
-	Unproject,
-	SetCursor,
-	GetLngLatFromEvent,
+	type TerraDrawChanges,
+	type TerraDrawStylingFunction,
+	type Project,
+	type Unproject,
+	type SetCursor,
+	type GetLngLatFromEvent,
 
 	// Validations
 	ValidateMinAreaSquareMeters,


### PR DESCRIPTION
## Description of Changes

Ensures types are exported with the type keyword

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 