### PR TITLE
fix(terra-draw): ensure polygon coordinate points respect right hand rule

### DIFF
--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -216,10 +216,16 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			const correctedGeometry = ensureRightHandRule(
 				this.store.getGeometryCopy<Polygon>(this.currentId),
 			);
+
 			if (correctedGeometry) {
 				this.store.updateGeometry([
 					{ id: this.currentId, geometry: correctedGeometry },
 				]);
+
+				// Create or update coordinate points to reflect the new geometry
+				if (this.showCoordinatePoints) {
+					this.coordinatePoints.createOrUpdate(this.currentId);
+				}
 			}
 
 			this.store.updateProperty([


### PR DESCRIPTION
## Description of Changes

Coordinate points were not being updated to reflect re-ordering when a polygon was re-created to follow the right hand rule. This PR ensures that the coordinate points get updated to reflect the new order of the polygons coordinates.


## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/609

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 