### PR TITLE
docs(terra-draw): add Storybook examples for zIndexing

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -104,6 +104,30 @@ const PolygonWithLineSnapping: Story = {
 	...DefaultPlay,
 };
 
+// Z Index ordering story
+const ZIndexOrdering: Story = {
+	...DefaultStory,
+	args: {
+		id: "polygon-z-index",
+		modes: [
+			() =>
+				new TerraDrawPolygonMode({
+					showCoordinatePoints: true,
+					editable: true,
+					styles: {
+						coordinatePointColor: "#ff0000",
+						closingPointColor: "#00ff00",
+					},
+				}),
+			() => new TerraDrawLineStringMode(),
+			() => new TerraDrawPointMode(),
+		],
+		...DefaultStory.args,
+		instructions:
+			"Different mode features have different z-indexes, you can experiment by drawing different features on top of each other.",
+	},
+};
+
 // Polygon with editable enabled story
 const PolygonWithEditableEnabled: Story = {
 	args: {
@@ -484,6 +508,7 @@ const AllStories = {
 	PolygonWithCoordinateSnapping,
 	PolygonWithLineSnapping,
 	PolygonWithEditableEnabled,
+	ZIndexOrdering,
 	Circle,
 	Rectangle,
 	AngledRectangle,

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -20,6 +20,7 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -206,6 +206,11 @@ export const COMMON_PROPERTIES = {
 	COORDINATE_POINT_IDS: "coordinatePointIds",
 } as const;
 
+/**
+ * Lower z-index represents layers that are lower in the stack
+ * and higher z-index represents layers that are higher in the stack
+ * i.e. a layer with z-index 10 will be rendered below a layer with z-index 20
+ */
 export const Z_INDEX = {
 	LAYER_ONE: 10,
 	LAYER_TWO: 20,


### PR DESCRIPTION
## Description of Changes

This PR adds a zIndexing example to Storybook so developers can see the default zIndexing ordering present within Terra Draw.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 