### PR TITLE
fix(terra-draw-mapbox-gl-adapter): ensure zIndex is set for all geometry types

### DIFF
--- a/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.ts
+++ b/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.ts
@@ -333,12 +333,18 @@ export class TerraDrawMapboxGLAdapter extends TerraDrawExtend.TerraDrawBaseAdapt
 				const mode = properties.mode as string;
 				const styles = styling[mode](feature);
 
+				// Set the zIndex property for the feature regardless of geometry type
+				// NOTE: Render ordering is predominately controlled by the layer order.
+				// In this instance we are only controlling the zIndex order in relation to the layer itself. Since we have a
+				// layer for each geometry type, the zIndex is only used to control the order of features within that layer.
+				// Long term we need to consider how to handle zIndex ordering across multiple geometry types.
+				properties.zIndex = styles.zIndex;
+
 				if (feature.geometry.type === "Point") {
 					properties.pointColor = styles.pointColor;
 					properties.pointOutlineColor = styles.pointOutlineColor;
 					properties.pointOutlineWidth = styles.pointOutlineWidth;
 					properties.pointWidth = styles.pointWidth;
-					properties.zIndex = styles.zIndex;
 					points.push(feature);
 				} else if (feature.geometry.type === "LineString") {
 					properties.lineStringColor = styles.lineStringColor;


### PR DESCRIPTION
## Description of Changes

zIndex was not being set for LineStrings or Polygons, which causes a warning when it tries to get the zIndex property on these layers. I think this may have been deliberate because internally in the built-in modes we do not differentiate between linestrings and polygon zIndexes. This PR ensures that it is always set. 

Note, a code comment has been added about the complexity that render order is predominately controlled by layer ordering, then within the same layer by the `sort-key`. 

## Link to Issue

#607 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 