### PR TITLE
fix(terra-draw-maplibre-gl-adapter): ensure zIndex is set for all geometry type

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -340,6 +340,7 @@ export class TerraDrawMapLibreGLAdapter<
 				const { properties } = feature;
 				const mode = properties.mode as string;
 				const styles = styling[mode](feature);
+				properties.zIndex = styles.zIndex;
 
 				// Set the zIndex property for the feature regardless of geometry type
 				// NOTE: Render ordering is predominately controlled by the layer order.


### PR DESCRIPTION
## Description of Changes

zIndex was not being set for LineStrings or Polygons, which causes a warning when it tries to get the zIndex property on these layers. I think this may have been deliberate because internally in the built-in modes we do not differentiate between linestrings and polygon zIndexes. This PR ensures that it is always set. 

Note, a code comment has been added about the complexity that render order is predominately controlled by layer ordering, then within the same layer by the `sort-key`. 

## Link to Issue

#607 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 