### PR TITLE
feat(terra-draw): provide properties in polygon mode for determining current coordinate count

### DIFF
--- a/packages/storybook/src/common/setup.ts
+++ b/packages/storybook/src/common/setup.ts
@@ -45,6 +45,7 @@ export function setupMapContainer(args: StoryArgs) {
 
 	if (args.instructions) {
 		const instructions = document.createElement("h3");
+		instructions.id = `instructions`;
 		instructions.style.margin = "0";
 		instructions.style.width = `${args.width}`;
 		instructions.textContent = args.instructions;

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -49,6 +49,45 @@ const Polygon: Story = {
 	},
 };
 
+// Polygon coordinate count story
+const PolygonWithCoordinateCounts: Story = {
+	...DefaultStory,
+	args: {
+		id: "polygon",
+		modes: [() => new TerraDrawPolygonMode()],
+		instructions:
+			"Click to add points, the provisional and committed coordinate counts will appear here",
+		afterRender: (draw: TerraDraw) => {
+			draw.on("change", (ids) => {
+				const feature = draw.getSnapshotFeature(ids[0]);
+				if (feature) {
+					const provisionalCount =
+						feature.properties["provisionalCoordinateCount"];
+					const committedCount = feature.properties["committedCoordinateCount"];
+					if (provisionalCount === undefined || committedCount === undefined) {
+						return;
+					}
+
+					const instructions = document.getElementById("instructions");
+					if (!instructions) {
+						return;
+					}
+					instructions.textContent = `Provisional Coordinates: ${provisionalCount}, Committed Coordinates: ${committedCount}`;
+				}
+			});
+
+			draw.on("finish", (_ids) => {
+				const instructions = document.getElementById("instructions");
+				if (!instructions) {
+					return;
+				}
+				instructions.textContent = `Finished drawing polygon`;
+			});
+		},
+		...DefaultStory.args,
+	},
+};
+
 // Polygon with coordinate points story
 const PolygonWithCoordinatePoints: Story = {
 	args: {
@@ -508,6 +547,7 @@ const AllStories = {
 	PolygonWithCoordinateSnapping,
 	PolygonWithLineSnapping,
 	PolygonWithEditableEnabled,
+	PolygonWithCoordinateCounts,
 	ZIndexOrdering,
 	Circle,
 	Rectangle,

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -20,6 +20,8 @@ export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
+export const PolygonWithCoordinateCounts =
+	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -204,6 +204,8 @@ export const COMMON_PROPERTIES = {
 	COORDINATE_POINT: "coordinatePoint",
 	COORDINATE_POINT_FEATURE_ID: "coordinatePointFeatureId",
 	COORDINATE_POINT_IDS: "coordinatePointIds",
+	PROVISIONAL_COORDINATE_COUNT: "provisionalCoordinateCount",
+	COMMITTED_COORDINATE_COUNT: "committedCoordinateCount",
 } as const;
 
 /**

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -234,6 +234,16 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					property: COMMON_PROPERTIES.CURRENTLY_DRAWING,
 					value: undefined,
 				},
+				{
+					id: this.currentId,
+					property: COMMON_PROPERTIES.COMMITTED_COORDINATE_COUNT,
+					value: undefined,
+				},
+				{
+					id: this.currentId,
+					property: COMMON_PROPERTIES.PROVISIONAL_COORDINATE_COUNT,
+					value: undefined,
+				},
 			]);
 		}
 
@@ -387,6 +397,14 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				];
 			}
 		}
+
+		this.store.updateProperty([
+			{
+				id: this.currentId,
+				property: COMMON_PROPERTIES.PROVISIONAL_COORDINATE_COUNT,
+				value: this.currentCoordinate + 1,
+			},
+		]);
 
 		this.updatePolygonGeometry(updatedCoordinates, UpdateTypes.Provisional);
 	}
@@ -611,6 +629,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					properties: {
 						mode: this.mode,
 						[COMMON_PROPERTIES.CURRENTLY_DRAWING]: true,
+						[COMMON_PROPERTIES.COMMITTED_COORDINATE_COUNT]:
+							this.currentCoordinate + 1,
+						[COMMON_PROPERTIES.PROVISIONAL_COORDINATE_COUNT]:
+							this.currentCoordinate + 1,
 					},
 				},
 			]);
@@ -659,6 +681,14 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				return;
 			}
 
+			this.store.updateProperty([
+				{
+					id: this.currentId,
+					property: COMMON_PROPERTIES.COMMITTED_COORDINATE_COUNT,
+					value: this.currentCoordinate + 1,
+				},
+			]);
+
 			this.currentCoordinate++;
 		} else if (this.currentCoordinate === 2 && this.currentId) {
 			const snappedCoordinate = this.snapCoordinate(event);
@@ -700,6 +730,14 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			if (this.currentCoordinate === 2) {
 				this.closingPoints.create(currentPolygonCoordinates, "polygon");
 			}
+
+			this.store.updateProperty([
+				{
+					id: this.currentId,
+					property: COMMON_PROPERTIES.COMMITTED_COORDINATE_COUNT,
+					value: this.currentCoordinate + 1,
+				},
+			]);
 
 			this.currentCoordinate++;
 		} else if (this.currentId) {
@@ -747,6 +785,14 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				if (!updated) {
 					return;
 				}
+
+				this.store.updateProperty([
+					{
+						id: this.currentId,
+						property: COMMON_PROPERTIES.COMMITTED_COORDINATE_COUNT,
+						value: this.currentCoordinate + 1,
+					},
+				]);
 				this.currentCoordinate++;
 
 				// Update closing points straight away


### PR DESCRIPTION
## Description of Changes

Add a way to determine current drawn coordinate in polygon mode. At the moment this is difficult because of work arounds we do to ensure a polygon can be rendered in all adapters - many adapters struggle to render a polygon with at least 3 coordinates (4 with closing coordinate). This PR provides `provisionalCoordinateCount` and `committedCoordinateCount` properties as a way of understanding the true coordinate count. `committedCoordinateCount` is the count of all fully committed coordinates, excluding the duplicate closing coordinate. `provisionalCoordinateCount` is the count including the coordinate that is created on cursor move but that is not committed until cursor down.

## Link to Issue

#604

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 