### PR TITLE
feat(terra-draw): allow setting of custom properties with updateFeatureProperties

### DIFF
--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -207,8 +207,7 @@ draw.updateFeatureGeometry(result.id as FeatureId, {
 
 This can be useful if you want to control a specific geometry via some sort of UI element, like a button or an input for example. In the internals of Terra Draw `updateFeatureGeometry` calls a modes `afterFeatureUpdated` method which handles any tidy up necessary, for example updating guidance features like selection points or midpoints when a feature is selected in TerraDrawSelectMode. As a general rule, if you update a feature using `updateFeatureGeometry` which was currently being drawn, the drawing state will end and the new geometry will have been committed to the store.
 
-Similarly `transformFeatureGeometry` can be used to rotate or scale a geometry using the same internal approach as Select modes keyboard rotation and scale operations:
-
+In conjunction `transformFeatureGeometry` can be used to rotate or scale a geometry using the same internal approach as Select modes keyboard rotation and scale operations:
 
 ```javascript
 // add a feature to the Terra Draw instance
@@ -235,7 +234,7 @@ const [result] = draw.addFeatures([
 ]);
 
 // Later on  we can update its geometry programmatically
-  draw.transformFeatureGeometry(id!, {
+  draw.transformFeatureGeometry(result.id as FeatureId, {
     projection: "web-mercator",
     origin: [-74.006, 40.7128],
     type: "scale",
@@ -245,6 +244,43 @@ const [result] = draw.addFeatures([
     },
   });
 ```
+
+Lastly `updateFeatureProperty` can be used to set properties as needed to custom values:
+
+```javascript
+  // add a feature to the Terra Draw instance
+  const [result] = draw.addFeatures([
+    {
+      id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+                [-74.006, 40.7128],
+                [-73.996, 40.7128],
+                [-73.996, 40.7228],
+                [-74.036, 40.7228],
+                [-74.006, 40.7128],
+          ],
+        ]
+      },
+      properties: {
+        mode: "polygon",
+      },
+    },
+  ]);
+
+  draw.updateFeatureProperty(result.id as FeatureId, 'customProperty', 'customValue');
+
+  const feature = draw.getSnapshotFeature(result.id as FeatureId);
+
+  console.log(feature.customProperty === 'customValue'); // true
+```
+
+> [!NOTE]
+> Because Terra Draw uses GeoJSON as the internal representation format and many people store GeoJSON as the export format, Terra Draw ensures set values are valid JSON. The exception here is using `undefined` which deletes the property from the internal feature properties object.
+
 
 See the `TerraDraw` [API Docs](https://jameslmilner.github.io/terra-draw/classes/TerraDraw.html) for more information.
 

--- a/guides/2.STORE.md
+++ b/guides/2.STORE.md
@@ -245,7 +245,9 @@ const [result] = draw.addFeatures([
   });
 ```
 
-Lastly `updateFeatureProperty` can be used to set properties as needed to custom values:
+Lastly `updateFeatureProperties` can be used to set properties as needed to custom values. It is important to point out here the method only updates the properties passed. You cannot do partial updates of nested properties, so must update them completely with the full desired state. 
+
+You can use the function like so:
 
 ```javascript
   // add a feature to the Terra Draw instance
@@ -271,7 +273,7 @@ Lastly `updateFeatureProperty` can be used to set properties as needed to custom
     },
   ]);
 
-  draw.updateFeatureProperty(result.id as FeatureId, 'customProperty', 'customValue');
+  draw.updateFeatureProperties(result.id as FeatureId, { customProperty: 'customValue' });
 
   const feature = draw.getSnapshotFeature(result.id as FeatureId);
 

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -11,6 +11,8 @@ import {
 	TerraDrawSensorMode,
 	TerraDraw,
 	TerraDrawSelectMode,
+	GeoJSONStoreFeatures,
+	HexColor,
 } from "../../../terra-draw/src/terra-draw";
 import {
 	DefaultSize,
@@ -20,7 +22,7 @@ import {
 	DefaultPlay,
 } from "./config";
 
-const DefaultStory = {
+export const DefaultStory = {
 	args: {
 		...DefaultSize,
 		...LocationNewYork,
@@ -141,6 +143,40 @@ const PolygonWithLineSnapping: Story = {
 		],
 	},
 	...DefaultPlay,
+};
+
+// Polygon styling story - changes fill color based on a property on the feature
+const Styling: Story = {
+	...DefaultStory,
+	args: {
+		id: "polygon-styling",
+		modes: [
+			() =>
+				new TerraDrawPolygonMode({
+					styles: {
+						fillColor: (feature: GeoJSONStoreFeatures) =>
+							(feature.properties.randomColor as HexColor) ||
+							("#ff0000" as HexColor),
+					},
+				}),
+		],
+		...DefaultStory.args,
+		afterRender: (draw: TerraDraw) => {
+			setInterval(() => {
+				const features = draw.getSnapshot();
+				if (features.length === 0) return;
+				features.forEach((feature) => {
+					draw.updateFeatureProperty(
+						feature.id!,
+						"randomColor",
+						`#${Math.floor(Math.random() * 16777215).toString(16)}`,
+					);
+				});
+			}, 2000);
+		},
+		instructions:
+			"Random colors will be applied to each polygon every two seconds based on the 'randomColor' property on the feature.",
+	},
 };
 
 // Z Index ordering story
@@ -548,6 +584,7 @@ const AllStories = {
 	PolygonWithLineSnapping,
 	PolygonWithEditableEnabled,
 	PolygonWithCoordinateCounts,
+	Styling,
 	ZIndexOrdering,
 	Circle,
 	Rectangle,

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -166,11 +166,9 @@ const Styling: Story = {
 				const features = draw.getSnapshot();
 				if (features.length === 0) return;
 				features.forEach((feature) => {
-					draw.updateFeatureProperty(
-						feature.id!,
-						"randomColor",
-						`#${Math.floor(Math.random() * 16777215).toString(16)}`,
-					);
+					draw.updateFeatureProperties(feature.id!, {
+						randomColor: `#${Math.floor(Math.random() * 16777215).toString(16)}`,
+					});
 				});
 			}, 2000);
 		},

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -23,6 +23,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -23,6 +23,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -23,6 +23,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -23,6 +23,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -1,6 +1,14 @@
 import { AllStories } from "../../common/stories";
 import { DefaultMeta } from "../../common/meta";
 import { SetupMapLibre } from "./setup";
+import { TerraDrawPolygonMode } from "../../../../terra-draw/src/terra-draw";
+import {
+	Story,
+	DefaultSize,
+	LocationNewYork,
+	DefaultZoom,
+	DefaultPlay,
+} from "../../common/config";
 
 const meta = {
 	...DefaultMeta,
@@ -10,6 +18,18 @@ const meta = {
 };
 
 export default meta;
+
+// Polygon with coordinate points story
+export const PolygonWithChangeLayer: Story = {
+	args: {
+		id: "polygon-layer-change",
+		...DefaultSize,
+		...LocationNewYork,
+		...DefaultZoom,
+		modes: [() => new TerraDrawPolygonMode()],
+	},
+	...DefaultPlay,
+};
 
 // Ensure the names are set correctly for the stories
 export const Point = AllStories.Point;
@@ -23,6 +43,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -23,6 +23,7 @@ export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;
 export const ZIndexOrdering = AllStories.ZIndexOrdering;
+export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
 export const AngledRectangle = AllStories.AngledRectangle;

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -197,6 +197,7 @@ export const SELECT_PROPERTIES = {
 } as const;
 
 export const COMMON_PROPERTIES = {
+	MODE: "mode",
 	CURRENTLY_DRAWING: "currentlyDrawing",
 	EDITED: "edited",
 	CLOSING_POINT: "closingPoint",

--- a/packages/terra-draw/src/store/store.ts
+++ b/packages/terra-draw/src/store/store.ts
@@ -4,7 +4,7 @@ import { SpatialIndex } from "./spatial-index/spatial-index";
 import { isValidTimestamp } from "./store-feature-validation";
 import { Validation } from "../common";
 
-type JSON = string | number | boolean | null | JSONArray | JSONObject;
+export type JSON = string | number | boolean | null | JSONArray | JSONObject;
 
 export interface JSONObject {
 	[member: string]: JSON;

--- a/packages/terra-draw/src/store/valid-json.spec.ts
+++ b/packages/terra-draw/src/store/valid-json.spec.ts
@@ -1,0 +1,150 @@
+import { isValidJSONValue } from "./valid-json";
+
+describe("isValidJSONValue", () => {
+	describe("primitives", () => {
+		it("null", () => {
+			expect(isValidJSONValue(null)).toBe(true);
+		});
+
+		it("booleans", () => {
+			expect(isValidJSONValue(true)).toBe(true);
+			expect(isValidJSONValue(false)).toBe(true);
+		});
+
+		it("strings", () => {
+			expect(isValidJSONValue("")).toBe(true);
+			expect(isValidJSONValue("hello")).toBe(true);
+			expect(isValidJSONValue("💡")).toBe(true);
+		});
+
+		it("numbers: finite only", () => {
+			expect(isValidJSONValue(0)).toBe(true);
+			expect(isValidJSONValue(42)).toBe(true);
+			expect(isValidJSONValue(-0)).toBe(true); // valid JSON number
+			expect(isValidJSONValue(1.234)).toBe(true);
+
+			expect(isValidJSONValue(Number.NaN)).toBe(false);
+			expect(isValidJSONValue(Number.POSITIVE_INFINITY)).toBe(false);
+			expect(isValidJSONValue(Number.NEGATIVE_INFINITY)).toBe(false);
+		});
+
+		it("invalid primitive-like values", () => {
+			expect(isValidJSONValue(undefined)).toBe(false);
+			expect(isValidJSONValue(Symbol("x"))).toBe(false);
+			expect(isValidJSONValue(BigInt(1))).toBe(false);
+			expect(isValidJSONValue(function () {})).toBe(false);
+			expect(isValidJSONValue(() => {})).toBe(false);
+		});
+	});
+
+	describe("arrays", () => {
+		it("simple arrays", () => {
+			expect(isValidJSONValue([])).toBe(true);
+			expect(isValidJSONValue([1, "a", true, null])).toBe(true);
+		});
+
+		it("nested arrays/objects", () => {
+			const v = [1, { a: [null, { b: "x" }] }, false];
+			expect(isValidJSONValue(v)).toBe(true);
+		});
+
+		it("arrays with undefined/holes are invalid", () => {
+			expect(isValidJSONValue([undefined])).toBe(false);
+			// An array hole is effectively `undefined`
+			const arrWithHole = [];
+			arrWithHole.length = 2;
+			arrWithHole[1] = 1; // arr is now [ <1 empty item>, 1 ]
+			expect(isValidJSONValue(arrWithHole)).toBe(false);
+		});
+
+		it("arrays containing invalid values", () => {
+			expect(isValidJSONValue([1, NaN])).toBe(false);
+			expect(isValidJSONValue([1, Infinity])).toBe(false);
+			expect(isValidJSONValue([1, () => {}])).toBe(false);
+			expect(isValidJSONValue([1, Symbol()])).toBe(false);
+			expect(isValidJSONValue([1, BigInt(2)])).toBe(false);
+		});
+	});
+
+	describe("objects", () => {
+		it("empty object", () => {
+			expect(isValidJSONValue({})).toBe(true);
+		});
+
+		it("simple object with valid values", () => {
+			expect(
+				isValidJSONValue({
+					a: 1,
+					b: "x",
+					c: true,
+					d: null,
+					e: [1, 2, 3],
+					f: { nested: "ok" },
+				}),
+			).toBe(true);
+		});
+
+		it("object with undefined value is invalid", () => {
+			expect(isValidJSONValue({ a: undefined })).toBe(false);
+		});
+
+		it("object with invalid value types is invalid", () => {
+			expect(isValidJSONValue({ a: NaN })).toBe(false);
+			expect(isValidJSONValue({ a: Infinity })).toBe(false);
+			expect(isValidJSONValue({ a: () => {} })).toBe(false);
+			expect(isValidJSONValue({ a: Symbol("s") })).toBe(false);
+			expect(isValidJSONValue({ a: BigInt(10) })).toBe(false);
+		});
+
+		it("Object.create(null) is allowed (JSON object with no prototype)", () => {
+			const o = Object.create(null);
+			o.a = 1;
+			o.b = "two";
+			expect(isValidJSONValue(o)).toBe(true);
+		});
+
+		it("symbol-keyed properties are ignored by JSON and should not invalidate", () => {
+			const s = Symbol("hidden");
+			const o: { visible: number; [key: symbol]: unknown } = { visible: 1 };
+			o[s] = () => {}; // non-JSON under a symbol key; JSON.stringify would ignore it
+			expect(isValidJSONValue(o)).toBe(true);
+		});
+
+		it("Date objects should be considered NOT a JSON value (only plain objects/arrays/primitive JSON types are allowed)", () => {
+			const d = new Date();
+			// Strict JSON value set does NOT include Date instances.
+			// If your implementation currently returns true here, update it to restrict to plain objects:
+			//   const proto = Object.getPrototypeOf(value);
+			//   if (proto !== Object.prototype && proto !== null) return false;
+			expect(isValidJSONValue(d)).toBe(false);
+		});
+
+		it("Map/Set are not JSON values", () => {
+			expect(isValidJSONValue(new Map())).toBe(false);
+			expect(isValidJSONValue(new Set())).toBe(false);
+		});
+
+		it("class instances are not JSON values (unless plain objects)", () => {
+			class X {
+				private a: number;
+				constructor() {
+					this.a = 1;
+				}
+			}
+			expect(isValidJSONValue(new X())).toBe(false);
+		});
+
+		it("typed arrays are not JSON values (they are objects, not arrays)", () => {
+			expect(isValidJSONValue(new Uint8Array([1, 2, 3]))).toBe(false);
+			expect(isValidJSONValue(new Int16Array([1, -2]))).toBe(false);
+		});
+
+		it("deeply nested valid structure", () => {
+			const v = {
+				a: [{ b: [{ c: [null, { d: "ok", e: [1, 2, 3] }] }] }],
+				f: false,
+			};
+			expect(isValidJSONValue(v)).toBe(true);
+		});
+	});
+});

--- a/packages/terra-draw/src/store/valid-json.ts
+++ b/packages/terra-draw/src/store/valid-json.ts
@@ -1,0 +1,100 @@
+/**
+ * Checks if a value is a valid JSON value.
+ * @param value - The value to check
+ * @returns true if the value is valid JSON, false otherwise
+ */
+export function isValidJSONValue(value: unknown): value is JSON {
+	// null is valid JSON
+	if (value === null) {
+		return true;
+	}
+
+	// boolean is valid JSON
+	if (typeof value === "boolean") {
+		return true;
+	}
+
+	// string is valid JSON
+	if (typeof value === "string") {
+		return true;
+	}
+
+	// undefined is not valid JSON
+	if (value === undefined) {
+		return false;
+	}
+
+	// number must be finite to be valid JSON
+	if (typeof value === "number") {
+		return Number.isFinite(value);
+	}
+
+	// BigInt is not a valid JSON type
+	if (typeof value === "bigint") {
+		return false;
+	}
+
+	// Symbols are not valid JSON types
+	if (typeof value === "symbol") {
+		return false;
+	}
+
+	// Functions are not valid JSON types
+	if (typeof value === "function") {
+		return false;
+	}
+
+	// Regular expressions are not valid JSON types
+	if (value instanceof RegExp) {
+		return false;
+	}
+
+	// Maps are not valid JSON types
+	if (value instanceof Map) {
+		return false;
+	}
+
+	// Sets are not valid JSON types
+	if (value instanceof Set) {
+		return false;
+	}
+
+	// Dates are not valid JSON types
+	if (value instanceof Date) {
+		return false;
+	}
+
+	// Class instances are not valid JSON types (only plain objects)
+	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+		const proto = Object.getPrototypeOf(value);
+		if (proto !== Object.prototype && proto !== null) {
+			return false;
+		}
+	}
+
+	// Typed Arrays are not valid JSON types
+	if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+		return false;
+	}
+
+	// Array: all elements must be valid JSON
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			if (!isValidJSONValue(item)) {
+				return false;
+			}
+		}
+	}
+
+	// Object: must be plain object with string keys
+	if (typeof value === "object") {
+		return Object.keys(value).every(
+			(key) =>
+				typeof key === "string" &&
+				isValidJSONValue(value[key as keyof typeof value] as unknown),
+		);
+	}
+
+	// Other types (shouldn't reach here) are not valid JSON
+	return false;
+}

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -41,6 +41,8 @@ import {
 	GeoJSONStoreFeatures,
 	GeoJSONStoreGeometries,
 	IdStrategy,
+	JSON,
+	JSONObject,
 	StoreChangeHandler,
 	StoreValidation,
 } from "./store/store";
@@ -60,19 +62,11 @@ import * as TerraDrawExtend from "./extend";
 import { hasModeProperty } from "./store/store-feature-validation";
 import { ValidationReasons } from "./validation-reasons";
 import { TerraDrawFreehandLineStringMode } from "./modes/freehand-linestring/freehand-linestring.mode";
-import { ScaleFeatureBehavior } from "./modes/select/behaviors/scale-feature.behavior";
-import { DragCoordinateResizeBehavior } from "./modes/select/behaviors/drag-coordinate-resize.behavior";
-import { PixelDistanceBehavior } from "./modes/pixel-distance.behavior";
-import { SelectionPointBehavior } from "./modes/select/behaviors/selection-point.behavior";
-import { MidPointBehavior } from "./modes/select/behaviors/midpoint.behavior";
-import { CoordinatePointBehavior } from "./modes/select/behaviors/coordinate-point.behavior";
-import {
-	lngLatToWebMercatorXY,
-	webMercatorXYToLngLat,
-} from "./geometry/project/web-mercator";
+import { lngLatToWebMercatorXY } from "./geometry/project/web-mercator";
 import { transformRotateWebMercator } from "./geometry/transform/rotate";
 import { transformScaleWebMercatorCoordinates } from "./geometry/transform/scale";
 import { limitPrecision } from "./geometry/limit-decimal-precision";
+import { isValidJSONValue } from "./store/valid-json";
 
 // Helper type to determine the instance type of a class
 type InstanceType<T extends new (...args: any[]) => any> = T extends new (
@@ -755,6 +749,82 @@ class TerraDraw {
 	 */
 	hasFeature(id: FeatureId): boolean {
 		return this._store.has(id);
+	}
+
+	/**
+	 * Checks if a property name is reserved and cannot be used.
+	 * @param propertyName - the property name to check
+	 * @returns
+	 */
+	private checkIsReservedProperty(propertyName: string) {
+		const UNAVAILABLE_PROPERTIES = [
+			...Object.values(SELECT_PROPERTIES),
+			...Object.values(COMMON_PROPERTIES),
+		] as const;
+
+		return !UNAVAILABLE_PROPERTIES.includes(
+			propertyName as unknown as (typeof UNAVAILABLE_PROPERTIES)[number],
+		);
+	}
+
+	/**
+	 * Updates a features property. This can be used to programmatically change a property of a feature.
+	 * Certain properties are reserved and cannot be updated.
+	 * @param id - the id of the feature to update the property for
+	 * @param propertyName - the property name to update
+	 * @param value - the new value for the property
+	 * @throws error if the property name is reserved or if the feature does not exist
+	 */
+	updateFeatureProperty(
+		id: FeatureId,
+		propertyName: string,
+		value: JSON | undefined,
+	) {
+		if (!this._store.has(id)) {
+			throw new Error(`No feature with id ${id} present in store`);
+		}
+
+		const feature = this._store.copy(id);
+
+		// We don't want users to be able to update guidance features directly
+		if (this.isGuidanceFeature(feature)) {
+			throw new Error(
+				`Guidance features are not allowed to be updated directly.`,
+			);
+		}
+
+		// Ensure that the property is valid
+		if (!propertyName) {
+			throw new Error("Invalid property name provided");
+		}
+
+		const isReservedProperty = this.checkIsReservedProperty(propertyName);
+
+		if (!isReservedProperty) {
+			throw new Error(
+				`You are trying to update a reserved property name: ${propertyName}. Please choose another name.`,
+			);
+		}
+
+		const mode = feature.properties.mode;
+		const modeToUpdate = this._modes[mode as string];
+
+		if (!modeToUpdate) {
+			throw new Error(`No mode with name ${mode} present in instance`);
+		}
+
+		// Check if is allowed JSON value - if value is undefined, we allow this as it means the property will be deleted
+		// We do not however allow nested undefined values in objects or arrays.
+		if (value !== undefined && !isValidJSONValue(value)) {
+			throw new Error(
+				`Invalid JSON value provided for property ${propertyName}`,
+			);
+		}
+
+		this._store.updateProperty(
+			[{ id: feature.id as FeatureId, property: propertyName, value }],
+			{ origin: "api" }, // origin is used to indicate that this update has come from an API call
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description of Changes

Allows setting up custom properties on store objects with valid JSON values via the top level API method `updateFeatureProperty`.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/623

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 