### PR TITLE
fix(terra-draw-google-maps-adapter): ensure onAdd is only called once per adapter registration

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -39,6 +39,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 	private _overlay: google.maps.OverlayView | undefined;
 	private _clickEventListener: google.maps.MapsEventListener | undefined;
 	private _mouseMoveEventListener: google.maps.MapsEventListener | undefined;
+	private _readyCalled = false;
 
 	private get _layers(): boolean {
 		return Boolean(this.renderedFeatureIds?.size > 0);
@@ -72,8 +73,9 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 		// method is called, which is why we need to use the 'ready'
 		// listener with the Google Maps adapter
 		this._overlay.onAdd = () => {
-			if (this._currentModeCallbacks?.onReady) {
+			if (this._currentModeCallbacks?.onReady && !this._readyCalled) {
 				this._currentModeCallbacks.onReady();
+				this._readyCalled = true;
 			}
 		};
 		this._overlay.setMap(this._map);
@@ -128,6 +130,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			this._overlay.setMap(null);
 		}
 		this._overlay = undefined;
+		this._readyCalled = false;
 	}
 
 	/**


### PR DESCRIPTION
## Description of Changes

I was able to produce a scenario where onAdd for the overlay (and in turn onReady) of the Google Maps adapter was being called multiple times. This PR ensures that onReady is only called once per registration.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/630

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 