### PR TITLE
fix(terra-draw): ensure closing points for linestring mode are styleable

### DIFF
--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -282,6 +282,9 @@ describe("TerraDrawLineStringMode", () => {
 			]);
 
 			expect(features[1].geometry.coordinates).toStrictEqual([1, 1]);
+			expect(features[1].properties[COMMON_PROPERTIES.CLOSING_POINT]).toBe(
+				true,
+			);
 
 			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
 

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -368,7 +368,10 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 					type: "Point",
 					coordinates: [...updatedCoord],
 				},
-				properties: { mode: this.mode },
+				properties: {
+					mode: this.mode,
+					[COMMON_PROPERTIES.CLOSING_POINT]: true,
+				},
 			},
 		]);
 		this.closingPointId = pointId;


### PR DESCRIPTION
## Description of Changes

Closing points were not styleable in TerraDrawLineString mode as the closing point property was not being applied correctly. This is resolved in this PR

## Link to Issue

#633 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 