### PR TITLE
chore(terra-draw): ensure badge colors in README are consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p></p>
 
 ![Terra Draw CI Badge](https://github.com/JamesLMilner/terra-draw/actions/workflows/ci.yml/badge.svg)
-[![npm Version](https://img.shields.io/npm/v/terra-draw)](https://www.npmjs.com/package/terra-draw)
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/JamesLMilner?color=%23f66fb8)](https://github.com/sponsors/JamesLMilner)
+[![npm Version](https://img.shields.io/npm/v/terra-draw?labelColor=rgb(61%2070%2078))](https://www.npmjs.com/package/terra-draw)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/JamesLMilner?color=%23f66fb8&labelColor=rgb(61%2070%2078))](https://github.com/sponsors/JamesLMilner)
 
 Frictionless map drawing across mapping libraries.
 


### PR DESCRIPTION
## Description of Changes

Tiny PR to keep badge colors consistent in the README

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 