### PR TITLE
fix(terra-draw-google-maps-adapter): feature id was not set in the style rendering functions

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -1084,6 +1084,7 @@ const getStyleAppliedToAddedFeature = (
 	// looks up mode
 	Object.assign(feature, { getProperty: () => "test" });
 	Object.assign(feature, { forEachProperty: () => {} });
+	Object.assign(feature, { getId: () => feature.id });
 
 	const addGeoJsonMock = jest.fn();
 	let setStyleResult;

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -418,6 +418,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			}
 			const type = gmGeometry.getType();
 			const properties: Record<string, any> = {};
+			const id = feature.getId();
 
 			feature.forEachProperty((value, property) => {
 				properties[property] = value;
@@ -425,6 +426,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 
 			const calculatedStyles = styling[mode]({
 				type: "Feature",
+				id,
 				geometry: {
 					type: type as "Point" | "LineString" | "Polygon",
 					coordinates: [],


### PR DESCRIPTION
Google Maps' version of Feature does not match the GeoJSON specification, having getX() methods instead of X property.
The feature id was the only one that was ignored for the styling functions call. 
This has been rectified.

## Description of Changes

As described in the Google Maps API documentation, provided the feature id to styling functions.

## Link to Issue
https://github.com/JamesLMilner/terra-draw/issues/639

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 