### PR TITLE
docs(terra-draw): add editable and pointerDistance documentation

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -493,7 +493,28 @@ It is possible to select and deselect a feature via the draw instance, which use
   draw.deselectFeature("f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8");
  
 ```
+### Editable Features
 
+Some modes support the concept of features being editable via the `editable` option . You can think of editable as a lightweight version of the select mode without having to switch into select mode directly. Users can do light edits to geometries they have already created, for example dragging existing coordinates. Currently three modes support the editable option: `TerraDrawPointMode`, `TerraDrawLineStringMode` and `TerraDrawPolygonMode`.
+
+Enabling it is straight forward and can be done like so:
+
+```typescript
+new TerraDrawPolygonMode({ editable: true }),
+```
+
+### User Interactions and Pointer Distance
+
+There are certain situations when a user is using Terra Draw, where the library needs to be able to determine if an interaction was intended to cause a specific event or not. For example:
+
+* When selecting a geometry, Terra Draw needs to know if a click was just intended for the underlying map, or to select a given geometry
+* When trying to close a geometry by it's closing point, or if a new coordinate was intended to be drawn on the geometry.
+
+This cut off point is determined by what is called the 'pointer distance'. Pointer distance is measured in pixels and provides the buffer around an already drawn coordinate that would be considered a closing/select event or not. That is to say pointer down events within that pointer distance buffer would be considered a closing or selection event when trying to draw or select respectively. This pointer distance can be configured for features by the `pointerDistance` option, and defaults to 40px. You can configure it like so:
+
+```typescript
+new TerraDrawPolygonMode({ pointerDistance: 25 }), 
+```
 
 ### Render Mode
 


### PR DESCRIPTION
## Description of Changes

Adds `editable` documentation and also documentation for `pointerDistance`

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/433
https://github.com/JamesLMilner/terra-draw/issues/642

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 