### PR TITLE
fix(terra-draw-google-maps-adapter): remove id requirement

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -660,6 +660,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				offsetLeft: 0,
 				offsetTop: 0,
 				id: elId,
+				querySelector: jest.fn(),
 			};
 
 			map.getDiv = jest.fn(() => container);
@@ -674,16 +675,12 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				map,
 			});
 
-			const mockQuerySelector = jest.spyOn(document, "querySelector");
-
+			const mockQuerySelector = jest.spyOn(container, "querySelector");
 			mockQuerySelector.mockImplementationOnce(
 				() => ({ classList: { add: jest.fn() } }) as unknown as Element,
 			);
 
 			adapter.setCursor("pointer");
-
-			// Once in constructor, once in setCursor
-			expect(map.getDiv).toHaveBeenCalledTimes(2);
 
 			const firstSheetAndRule = document.styleSheets[0]
 				.cssRules[0] as CSSStyleRule;
@@ -703,6 +700,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				offsetLeft: 0,
 				offsetTop: 0,
 				id: elId,
+				querySelector: jest.fn(() => document.createElement("div")),
 			};
 
 			map.getDiv = jest.fn(() => container);
@@ -717,12 +715,17 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				map,
 			});
 
+			const createElementSpy = jest.spyOn(document, "createElement");
+
 			adapter.setCursor("pointer");
 			adapter.setCursor("pointer");
 			adapter.setCursor("pointer");
 
-			// Once in constructor, once in setCursor
-			expect(map.getDiv).toHaveBeenCalledTimes(2);
+			// filter only document.createElement('style')
+			const calls = createElementSpy.mock.calls.filter(
+				(args) => args[0] === "style",
+			);
+			expect(calls.length).toBe(1);
 		});
 	});
 

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -254,7 +254,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			// TODO: We could cache these individually per cursor
 
 			const div = this._map.getDiv();
-			const styleDiv = div.querySelector('.gm-style > div');
+			const styleDiv = div.querySelector(".gm-style > div");
 
 			if (styleDiv) {
 				styleDiv.classList.add("terra-draw-google-maps");


### PR DESCRIPTION
## Description of Changes

By changing the way to retrieve the google maps internal element targeted for changing the cursor style, we can get rid of the id requirement, which is helpful when the map instance itself isn't under our control (e.g. when using the `<gmp-map>` web-comnponent, or the `@vis.gl/react-google-maps` library)

## Link to Issue

#649

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 