### PR TITLE
test(terra-draw): add unit tests for ignoreSnappingPoints

### DIFF
--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -2445,6 +2445,99 @@ describe("Terra Draw", () => {
 			expect(features).toHaveLength(3);
 		});
 
+		it("filters out coordinate points if ignoreSnappingPoints set to true", () => {
+			const draw = new TerraDraw({
+				adapter,
+				modes: [
+					new TerraDrawPolygonMode({
+						snapping: {
+							toCoordinate: true,
+						},
+					}),
+				],
+			});
+
+			draw.start();
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[0, 1],
+								[1, 1],
+								[1, 0],
+								[0, 0],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			const features = draw.getFeaturesAtLngLat(
+				{ lng: 0, lat: 0 },
+				{
+					ignoreSnappingPoints: true,
+				},
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("Polygon");
+		});
+
+		it("filters out coordinate points if ignoreSnappingPoints set to false", () => {
+			const polygonMode = new TerraDrawPolygonMode({
+				snapping: {
+					toCoordinate: true,
+				},
+			});
+
+			const draw = new TerraDraw({
+				adapter,
+				modes: [polygonMode],
+			});
+
+			draw.start();
+			draw.addFeatures([
+				{
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[0, 1],
+								[1, 1],
+								[1, 0],
+								[0, 0],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			polygonMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			const features = draw.getFeaturesAtLngLat(
+				{ lng: 0, lat: 0 },
+				{
+					ignoreSnappingPoints: false,
+				},
+			);
+
+			expect(features).toHaveLength(2);
+			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[1].geometry.type).toBe("Point");
+		});
+
 		it("filters out points and linestrings that are not within the pointer distance", () => {
 			const draw = new TerraDraw({
 				adapter,


### PR DESCRIPTION
## Description of Changes

Adds unit tests for ignoreSnappingPoints as a follow up to https://github.com/JamesLMilner/terra-draw/pull/658

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/656

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 