### PR TITLE
chore(terra-draw): add benchmarking for the public Terra Draw API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,5 @@ jobs:
           node-version: "22.x"
       - name: Install Parent Folder
         run: npm ci
-      - name: Build terra-draw
-        run: cd packages/terra-draw && npm run build
-      - name: Test
-        run: npm run benchmark
-        env:
-          CI: true
+      - name: Benchmark
+        run: cd packages/terra-draw && npm run benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,20 @@ jobs:
     - name: Run Playwright tests
       working-directory: ./packages/e2e
       run: npm run test
+    
+  api-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+      - name: Install Parent Folder
+        run: npm ci
+      - name: Build terra-draw
+        run: cd packages/terra-draw && npm run build
+      - name: Test
+        run: npm run benchmark
+        env:
+          CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,5 @@ jobs:
         run: npm ci
       - name: Benchmark
         run: cd packages/terra-draw && npm run benchmark
+        env:
+          CI: true

--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -181,6 +181,25 @@ npm run test:nocheck
 npm run test:nocheck:coverage
 ```
 
+## Benchmarking
+
+The Terra Draw package includes a small benchmark suite to measure the performance of the core API and store operations (not rendering). It lives in `packages/terra-draw/src/terra-draw.benchmark.ts` and uses Tinybench under the hood.
+
+Key points:
+- Focus: core operations such as `getMode`, `getModeState`, `addFeatures`, `removeFeatures`, `hasFeature`, `select/deselect`, `clear`, `getSnapshot`, `updateFeatureProperties`, `updateFeatureGeometry`, `getFeaturesAtLngLat`, `getFeaturesAtPointerEvent`, and event subscription via `on`.
+- Test data: by default seeds a set of point features (e.g., 100) and some tasks use looped iterations to stabilize measurements.
+- Adapter: it does not use a real map adapter. Instead it uses a mock `TerraDrawTestAdapter` that implements the adapter interface but performs no rendering. This is intentional because these benchmarks are not render-performance tests and are meant to isolate algorithmic/data structure performance in the core library.
+- Output: locally results are printed as a table (ops/sec and avg ms). In CI, a Markdown summary is written to the GitHub job summary when `CI` is true.
+
+Run locally from the Terra Draw package folder:
+
+```shell
+cd packages/terra-draw
+npm run benchmark
+```
+
+You can adjust which tasks run, their loop counts, and the feature counts in `src/terra-draw.benchmark.ts` and `src/benchmark/setup.ts`.
+
 ## Developing Locally with Storybook
 
 One of the simplest way to start developing locally is in the `packages/storybook` folder. This package is based off  Storybook.js. It can allow you to quickly visualise and test different Terra Draw configurations. The development tooling for Storybook.js is designed to respond in real time to changes in the source via hot module reloading. The stories (you can think of them as examples) provided should give you a good starting point for experimenting with Terra Draw. The project runs the Storybook build and test steps on CI to help ensure the integrity of both the Terra Draw Storybook implementation and Terra Draw more broadly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"knip": "5.30.2",
 				"microbundle": "0.15.0",
 				"serve": "14.2.4",
+				"tinybench": "^5.0.1",
 				"ts-jest": "29.1.2",
 				"ts-loader": "9.5.1",
 				"tsx": "4.7.2",
@@ -22540,6 +22541,16 @@
 			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-5.0.1.tgz",
+			"integrity": "sha512-aNVgWQZY4veCZLQJRftDA1X9OoLUIjDWNfC90nledkX7Lx205IpSEFYnsu4slyofoPGpJ+NIQj+BNSt4U5edMg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
 		},
 		"node_modules/tinyqueue": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"knip": "5.30.2",
 		"microbundle": "0.15.0",
 		"serve": "14.2.4",
+		"tinybench": "^5.0.1",
 		"ts-jest": "29.1.2",
 		"ts-loader": "9.5.1",
 		"tsx": "4.7.2",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -18,7 +18,8 @@
 		"lint:fix:quiet": "eslint --fix --quiet src/",
 		"format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
 		"format:quiet": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\" --log-level=silent",
-		"benchmark": "tsx ./src/terra-draw.benchmark.ts"
+		"benchmark": "tsx ./src/terra-draw.benchmark.ts",
+		"benchmark:ci": "tsx ./src/terra-draw.benchmark.ts"
 	},
 	"type": "module",
 	"source": "src/terra-draw.ts",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -18,8 +18,7 @@
 		"lint:fix:quiet": "eslint --fix --quiet src/",
 		"format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
 		"format:quiet": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\" --log-level=silent",
-		"benchmark": "tsx ./src/terra-draw.benchmark.ts",
-		"benchmark:ci": "tsx ./src/terra-draw.benchmark.ts"
+		"benchmark": "tsx ./src/terra-draw.benchmark.ts"
 	},
 	"type": "module",
 	"source": "src/terra-draw.ts",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -17,7 +17,8 @@
 		"lint:fix": "eslint --fix src/",
 		"lint:fix:quiet": "eslint --fix --quiet src/",
 		"format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
-		"format:quiet": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\" --log-level=silent"
+		"format:quiet": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\" --log-level=silent",
+		"benchmark": "tsx ./src/terra-draw.benchmark.ts"
 	},
 	"type": "module",
 	"source": "src/terra-draw.ts",

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -1,0 +1,138 @@
+import { FeatureId } from "../extend";
+import {
+	GeoJSONStoreFeatures,
+	TerraDraw,
+	TerraDrawPointMode,
+	TerraDrawPolygonMode,
+	TerraDrawSelectMode,
+} from "../terra-draw";
+import { TerraDrawTestAdapter } from "../test/test-adapter";
+import { uuid4 } from "../util/id";
+import { Bench } from "tinybench";
+
+export const createPointFeatures = (n: number) =>
+	new Array(n).fill({}).map((_, i) => ({
+		id: uuid4(),
+		type: "Feature",
+		geometry: {
+			type: "Point",
+			coordinates: [Math.min(i, 180), Math.min(i, 90)],
+		},
+		properties: {
+			mode: "point",
+		},
+	})) as GeoJSONStoreFeatures[];
+
+export const createDraw = () => {
+	const draw = new TerraDraw({
+		adapter: new TerraDrawTestAdapter({ lib: {} }),
+		modes: [
+			new TerraDrawPointMode(),
+			new TerraDrawPolygonMode(),
+			new TerraDrawSelectMode(),
+		],
+	});
+
+	return draw;
+};
+
+export type BenchmarkProps = {
+	draw: TerraDraw;
+	features: GeoJSONStoreFeatures[];
+	featureIds: FeatureId[];
+	randomFeatureId: FeatureId;
+};
+
+export type BenchmarkTask = {
+	name: string;
+	beforeEach: (benchmarkProps: BenchmarkProps) => void;
+	task: (benchmarkProps: BenchmarkProps) => void;
+	featureCount?: number;
+	loopCount?: number;
+	enabled?: boolean;
+};
+
+export const createBenchmark = (
+	benmarkName: string,
+	tasks: BenchmarkTask[],
+) => {
+	const bench = new Bench({ name: benmarkName });
+
+	tasks.forEach(
+		({ name, beforeEach, task, enabled, featureCount, loopCount }) => {
+			const features = createPointFeatures(featureCount || 100);
+			const featureIds = features.map((feature) => feature.id as FeatureId);
+
+			const benchmarkProps: BenchmarkProps = {
+				draw: createDraw(),
+				features,
+				featureIds,
+				randomFeatureId:
+					featureIds[Math.floor(Math.random() * featureIds.length)],
+			};
+
+			const isEnabled = enabled === false ? false : true;
+
+			const finalTask =
+				loopCount && loopCount > 1
+					? (props: BenchmarkProps) => {
+							for (let i = 0; i < loopCount; i++) {
+								task(props);
+							}
+						}
+					: task;
+
+			isEnabled &&
+				bench.add(
+					loopCount ? `${name} (x${loopCount})` : name,
+					() => {
+						finalTask(benchmarkProps);
+					},
+					{
+						beforeEach: () => {
+							benchmarkProps.randomFeatureId =
+								featureIds[Math.floor(Math.random() * featureIds.length)];
+							beforeEach(benchmarkProps);
+						},
+					},
+				);
+		},
+	);
+
+	return bench;
+};
+
+export const processBenchmarks = (
+	bench: Bench,
+	benchmarkTasks: BenchmarkTask[],
+) => {
+	const results = bench.results.map((result, i) => {
+		return {
+			name: benchmarkTasks[i].name,
+			opsPerSecond: parseInt(
+				(benchmarkTasks[i].loopCount
+					? result!.throughput!.mean * benchmarkTasks[i].loopCount
+					: result!.throughput!.mean
+				).toFixed(0),
+			),
+			averageTimeMs: parseFloat(
+				(benchmarkTasks[i].loopCount
+					? result!.latency!.mean / benchmarkTasks[i].loopCount
+					: result!.latency!.mean
+				).toFixed(8),
+			),
+		};
+	});
+
+	return results;
+};
+
+export const logBenchmarkResults = (
+	results: { name: string; opsPerSecond: number; averageTimeMs: number }[],
+) => {
+	console.table(
+		results.sort(
+			(resultOne, resultTwo) => resultOne.opsPerSecond - resultTwo.opsPerSecond,
+		),
+	);
+};

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -148,6 +148,9 @@ export function writeBenchmarkSummary(results: BenchmarkResult[]) {
 		markdown += `| \`${r.name}\` | ${r.opsPerSecond.toLocaleString()} | ${r.averageTimeMs} |\n`;
 	}
 
+	logBenchmarkResults(results);
+
+	// eslint-disable-next-line no-console
 	console.log("Writing benchmark summary to GITHUB_STEP_SUMMARY");
 	fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY!, markdown);
 }

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -36,7 +36,7 @@ export const createDraw = () => {
 	return draw;
 };
 
-export type BenchmarkProps = {
+type BenchmarkProps = {
 	draw: TerraDraw;
 	features: GeoJSONStoreFeatures[];
 	featureIds: FeatureId[];

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -136,14 +136,19 @@ export const processBenchmarks = (
 };
 
 export function writeBenchmarkSummary(results: BenchmarkResult[]) {
+	const sortedResults = results.sort(
+		(resultOne, resultTwo) => resultOne.opsPerSecond - resultTwo.opsPerSecond,
+	);
+
 	let markdown = `## ⚡ Benchmark Results\n\n`;
 	markdown += `|  Method | Ops/sec | Avg time (ms) |\n`;
 	markdown += `|---------|---------|---------------|\n`;
 
-	for (const r of results) {
+	for (const r of sortedResults) {
 		markdown += `| \`${r.name}\` | ${r.opsPerSecond.toLocaleString()} | ${r.averageTimeMs} |\n`;
 	}
 
+	console.log("Writing benchmark summary to GITHUB_STEP_SUMMARY");
 	fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY!, markdown);
 }
 

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -130,6 +130,7 @@ export const processBenchmarks = (
 export const logBenchmarkResults = (
 	results: { name: string; opsPerSecond: number; averageTimeMs: number }[],
 ) => {
+	// eslint-disable-next-line no-console
 	console.table(
 		results.sort(
 			(resultOne, resultTwo) => resultOne.opsPerSecond - resultTwo.opsPerSecond,

--- a/packages/terra-draw/src/benchmark/setup.ts
+++ b/packages/terra-draw/src/benchmark/setup.ts
@@ -10,6 +10,14 @@ import { TerraDrawTestAdapter } from "../test/test-adapter";
 import { uuid4 } from "../util/id";
 import { Bench } from "tinybench";
 
+import fs from "fs";
+
+type BenchmarkResult = {
+	name: string;
+	opsPerSecond: number;
+	averageTimeMs: number;
+};
+
 export const createPointFeatures = (n: number) =>
 	new Array(n).fill({}).map((_, i) => ({
 		id: uuid4(),
@@ -105,7 +113,7 @@ export const createBenchmark = (
 export const processBenchmarks = (
 	bench: Bench,
 	benchmarkTasks: BenchmarkTask[],
-) => {
+): BenchmarkResult[] => {
 	const results = bench.results.map((result, i) => {
 		return {
 			name: benchmarkTasks[i].name,
@@ -126,6 +134,18 @@ export const processBenchmarks = (
 
 	return results;
 };
+
+export function writeBenchmarkSummary(results: BenchmarkResult[]) {
+	let markdown = `## ⚡ Benchmark Results\n\n`;
+	markdown += `|  Method | Ops/sec | Avg time (ms) |\n`;
+	markdown += `|---------|---------|---------------|\n`;
+
+	for (const r of results) {
+		markdown += `| \`${r.name}\` | ${r.opsPerSecond.toLocaleString()} | ${r.averageTimeMs} |\n`;
+	}
+
+	fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY!, markdown);
+}
 
 export const logBenchmarkResults = (
 	results: { name: string; opsPerSecond: number; averageTimeMs: number }[],

--- a/packages/terra-draw/src/terra-draw.benchmark.ts
+++ b/packages/terra-draw/src/terra-draw.benchmark.ts
@@ -1,0 +1,285 @@
+import {
+	TerraDraw,
+	TerraDrawMouseEvent,
+	TerraDrawPolygonMode,
+} from "./terra-draw";
+
+import {
+	BenchmarkTask,
+	createBenchmark,
+	createDraw,
+	logBenchmarkResults,
+	processBenchmarks,
+} from "./benchmark/setup";
+
+(async () => {
+	const DrawAPI: TerraDraw = createDraw();
+
+	const benchmarkName = "Terra Draw API";
+
+	const featureCount = 100;
+
+	const benchmarkTasks: BenchmarkTask[] = [
+		{
+			name: DrawAPI.getMode.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+			},
+			task: ({ draw }) => {
+				draw.getMode();
+			},
+			loopCount: 1000000,
+		},
+		{
+			name: DrawAPI.getModeState.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+			},
+			task: ({ draw }) => {
+				draw.getModeState();
+			},
+			loopCount: 1000000,
+		},
+		{
+			name: DrawAPI.addFeatures.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+			},
+			task: ({ draw, features }) => {
+				draw.addFeatures([features[0]]);
+			},
+		},
+		{
+			name: DrawAPI.removeFeatures.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw, randomFeatureId }) => {
+				draw.removeFeatures([randomFeatureId]);
+			},
+		},
+		{
+			name: DrawAPI.hasFeature.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw, randomFeatureId }) => {
+				draw.hasFeature(randomFeatureId);
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.getFeatureId.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.getFeatureId();
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.selectFeature.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features.slice(0, 1));
+			},
+			task: ({ draw, featureIds }) => {
+				draw.selectFeature(featureIds[0]);
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.deselectFeature.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features.slice(0, 1));
+				benchmarkProps.draw.selectFeature(benchmarkProps.featureIds[0]);
+			},
+			task: ({ draw, featureIds }) => {
+				draw.deselectFeature(featureIds[0]);
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.clear.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.clear();
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.getSnapshot.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.getSnapshot();
+			},
+			loopCount: 100,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.getSnapshotFeature.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw, randomFeatureId }) => {
+				draw.getSnapshotFeature(randomFeatureId);
+			},
+			loopCount: 1000,
+			enabled: true,
+		},
+		{
+			name: DrawAPI.updateModeOptions.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.updateModeOptions<typeof TerraDrawPolygonMode>("polygon", {
+					snapping: {
+						toCoordinate: true,
+						toLine: true,
+					},
+					pointerDistance: 40,
+					editable: true,
+					showCoordinatePoints: true,
+				});
+			},
+			enabled: true,
+			loopCount: 100,
+		},
+		{
+			name: DrawAPI.updateFeatureProperties.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw, randomFeatureId }) => {
+				draw.updateFeatureProperties(randomFeatureId, {
+					test: "property",
+					anotherProperty: 123,
+				});
+			},
+			enabled: true,
+			loopCount: 100,
+		},
+		{
+			name: DrawAPI.updateFeatureGeometry.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw, randomFeatureId }) => {
+				draw.updateFeatureGeometry(randomFeatureId, {
+					type: "Point",
+					coordinates: [0, 0],
+				});
+			},
+			enabled: true,
+			loopCount: 100,
+		},
+		{
+			name: DrawAPI.getFeaturesAtLngLat.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.getFeaturesAtLngLat({ lng: 0, lat: 0 });
+			},
+			enabled: true,
+			loopCount: 100,
+		},
+		{
+			name: DrawAPI.getFeaturesAtPointerEvent.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+				benchmarkProps.draw.addFeatures(benchmarkProps.features);
+			},
+			task: ({ draw }) => {
+				draw.getFeaturesAtPointerEvent({
+					clientX: 0,
+					clientY: 0,
+					buttons: 0,
+				} as PointerEvent);
+			},
+			enabled: true,
+			loopCount: 100,
+		},
+		{
+			name: DrawAPI.on.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+			},
+			task: ({ draw }) => {
+				draw.on("change", () => {});
+			},
+			enabled: true,
+			loopCount: 10000,
+		},
+
+		// These take too long to run if enabled
+		{
+			name: DrawAPI.start.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+			},
+			task: ({ draw }) => {
+				draw.start();
+			},
+			enabled: false,
+		},
+		{
+			name: DrawAPI.stop.name,
+			beforeEach: (benchmarkProps) => {
+				benchmarkProps.draw = createDraw();
+				benchmarkProps.draw.start();
+			},
+			task: ({ draw }) => {
+				draw.stop();
+			},
+			enabled: false,
+		},
+	];
+
+	const bench = createBenchmark(benchmarkName, benchmarkTasks);
+
+	await bench.runSync();
+
+	const results = processBenchmarks(bench, benchmarkTasks);
+
+	logBenchmarkResults(results);
+})();

--- a/packages/terra-draw/src/terra-draw.benchmark.ts
+++ b/packages/terra-draw/src/terra-draw.benchmark.ts
@@ -10,6 +10,7 @@ import {
 	createDraw,
 	logBenchmarkResults,
 	processBenchmarks,
+	writeBenchmarkSummary,
 } from "./benchmark/setup";
 
 (async () => {
@@ -281,5 +282,9 @@ import {
 
 	const results = processBenchmarks(bench, benchmarkTasks);
 
-	logBenchmarkResults(results);
+	if (process.env.CI) {
+		writeBenchmarkSummary(results);
+	} else {
+		logBenchmarkResults(results);
+	}
 })();

--- a/packages/terra-draw/src/test/test-adapter.ts
+++ b/packages/terra-draw/src/test/test-adapter.ts
@@ -1,0 +1,145 @@
+import {
+	Project,
+	Unproject,
+	SetCursor,
+	GetLngLatFromEvent,
+	TerraDrawChanges,
+	TerraDrawStylingFunction,
+	TerraDrawAdapterStyling,
+} from "../common";
+import {
+	TerraDrawBaseAdapter,
+	CustomStyling,
+	TerraDrawBaseDrawMode,
+} from "../extend";
+import {
+	TerraDrawExtend,
+	GeoJSONStoreFeatures,
+	BehaviorConfig,
+} from "../terra-draw";
+
+/**
+ * A mock implementation of a custom adapter - this is to ensure that it is possible to write
+ * custom adapters for Terra Draw exclusively relying on the public API of the library.
+ */
+export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
+	constructor(
+		config: {
+			lib: Record<string, unknown>;
+		} & TerraDrawExtend.BaseAdapterConfig,
+	) {
+		super(config);
+	}
+
+	public getMapEventElement(): HTMLElement {
+		return {
+			addEventListener: () => {
+				//
+			},
+			removeEventListener: () => {
+				//
+			},
+		} as unknown as HTMLElement;
+	}
+	public clear(): void {
+		if (this._currentModeCallbacks) {
+			this._currentModeCallbacks.onClear();
+		}
+	}
+
+	public project(lng: number, lat: number): ReturnType<Project> {
+		return { x: lng, y: lat };
+	}
+	public unproject(x: number, y: number): ReturnType<Unproject> {
+		return { lng: x, lat: y };
+	}
+	public setCursor(
+		_:
+			| "move"
+			| "unset"
+			| "grab"
+			| "grabbing"
+			| "crosshair"
+			| "pointer"
+			| "wait",
+	): ReturnType<SetCursor> {
+		// pass
+	}
+	public getLngLatFromEvent(
+		_: PointerEvent | MouseEvent,
+	): ReturnType<GetLngLatFromEvent> {
+		return { lng: 0, lat: 0 };
+	}
+	public setDraggability(_: boolean): void {
+		// pass
+	}
+	public setDoubleClickToZoom(_: boolean): void {
+		// pass
+	}
+	public render(_1: TerraDrawChanges, _2: TerraDrawStylingFunction): void {
+		// pass
+	}
+
+	public register(callbacks: TerraDrawExtend.TerraDrawCallbacks): void {
+		this._currentModeCallbacks = callbacks;
+	}
+
+	public unregister(): void {
+		super.unregister();
+	}
+}
+
+/**
+ * A mock implementation for a custom draw mode - this is to ensure that it is possible to write
+ * custom draw modes for Terra Draw exclusively relying on the public API of the library.
+ */
+
+interface TerraDrawTestModeOptions<T extends CustomStyling>
+	extends TerraDrawExtend.BaseModeOptions<T> {
+	customProperty: string;
+}
+
+interface TestModeStyling extends CustomStyling {
+	fillColor: TerraDrawExtend.HexColorStyling;
+	outlineWidth: TerraDrawExtend.NumericStyling;
+}
+
+export class TerraDrawTestMode extends TerraDrawBaseDrawMode<TestModeStyling> {
+	private customProperty: string;
+
+	constructor(options?: TerraDrawTestModeOptions<TestModeStyling>) {
+		super(options);
+
+		this.customProperty = options?.customProperty ?? "default";
+	}
+
+	styleFeature(_: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
+		return {
+			polygonFillColor: "#3f97e0",
+			polygonOutlineColor: "#3f97e0",
+			polygonOutlineWidth: 4,
+			polygonFillOpacity: 0.3,
+			pointColor: "#B90E0A",
+			pointOutlineColor: "#ffffff",
+			pointOutlineWidth: 2,
+			pointWidth: 5,
+			lineStringColor: "#B90E0A",
+			lineStringWidth: 4,
+			zIndex: 0,
+		};
+	}
+
+	registerBehaviors(_: BehaviorConfig): void {
+		// pass
+	}
+
+	start(): void {
+		throw new Error("Method not implemented.");
+	}
+	stop(): void {
+		throw new Error("Method not implemented.");
+	}
+	cleanUp(): void {
+		throw new Error("Method not implemented.");
+	}
+}


### PR DESCRIPTION
## Description of Changes

Adds basic benchmarking for the public API. This is adapter agnostic and just focuses on the Terra Draw API rather than rendering performance. The aim here is to be able to track performance regressions and also give some guidance on if performance is improved when actively trying to make operations faster.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/654

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 