### PR TITLE
fix(terra-draw): ensure addClosestCoordinateInfoToProperties does not break polygon coordinates

### DIFF
--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -2443,6 +2443,23 @@ describe("Terra Draw", () => {
 			const features = draw.getFeaturesAtLngLat({ lng: 0, lat: 0 });
 
 			expect(features).toHaveLength(3);
+			expect(features[0].geometry.type).toBe("Point");
+			expect(features[0].geometry.coordinates).toEqual([0, 0]);
+			expect(features[1].geometry.type).toBe("LineString");
+			expect(features[1].geometry.coordinates).toEqual([
+				[0, 0],
+				[1, 1],
+			]);
+			expect(features[2].geometry.type).toBe("Polygon");
+			expect(features[2].geometry.coordinates).toEqual([
+				[
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				],
+			]);
 		});
 
 		it("filters out coordinate points if ignoreSnappingPoints set to true", () => {
@@ -2488,6 +2505,15 @@ describe("Terra Draw", () => {
 
 			expect(features).toHaveLength(1);
 			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[0].geometry.coordinates).toEqual([
+				[
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				],
+			]);
 		});
 
 		it("filters out coordinate points if ignoreSnappingPoints set to false", () => {
@@ -2535,7 +2561,17 @@ describe("Terra Draw", () => {
 
 			expect(features).toHaveLength(2);
 			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[0].geometry.coordinates).toEqual([
+				[
+					[0, 0],
+					[0, 1],
+					[1, 1],
+					[1, 0],
+					[0, 0],
+				],
+			]);
 			expect(features[1].geometry.type).toBe("Point");
+			expect(features[1].geometry.coordinates).toEqual([0, 0]);
 		});
 
 		it("filters out points and linestrings that are not within the pointer distance", () => {
@@ -2981,6 +3017,15 @@ describe("Terra Draw", () => {
 			);
 
 			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[0].geometry.coordinates).toEqual([
+				[
+					[0, 0],
+					[1, 1],
+					[0, 1],
+					[0, 0],
+				],
+			]);
 			expect(features[0].properties.closestCoordinateIndexToEvent).toBe(2);
 			expect(
 				features[0].properties.closestCoordinatePixelDistanceToEvent,

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -512,8 +512,7 @@ class TerraDraw {
 
 				let coordinates;
 				if (feature.geometry.type === "Polygon") {
-					coordinates = feature.geometry.coordinates[0];
-					coordinates.pop(); // Remove duplicate end coordinate
+					coordinates = feature.geometry.coordinates[0].slice(0, -1); // Remove the closing coordinate as it's always the same as the first
 				} else if (feature.geometry.type === "LineString") {
 					coordinates = feature.geometry.coordinates;
 				} else {


### PR DESCRIPTION
## Description of Changes

Fixes issue where when addClosestCoordinateInfoToProperties it was calling `pop` which mutates the returned coordinate array.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/657

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 