### PR TITLE
docs(terra-draw): update 6.EVENTS.md with new getFeaturesAt options

### DIFF
--- a/guides/6.EVENTS.md
+++ b/guides/6.EVENTS.md
@@ -31,7 +31,14 @@ document.addEventListener("mousemove", (event) => {
     ignoreCurrentlyDrawing: true,
 
     // Ignore closing points 
-    ignoreClosingPoints: true 
+    ignoreClosingPoints: true,
+
+    // Ignore snapping points 
+    ignoreSnappingPoints: true,
+
+    // Adds to feature's properties information about the closest coordinate to pointer event
+    addClosestCoordinateInfoToProperties: true
+
   });
 
   // Do something with the features...


### PR DESCRIPTION
 Reflect in the guide docs recently introduced features, namely `ignoreSnappingPoints` and `addClosestCoordinateInfoToProperties` options for `getFeaturesAt` functions