### PR TITLE
fix(terra-draw-maplibre-gl-adapter): remove unused scaling for markers

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -53,7 +53,7 @@ const Marker: Story = {
 						markerUrl:
 							"https://leafletjs.com/examples/custom-icons/leaf-green.png",
 						markerWidth: 25,
-						markerHeight: 100,
+						markerHeight: 60,
 					},
 				}),
 		],


### PR DESCRIPTION
## Description of Changes

- make resizeImage a method
- remove unnecessary scaling logic

## Link to Issue

#613 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 