### PR TITLE
fix(terra-draw-maplibre-gl-adapter): use hasImage to determine if marker is loaded

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -83,10 +83,6 @@ export class TerraDrawMapLibreGLAdapter<
 	private _map: MaplibreMap;
 	private _container: HTMLElement;
 
-	// Marker state
-	private markerCounter = 0;
-	private markerMap = new Map<string, string>();
-
 	private _addGeoJSONSource(id: string, features: Feature[]) {
 		this._map.addSource(id, {
 			type: "geojson",
@@ -412,28 +408,26 @@ export class TerraDrawMapLibreGLAdapter<
 					properties.pointWidth = styles.pointWidth;
 
 					if (styles.markerUrl && styles.markerWidth && styles.markerHeight) {
-						if (!this.markerMap.has(styles.markerUrl)) {
-							const id = `marker-${this.hashCode(styles.markerUrl)}`;
+						const id = `marker-${this.hashCode(styles.markerUrl)}`;
 
+						if (!this._map.hasImage(id)) {
 							this.resizeImage(
 								styles.markerUrl,
 								styles.markerWidth,
 								styles.markerHeight,
 								(resizedDataURL) => {
 									this._map.loadImage(resizedDataURL).then((image) => {
-										this._map.addImage(id, image.data);
+										// Async so we check again if the image has been added
+										if (!this._map.hasImage(id)) {
+											this._map.addImage(id, image.data);
+										}
 									});
 								},
 							);
-
-							this.markerMap.set(styles.markerUrl, id);
-
-							properties.markerId = id;
-							properties.pointWidth = 0; // Make circle invisible
-						} else {
-							properties.markerId = this.markerMap.get(styles.markerUrl)!;
-							properties.pointWidth = 0; // Make circle invisible
 						}
+
+						properties.markerId = id;
+						properties.pointWidth = 0; // Make circle invisible
 					}
 
 					points.push(feature);


### PR DESCRIPTION
## Description of Changes

Simplifies the logic for checking if a marker is loaded by removing the Map/counter and just using `hasImage` from the map directly. This should fix issues outlined in https://github.com/JamesLMilner/terra-draw/issues/680

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/680

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 