### PR TITLE
fix(terra-draw): ensure markers are styleable in select mode

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -212,6 +212,7 @@ export const COMMON_PROPERTIES = {
 	COORDINATE_POINT_IDS: "coordinatePointIds",
 	PROVISIONAL_COORDINATE_COUNT: "provisionalCoordinateCount",
 	COMMITTED_COORDINATE_COUNT: "committedCoordinateCount",
+	MARKER: "marker",
 } as const;
 
 /**

--- a/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
@@ -5,6 +5,7 @@ import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { DefaultPointerEvents } from "../base.mode";
 import { MockPoint } from "../../test/mock-features";
 import { GeoJSONStoreFeatures, JSONObject } from "../../store/store";
+import { COMMON_PROPERTIES } from "../../common";
 
 describe("TerraDrawMarkerMode", () => {
 	describe("constructor", () => {
@@ -164,6 +165,22 @@ describe("TerraDrawMarkerMode", () => {
 				"create",
 				undefined,
 			);
+			expect(mockConfig.onFinish).toHaveBeenCalledTimes(1);
+
+			expect(mockConfig.store.copyAll()[0]).toEqual({
+				id: expect.any(String),
+				type: "Feature",
+				geometry: {
+					type: "Point",
+					coordinates: [0, 0],
+				},
+				properties: {
+					mode: markerMode.mode,
+					[COMMON_PROPERTIES.MARKER]: true,
+					createdAt: expect.any(Number),
+					updatedAt: expect.any(Number),
+				},
+			});
 		});
 
 		it("right click can delete a point if editable is true", () => {

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -296,9 +296,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 
 		const properties = {
 			mode: this.mode,
-			markerUrl: this.markerUrl as string,
-			markerHeight: this.markerHeight as number,
-			markerWidth: this.markerWidth as number,
+			[COMMON_PROPERTIES.MARKER]: true,
 		};
 
 		if (this.validate) {

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -3,7 +3,11 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawSelectMode } from "./select.mode";
 import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
-import { TerraDrawGeoJSONStore, TerraDrawMouseEvent } from "../../common";
+import {
+	COMMON_PROPERTIES,
+	TerraDrawGeoJSONStore,
+	TerraDrawMouseEvent,
+} from "../../common";
 import { DefaultPointerEvents } from "../base.mode";
 
 describe("TerraDrawSelectMode", () => {
@@ -2921,7 +2925,7 @@ describe("TerraDrawSelectMode", () => {
 
 	describe("styleFeature", () => {
 		it("returns the correct styles for polygon from polygon mode", () => {
-			const polygonMode = new TerraDrawSelectMode({
+			const selectMode = new TerraDrawSelectMode({
 				styles: {
 					selectedPolygonOutlineWidth: 4,
 					selectedPolygonColor: "#222222",
@@ -2931,7 +2935,7 @@ describe("TerraDrawSelectMode", () => {
 			});
 
 			expect(
-				polygonMode.styleFeature({
+				selectMode.styleFeature({
 					type: "Feature",
 					geometry: { type: "Polygon", coordinates: [] },
 					properties: { mode: "polygon", selected: true },
@@ -2944,7 +2948,7 @@ describe("TerraDrawSelectMode", () => {
 			});
 
 			expect(
-				polygonMode.styleFeature({
+				selectMode.styleFeature({
 					type: "Feature",
 					geometry: { type: "Polygon", coordinates: [] },
 					properties: { mode: "polygon" },
@@ -2989,6 +2993,82 @@ describe("TerraDrawSelectMode", () => {
 				polygonFillColor: "#3f97e0",
 				polygonFillOpacity: 0.3,
 				polygonOutlineColor: "#3f97e0",
+			});
+		});
+
+		it("returns correct styles for marker from marker mode", () => {
+			const selectMode = new TerraDrawSelectMode({
+				styles: {
+					selectedMarkerUrl: "https://www.example.com/selected.png",
+					selectedMarkerHeight: 40,
+					selectedMarkerWidth: 40,
+				},
+			});
+
+			expect(
+				selectMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: "marker",
+						[COMMON_PROPERTIES.MARKER]: true,
+						selected: true,
+					},
+				}),
+			).toMatchObject({
+				markerUrl: "https://www.example.com/selected.png",
+				markerHeight: 40,
+				markerWidth: 40,
+			});
+
+			expect(
+				selectMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: { mode: "marker", [COMMON_PROPERTIES.MARKER]: true },
+				}),
+			).toMatchObject({
+				markerUrl: undefined,
+				markerHeight: undefined,
+				markerWidth: undefined,
+			});
+		});
+
+		it("returns correct styles for marker from marker mode when using a function", () => {
+			const selectMode = new TerraDrawSelectMode({
+				styles: {
+					selectedMarkerUrl: () => "https://www.example.com/selected.png",
+					selectedMarkerHeight: () => 40,
+					selectedMarkerWidth: () => 40,
+				},
+			});
+
+			expect(
+				selectMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: "marker",
+						[COMMON_PROPERTIES.MARKER]: true,
+						selected: true,
+					},
+				}),
+			).toMatchObject({
+				markerUrl: "https://www.example.com/selected.png",
+				markerHeight: 40,
+				markerWidth: 40,
+			});
+
+			expect(
+				selectMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: { mode: "marker", [COMMON_PROPERTIES.MARKER]: true },
+				}),
+			).toMatchObject({
+				markerUrl: undefined,
+				markerHeight: undefined,
+				markerWidth: undefined,
 			});
 		});
 	});

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -10,6 +10,8 @@ import {
 	UpdateTypes,
 	Z_INDEX,
 	Snapping,
+	UrlStyling,
+	COMMON_PROPERTIES,
 } from "../../common";
 import { Point, Position } from "geojson";
 import {
@@ -81,6 +83,11 @@ type SelectionStyling = {
 	selectedPointWidth: NumericStyling;
 	selectedPointOutlineColor: HexColorStyling;
 	selectedPointOutlineWidth: NumericStyling;
+
+	// Marker
+	selectedMarkerUrl: UrlStyling;
+	selectedMarkerHeight: NumericStyling;
+	selectedMarkerWidth: NumericStyling;
 
 	// LineString
 	selectedLineStringColor: HexColorStyling;
@@ -974,7 +981,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			feature.properties.mode === this.mode &&
 			feature.geometry.type === "Point"
 		) {
-			if (feature.properties.selectionPoint) {
+			if (feature.properties[SELECT_PROPERTIES.SELECTION_POINT]) {
 				styles.pointColor = this.getHexColorStylingValue(
 					this.styles.selectionPointColor,
 					styles.pointColor,
@@ -1004,7 +1011,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 				return styles;
 			}
 
-			if (feature.properties.midPoint) {
+			if (feature.properties[SELECT_PROPERTIES.MID_POINT]) {
 				styles.pointColor = this.getHexColorStylingValue(
 					this.styles.midPointColor,
 					styles.pointColor,
@@ -1037,7 +1044,27 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			// Select mode shortcuts the styling of a feature if it is selected
 			// A selected feature from another mode will end up in this block
 
-			if (feature.geometry.type === "Polygon") {
+			if (
+				feature.geometry.type === "Point" &&
+				feature.properties[COMMON_PROPERTIES.MARKER]
+			) {
+				styles.markerUrl = this.getUrlStylingValue(
+					this.styles.selectedMarkerUrl,
+					"",
+					feature,
+				);
+				styles.markerHeight = this.getNumericStylingValue(
+					this.styles.selectedMarkerHeight,
+					30,
+					feature,
+				);
+				styles.markerWidth = this.getNumericStylingValue(
+					this.styles.selectedMarkerWidth,
+					30,
+					feature,
+				);
+				return styles;
+			} else if (feature.geometry.type === "Polygon") {
 				styles.polygonFillColor = this.getHexColorStylingValue(
 					this.styles.selectedPolygonColor,
 					styles.polygonFillColor,


### PR DESCRIPTION
## Description of Changes

- Adds support for markers in Select mode
- Removes accidental properties that were added in Marker mode
- Adds some unit tests to cover the changes

## Link to Issue

#694 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 