### PR TITLE
fix(terra-draw): ensure default marker url path is correct

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -194,8 +194,10 @@ export interface TerraDrawAdapter {
 	getCoordinatePrecision(): number;
 }
 
-export const MARKER_URL_DEFAULT =
-	"https://github.com/JamesLMilner/terra-draw/blob/main/assets/markers/marker-blue.png?raw=true";
+const MARKER_URL_BASE =
+	"https://raw.githubusercontent.com/JamesLMilner/terra-draw/refs/heads/main/assets/markers";
+
+export const MARKER_URL_DEFAULT = `${MARKER_URL_BASE}/marker-blue.png`;
 
 export const SELECT_PROPERTIES = {
 	SELECTED: "selected",


### PR DESCRIPTION
## Description of Changes

This URL format is more appropriate for the default marker URL

## Link to Issue

#613 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 