### PR TITLE
chore(terra-draw): use a centralised type for updateOptions argument

### DIFF
--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -14,6 +14,7 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 } from "../base.mode";
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { getDefaultStyling } from "../../util/styling";
@@ -84,9 +85,8 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 	}
 
 	override updateOptions(
-		options?: Omit<
-			TerraDrawAngledRectangleModeOptions<PolygonStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawAngledRectangleModeOptions<PolygonStyling>
 		>,
 	) {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -47,6 +47,8 @@ export const DefaultPointerEvents = {
 
 type AllowPointerEvent = boolean | ((event: TerraDrawMouseEvent) => boolean);
 
+export type ModeUpdateOptions<Mode> = Omit<Mode, "modeName">;
+
 export interface PointerEvents {
 	leftClick: AllowPointerEvent;
 	rightClick: AllowPointerEvent;

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -22,6 +22,7 @@ import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
@@ -82,9 +83,8 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	}
 
 	override updateOptions(
-		options?: Omit<
-			TerraDrawCircleModeOptions<CirclePolygonStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawCircleModeOptions<CirclePolygonStyling>
 		>,
 	) {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -14,6 +14,7 @@ import { LineString } from "geojson";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { getDefaultStyling } from "../../util/styling";
@@ -78,9 +79,8 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 	}
 
 	public updateOptions(
-		options?: Omit<
-			TerraDrawFreehandLineStringModeOptions<FreehandLineStringStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawFreehandLineStringModeOptions<FreehandLineStringStyling>
 		>,
 	): void {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -15,6 +15,7 @@ import { Feature, LineString, Point, Position } from "geojson";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { cartesianDistance } from "../../geometry/measure/pixel-distance";
@@ -120,9 +121,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	}
 
 	updateOptions(
-		options?: Omit<
-			TerraDrawLineStringModeOptions<LineStringStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawLineStringModeOptions<LineStringStyling>
 		>,
 	) {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -19,6 +19,7 @@ import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidatePointFeature } from "../../validations/point.validation";
@@ -77,7 +78,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 	}
 
 	updateOptions(
-		options?: Omit<TerraDrawMarkerModeOptions<MarkerModeStyling>, "modeName">,
+		options?: ModeUpdateOptions<TerraDrawMarkerModeOptions<MarkerModeStyling>>,
 	): void {
 		super.updateOptions(options);
 

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -18,6 +18,7 @@ import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidatePointFeature } from "../../validations/point.validation";
@@ -75,7 +76,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 	}
 
 	updateOptions(
-		options?: Omit<TerraDrawPointModeOptions<PointModeStyling>, "modeName">,
+		options?: ModeUpdateOptions<TerraDrawPointModeOptions<PointModeStyling>>,
 	): void {
 		super.updateOptions(options);
 

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -18,6 +18,7 @@ import {
 	BaseModeOptions,
 	CustomStyling,
 	PointerEvents,
+	ModeUpdateOptions,
 } from "../base.mode";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
@@ -129,7 +130,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	}
 
 	override updateOptions(
-		options?: Omit<TerraDrawPolygonModeOptions<PolygonStyling>, "modeName">,
+		options?: ModeUpdateOptions<TerraDrawPolygonModeOptions<PolygonStyling>>,
 	) {
 		super.updateOptions(options);
 

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -19,6 +19,7 @@ import { getDefaultStyling } from "../../util/styling";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
@@ -68,9 +69,8 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	}
 
 	override updateOptions(
-		options?: Omit<
-			TerraDrawRectangleModeOptions<RectanglePolygonStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawRectangleModeOptions<RectanglePolygonStyling>
 		>,
 	) {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/render/render.mode.ts
+++ b/packages/terra-draw/src/modes/render/render.mode.ts
@@ -7,6 +7,7 @@ import {
 	BaseModeOptions,
 	CustomStyling,
 	ModeTypes,
+	ModeUpdateOptions,
 	TerraDrawBaseDrawMode,
 } from "../base.mode";
 import { BehaviorConfig } from "../base.behavior";
@@ -51,7 +52,7 @@ export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling
 	}
 
 	updateOptions(
-		options?: Omit<TerraDrawRenderModeOptions<RenderModeStyling>, "modeName">,
+		options?: ModeUpdateOptions<TerraDrawRenderModeOptions<RenderModeStyling>>,
 	): void {
 		super.updateOptions(options);
 	}

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -14,6 +14,7 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 } from "../base.mode";
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { getDefaultStyling } from "../../util/styling";
@@ -88,9 +89,8 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 	}
 
 	override updateOptions(
-		options?: Omit<
-			TerraDrawSectorModeOptions<SectorPolygonStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawSectorModeOptions<SectorPolygonStyling>
 		>,
 	) {
 		super.updateOptions(options);

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -18,6 +18,7 @@ import { Point, Position } from "geojson";
 import {
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 	TerraDrawBaseSelectMode,
 } from "../base.mode";
 import { MidPointBehavior } from "./behaviors/midpoint.behavior";
@@ -171,7 +172,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 	}
 
 	override updateOptions(
-		options?: Omit<TerraDrawSelectModeOptions<SelectionStyling>, "modeName">,
+		options?: ModeUpdateOptions<TerraDrawSelectModeOptions<SelectionStyling>>,
 	) {
 		super.updateOptions(options);
 

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -14,6 +14,7 @@ import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
 	CustomStyling,
+	ModeUpdateOptions,
 } from "../base.mode";
 import { getDefaultStyling } from "../../util/styling";
 import {
@@ -93,9 +94,8 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 	}
 
 	override updateOptions(
-		options?: Omit<
-			TerraDrawSensorModeOptions<SensorPolygonStyling>,
-			"modeName"
+		options?: ModeUpdateOptions<
+			TerraDrawSensorModeOptions<SensorPolygonStyling>
 		>,
 	): void {
 		super.updateOptions(options);


### PR DESCRIPTION
## Description of Changes

Avoids using Omit in every mode for updateOptions and wraps it in a generic type

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/627

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 