### PR TITLE
fix(terra-draw): avoid excessive change events and duplicate ids from property changes

### DIFF
--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -279,7 +279,7 @@ describe("TerraDrawCircleMode", () => {
 						true,
 					);
 
-					expect(onChange).toHaveBeenCalledTimes(6);
+					expect(onChange).toHaveBeenCalledTimes(5);
 					expect(onChange).toHaveBeenCalledWith(
 						[expect.any(String)],
 						"create",

--- a/packages/terra-draw/src/store/store.spec.ts
+++ b/packages/terra-draw/src/store/store.spec.ts
@@ -277,6 +277,22 @@ describe("GeoJSONStore", () => {
 			});
 		});
 
+		it("does not call onChange if property value is identical", () => {
+			const store = new GeoJSONStore();
+			const mockCallback = jest.fn();
+			store.registerOnChange(mockCallback);
+
+			const [id] = store.create<string>([
+				{ geometry: { type: "Point", coordinates: [0, 0] } },
+			]);
+			mockCallback.mockClear();
+
+			store.updateProperty([{ id, property: "test", value: 1 }]);
+			store.updateProperty([{ id, property: "test", value: 1 }]); // identical value
+
+			expect(mockCallback).toHaveBeenCalledTimes(1); // only called for create and first update
+		});
+
 		it("throws error on missing feature", () => {
 			const store = new GeoJSONStore();
 

--- a/packages/terra-draw/src/store/store.ts
+++ b/packages/terra-draw/src/store/store.ts
@@ -243,7 +243,7 @@ export class GeoJSONStore<
 		}[],
 		context?: OnChangeContext,
 	): void {
-		const ids: FeatureId[] = [];
+		const ids: Set<FeatureId> = new Set();
 		propertiesToUpdate.forEach(({ id, property, value }) => {
 			const feature = this.store[id];
 
@@ -253,7 +253,12 @@ export class GeoJSONStore<
 				);
 			}
 
-			ids.push(id);
+			if (feature.properties[property] === value) {
+				// If the value is the same, we don't need to update
+				return;
+			}
+
+			ids.add(id);
 
 			if (value === undefined) {
 				delete feature.properties[property];
@@ -267,8 +272,8 @@ export class GeoJSONStore<
 			}
 		});
 
-		if (this._onChange) {
-			this._onChange(ids, "update", context);
+		if (this._onChange && ids.size > 0) {
+			this._onChange([...ids], "update", context);
 		}
 	}
 
@@ -276,9 +281,9 @@ export class GeoJSONStore<
 		geometriesToUpdate: { id: FeatureId; geometry: GeoJSONStoreGeometries }[],
 		context?: OnChangeContext,
 	): void {
-		const ids: FeatureId[] = [];
+		const ids: Set<FeatureId> = new Set();
 		geometriesToUpdate.forEach(({ id, geometry }) => {
-			ids.push(id);
+			ids.add(id);
 
 			const feature = this.store[id];
 
@@ -298,8 +303,8 @@ export class GeoJSONStore<
 			}
 		});
 
-		if (this._onChange) {
-			this._onChange(ids, "update", context);
+		if (this._onChange && ids.size > 0) {
+			this._onChange([...ids], "update", context);
 		}
 	}
 


### PR DESCRIPTION
## Description of Changes

This PR fixes two bugs:

- Ids could appear multiple times in the id list when firing a change event via onChange in the store. This is because multiple properties could change on the same object. 
- A change event would be fired even if the property update was identical. This causes unnecessary change events when a feature has actually reminded the same (probably a broader issue here of trying to update features with identical properties to what they already have).

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/706
https://github.com/JamesLMilner/terra-draw/issues/702

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 