### PR TITLE
docs(terra-draw): document marker property requirement for marker icons

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -642,6 +642,27 @@ new TerraDrawMarkerMode({
 > [!NOTE]
 > Terra Draw currently supports PNG and JPG for images. Other formats are currently not actively supported.
 
+> [!IMPORTANT]
+> For a feature to render as a marker icon, it **must** have a `marker: true` property set in its GeoJSON properties. If this property is missing or removed (for example, when programmatically manipulating features), the feature will fall back to rendering as a standard point geometry. When adding features programmatically via `addFeatures()`, ensure you include `marker: true` in the properties object if you want the feature to display as a marker icon.
+
+Example of a properly formatted marker feature:
+
+```typescript
+draw.addFeatures([
+  {
+    type: "Feature",
+    geometry: {
+      type: "Point",
+      coordinates: [-0.09, 51.505]
+    },
+    properties: {
+      mode: "marker", // or your custom mode name
+      marker: true,   // Required for marker icon rendering
+    }
+  }
+]);
+```
+
 You can also leverage markers in your own custom modes by configuring these named styles. You can do this in `styleFeature` like so:
 
 ```typescript


### PR DESCRIPTION
This PR adds critical documentation to the Modes guide clarifying that features must include `marker: true` in their GeoJSON properties to render as marker icons when using `TerraDrawMarkerMode`. 
**Changes include:**
- Added an `[!IMPORTANT]` note explaining the `marker: true` property requirement
- Provided a complete TypeScript code example showing how to properly format marker features when using `addFeatures()`
- Clarified that without this property, features will fall back to rendering as standard point geometries
This documentation gap was causing confusion for developers who were programmatically adding marker features and wondering why they weren't rendering as marker icons.
**Demo:** https://terra-draw-marker-property-issue-de.vercel.app/

Link to Issue

Closes #711

PR Checklist
- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is an associated GitHub issue
- [x] If I have added significant code changes, there are relevant tests *(N/A - documentation only)*
- [x] If there are behaviour changes these are documented *(This PR adds missing documentation for existing behavior)*