### PR TITLE
docs(terra-draw): add Rectangle draw interaction examples to Storybook (#668)

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -277,6 +277,36 @@ const Rectangle: Story = {
 	},
 };
 
+// Rectangle drawing with click-drag interaction story
+const RectangleWithClickDragInteraction: Story = {
+	...DefaultStory,
+	args: {
+		id: "rectangle-with-click-drag-interaction",
+		modes: [
+			() =>
+				new TerraDrawRectangleMode({
+					drawInteraction: "click-drag",
+				}),
+		],
+		...DefaultStory.args,
+	},
+};
+
+// Rectangle drawing with click-move-or-drag interaction story
+const RectangleWithClickMoveOrDragInteraction: Story = {
+	...DefaultStory,
+	args: {
+		id: "rectangle-with-click-move-or-drag-interaction",
+		modes: [
+			() =>
+				new TerraDrawRectangleMode({
+					drawInteraction: "click-move-or-drag",
+				}),
+		],
+		...DefaultStory.args,
+	},
+};
+
 // Angled rectangle drawing story
 const AngledRectangle: Story = {
 	...DefaultStory,
@@ -666,6 +696,8 @@ const AllStories = {
 	ZIndexOrdering,
 	Circle,
 	Rectangle,
+	RectangleWithClickDragInteraction,
+	RectangleWithClickMoveOrDragInteraction,
 	AngledRectangle,
 	Sector,
 	LineString,

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -28,6 +28,10 @@ export const ZIndexOrdering = AllStories.ZIndexOrdering;
 export const Styling = AllStories.Styling;
 export const Circle = AllStories.Circle;
 export const Rectangle = AllStories.Rectangle;
+export const RectangleWithClickDragInteraction =
+	AllStories.RectangleWithClickDragInteraction;
+export const RectangleWithClickMoveOrDragInteraction =
+	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
 export const LineString = AllStories.LineString;


### PR DESCRIPTION
## Description of Changes

Add two new Rectangle draw interaction examples to Storybook: 
 - Rectangle With Click Drag Interaction 
 - Rectangle With Click Move Or Drag Interaction

These Rectangle drawing interactions were added in #700 

<img width="1092" height="607" alt="storybook_rectangle_options" src="https://github.com/user-attachments/assets/610920d6-1c5b-4af0-9d98-2379f30a9fdd" />


## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/668.  

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 