### PR TITLE
fix(terra-draw-google-maps-adapter): clean up google-maps adapter setStyle function on teardown

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -21,6 +21,7 @@ const createMockGoogleMap = (overrides?: Partial<google.maps.Map>) => {
 		controls: [],
 		data: {
 			addListener: jest.fn(),
+			setStyle: jest.fn(),
 		} as any,
 		fitBounds: jest.fn(),
 		getCenter: jest.fn(),
@@ -234,7 +235,9 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					id: "map",
 					querySelector: jest.fn(() => div),
 				})) as any,
-				data: {} as any,
+				data: {
+					setStyle: jest.fn(),
+				} as any,
 			});
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
@@ -265,6 +268,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				})) as any,
 				data: {
 					addListener: addListenerMock,
+					setStyle: jest.fn(),
 				} as any,
 			});
 			const adapter = new TerraDrawGoogleMapsAdapter({
@@ -985,6 +989,26 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 			});
 
 			adapter.clear();
+		});
+		it("is clears data.setStyle function", () => {
+			const mockMap = createMockGoogleMap({
+				data: {
+					setStyle: jest.fn(),
+				} as any,
+			});
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getProjection: jest.fn(),
+					})),
+				} as any,
+				map: mockMap,
+			});
+
+			adapter.clear();
+
+			expect(mockMap.data.setStyle).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -507,6 +507,11 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			// Then clean up rendering
 			this.clearLayers();
 		}
+
+		// clean up any styles set on the default data layer
+		if (this._map.data) {
+			this._map.data.setStyle(null);
+		}
 	}
 
 	public getCoordinatePrecision(): number {


### PR DESCRIPTION
## Description of Changes
Handles data.setStyle cleanup on terra-draw teardown

## Link to Issue

Fixes #724 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented