### PR TITLE
feat(terra-draw): provide event type to getMapEventElement

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -182,13 +182,23 @@ export type TerraDrawStylingFunction = {
 	[mode: string]: (feature: GeoJSONStoreFeatures) => TerraDrawAdapterStyling;
 };
 
+export type TerraDrawHandledEvents = Extract<
+	keyof HTMLElementEventMap,
+	| "pointerdown"
+	| "pointerup"
+	| "pointermove"
+	| "contextmenu"
+	| "keyup"
+	| "keydown"
+>;
+
 export interface TerraDrawAdapter {
 	project: Project;
 	unproject: Unproject;
 	setCursor: SetCursor;
 	getLngLatFromEvent: GetLngLatFromEvent;
 	setDoubleClickToZoom: (enabled: boolean) => void;
-	getMapEventElement: () => HTMLElement;
+	getMapEventElement: (eventType?: TerraDrawHandledEvents) => HTMLElement;
 	register(callbacks: TerraDrawCallbacks): void;
 	unregister(): void;
 	render(changes: TerraDrawChanges, styling: TerraDrawStylingFunction): void;

--- a/packages/terra-draw/src/common/base.adapter.ts
+++ b/packages/terra-draw/src/common/base.adapter.ts
@@ -8,6 +8,7 @@ import {
 	TerraDrawStylingFunction,
 	GetLngLatFromEvent,
 	TerraDrawAdapter,
+	TerraDrawHandledEvents,
 } from "../common";
 import { limitPrecision } from "../geometry/limit-decimal-precision";
 import { cartesianDistance } from "../geometry/measure/pixel-distance";
@@ -70,7 +71,9 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 		"not-dragging";
 	protected _currentModeCallbacks: TerraDrawCallbacks | undefined;
 
-	public abstract getMapEventElement(): HTMLElement;
+	public abstract getMapEventElement(
+		eventType?: TerraDrawHandledEvents,
+	): HTMLElement;
 
 	protected getButton(event: PointerEvent | MouseEvent) {
 		if (event.button === -1) {
@@ -88,7 +91,12 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 	}
 
 	protected getMapElementXYPosition(event: PointerEvent | MouseEvent) {
-		const mapElement = this.getMapEventElement();
+		const mapElement = this.getMapEventElement(
+			event.type as Extract<
+				TerraDrawHandledEvents,
+				"pointerdown" | "pointerup" | "pointermove"
+			>,
+		);
 		const { left, top } = mapElement.getBoundingClientRect();
 
 		return {
@@ -179,10 +187,13 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 						: undefined;
 				},
 				register: (callback) => {
-					this.getMapEventElement().addEventListener("pointerdown", callback);
+					this.getMapEventElement("pointerdown").addEventListener(
+						"pointerdown",
+						callback,
+					);
 				},
 				unregister: (callback) => {
-					this.getMapEventElement().removeEventListener(
+					this.getMapEventElement("pointerdown").removeEventListener(
 						"pointerdown",
 						callback,
 					);
@@ -276,11 +287,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 					}
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("pointermove");
 					mapElement.addEventListener("pointermove", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("pointermove");
 					mapElement.removeEventListener("pointermove", callback);
 				},
 			}),
@@ -297,11 +308,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 					this._nextKeyUpIsContextMenu = true;
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("contextmenu");
 					mapElement.addEventListener("contextmenu", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("contextmenu");
 					mapElement.removeEventListener("contextmenu", callback);
 				},
 			}),
@@ -312,7 +323,7 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 						return;
 					}
 
-					if (event.target !== this.getMapEventElement()) {
+					if (event.target !== this.getMapEventElement("pointerup")) {
 						return;
 					}
 
@@ -362,11 +373,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 					this.setDraggability(true);
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("pointerup");
 					mapElement.addEventListener("pointerup", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("pointerup");
 					mapElement.removeEventListener("pointerup", callback);
 				},
 			}),
@@ -386,11 +397,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 					});
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keyup");
 					mapElement.addEventListener("keyup", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keyup");
 					mapElement.removeEventListener("keyup", callback);
 				},
 			}),
@@ -410,11 +421,11 @@ export abstract class TerraDrawBaseAdapter implements TerraDrawAdapter {
 					});
 				},
 				register: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keydown");
 					mapElement.addEventListener("keydown", callback);
 				},
 				unregister: (callback) => {
-					const mapElement = this.getMapEventElement();
+					const mapElement = this.getMapEventElement("keydown");
 					mapElement.removeEventListener("keydown", callback);
 				},
 			}),

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -19,6 +19,7 @@ import {
 	TerraDrawGeoJSONStore,
 	TerraDrawOnChangeContext,
 	Projection,
+	TerraDrawHandledEvents,
 } from "./common";
 import {
 	ModeTypes,
@@ -1325,6 +1326,7 @@ export {
 	type TerraDrawKeyboardEvent,
 
 	// TerraDrawBaseAdapter
+	type TerraDrawHandledEvents,
 	type TerraDrawChanges,
 	type TerraDrawStylingFunction,
 	type Project,


### PR DESCRIPTION
## Description of Changes

In order to correctly assign the keyboard events to the right div that Google Maps uses for keyboard events, we have to be able to distinguish which event is being fired. This PR sets the groundwork to allow this to happen.

## Link to Issue

#703 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 