### PR TITLE
fix(terra-draw): ensure that toLine and toCoordinate snapping works correctly in linestring mode

### DIFF
--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -468,6 +468,44 @@ describe("TerraDrawLineStringMode", () => {
 			expect(features[1].geometry.coordinates).toStrictEqual([2, 2]);
 		});
 
+		it("can snap from existing line once finished with snapping toLine and toCoordinate enabled", () => {
+			lineStringMode = new TerraDrawLineStringMode({
+				snapping: { toLine: true, toCoordinate: true },
+			});
+			const mockConfig = MockModeConfig(lineStringMode.mode);
+			onChange = mockConfig.onChange;
+			onFinish = mockConfig.onFinish;
+			store = mockConfig.store;
+
+			lineStringMode.register(mockConfig);
+			lineStringMode.start();
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 4, lat: 4 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 4, lat: 4 }));
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 8, lat: 8 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 8, lat: 8 }));
+
+			lineStringMode.onClick(MockCursorEvent({ lng: 8, lat: 8 }));
+
+			expect(onFinish).toHaveBeenCalledTimes(1);
+
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			const features = store.copyAll();
+			expect(features.length).toBe(2);
+
+			expect(features[1].geometry.type).toBe("Point");
+			expect(features[1].properties.snappingPoint).toBe(true);
+			expect(features[1].geometry.coordinates).toStrictEqual([
+				1.999389836, 2.000609297,
+			]);
+		});
+
 		it("can snap from existing line once finished with snapping toCustom enabled", () => {
 			const coordinates = [
 				[5, 5],

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -937,19 +937,24 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		}
 
 		if (this.snapping?.toCoordinate) {
+			let snapped: Position | undefined;
 			if (this.currentId) {
-				snappedCoordinate = this.coordinateSnapping.getSnappableCoordinate(
+				snapped = this.coordinateSnapping.getSnappableCoordinate(
 					event,
 					this.currentId,
 				);
 			} else {
-				snappedCoordinate =
+				snapped =
 					this.coordinateSnapping.getSnappableCoordinateFirstClick(event);
+			}
+
+			if (snapped) {
+				snappedCoordinate = snapped;
 			}
 		}
 
 		if (this.snapping?.toCustom) {
-			snappedCoordinate = this.snapping.toCustom(event, {
+			const snapped = this.snapping.toCustom(event, {
 				currentCoordinate: this.currentCoordinate,
 				currentId: this.currentId,
 				getCurrentGeometrySnapshot: this.currentId
@@ -961,6 +966,10 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				project: this.project,
 				unproject: this.unproject,
 			});
+
+			if (snapped) {
+				snappedCoordinate = snapped;
+			}
 		}
 
 		return snappedCoordinate;

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -430,7 +430,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		}
 
 		if (this.snapping?.toCustom) {
-			snappedCoordinate = this.snapping.toCustom(event, {
+			const snapped = this.snapping.toCustom(event, {
 				currentCoordinate: this.currentCoordinate,
 				currentId: this.currentId,
 				getCurrentGeometrySnapshot: this.currentId
@@ -440,6 +440,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				project: this.project,
 				unproject: this.unproject,
 			});
+
+			if (snapped) {
+				snappedCoordinate = snapped;
+			}
 		}
 
 		return snappedCoordinate;


### PR DESCRIPTION
## Description of Changes

Ensures that snapping to linestrings works as expected in TerraDrawLineStringMode

## Link to Issue

#739 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 