### PR TITLE
fix(terra-draw): ensure that rectangle mode cleanup can handle deleted geometries

### DIFF
--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -319,9 +319,11 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			this.setStarted();
 		}
 
-		if (cleanUpId !== undefined) {
-			this.mutateFeature.deleteFeature(cleanUpId);
-		}
+		try {
+			if (cleanUpId !== undefined) {
+				this.mutateFeature.deleteFeature(cleanUpId);
+			}
+		} catch {}
 	}
 
 	/** @internal */


### PR DESCRIPTION
## Description of Changes

Ensures that cleanup will not fail if the geometry for the rectangle has already been deleted

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 