### PR TITLE
fix(terra-draw-maplibre-gl-adapter): use MaplibreMap type definition for map prop of the constructor

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -111,8 +111,8 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 	});
 
 	describe("getLngLatFromEvent", () => {
-		let adapter: TerraDrawMapLibreGLAdapter<maplibregl.Map>;
-		const map = createMapLibreGLMap();
+		let adapter: TerraDrawMapLibreGLAdapter;
+		const map = createMapLibreGLMap() as maplibregl.Map;
 		beforeEach(() => {
 			adapter = new TerraDrawMapLibreGLAdapter({
 				map,

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -18,12 +18,10 @@ import {
 } from "maplibre-gl";
 import { Feature, LineString, Point, Polygon } from "geojson";
 
-export class TerraDrawMapLibreGLAdapter<
-	MapType,
-> extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawMapLibreGLAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
 	constructor(
 		config: {
-			map: MapType;
+			map: MaplibreMap;
 			renderBelowLayerId?: string;
 			prefixId?: string;
 		} & TerraDrawExtend.BaseAdapterConfig,


### PR DESCRIPTION
## Description of Changes

Instead of using `mapType` for `map` prop of maplibre adapter constructor options, I changed to use actual MaplibreMap type like what Mapbox adapter is doing.

https://github.com/JamesLMilner/terra-draw/blob/dd4b1091dd43302f6b7409b25cf5e96296549ea9/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.ts#L21-L28

## Link to Issue

#737

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 