### PR TITLE
fix(terra-draw): ensure that setMode can be called in onFinish

### DIFF
--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	Z_INDEX,
 	COMMON_PROPERTIES,
+	FinishActions,
 } from "../../common";
 import {
 	TerraDrawBaseDrawMode,
@@ -120,12 +121,14 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: "draw" },
+			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});
 
 		if (!updated) {
 			return;
 		}
+
+		const featureId = this.currentId;
 
 		this.currentCoordinate = 0;
 		this.currentId = undefined;
@@ -134,6 +137,11 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	/** @internal */
@@ -470,12 +478,6 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 }

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -136,6 +136,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 		if (!updated) {
 			return;
 		}
+		const featureId = this.currentCircleId;
 
 		this.cursorMovedAfterInitialCursorDown = false;
 		this.center = undefined;
@@ -146,6 +147,11 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	private beginDrawing(
@@ -450,12 +456,6 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 }

--- a/packages/terra-draw/src/modes/closing-points.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/closing-points.behavior.spec.ts
@@ -20,7 +20,6 @@ describe("ClosingPointsBehavior", () => {
 				config,
 				new PixelDistanceBehavior(config),
 				new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
 					validate: jest.fn(() => ({ valid: true })),
 				}),
 				new ReadFeatureBehavior(config),
@@ -38,7 +37,6 @@ describe("ClosingPointsBehavior", () => {
 				config,
 				new PixelDistanceBehavior(config),
 				new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
 					validate: jest.fn(() => ({ valid: true })),
 				}),
 				new ReadFeatureBehavior(config),

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	COMMON_PROPERTIES,
 	Z_INDEX,
+	FinishActions,
 } from "../../common";
 
 import {
@@ -119,12 +120,14 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: "draw" },
+			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});
 
 		if (!updated) {
 			return;
 		}
+
+		const featureId = this.currentId;
 
 		this.closingPoints.delete();
 
@@ -135,6 +138,11 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	/** @internal */
@@ -372,12 +380,6 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 		this.pixelDistance = new PixelDistanceBehavior(config);
 		this.closingPoints = new ClosingPointsBehavior(

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	COMMON_PROPERTIES,
 	Z_INDEX,
+	FinishActions,
 } from "../../common";
 
 import {
@@ -134,12 +135,16 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: "draw" },
+			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});
 
 		if (!updated) {
 			return;
 		}
+
+		const featureId = this.currentId;
+
+		this.mutateFeature.deleteFeatureIfPresent(this.closingPointId);
 
 		this.canClose = false;
 		this.currentId = undefined;
@@ -149,6 +154,11 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	/** @internal */
@@ -420,13 +430,6 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-				this.mutateFeature.deleteFeatureIfPresent(this.closingPointId);
-			},
 		});
 	}
 }

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -213,9 +213,16 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 			return;
 		}
 
+		const featureId = this.editedFeatureId;
+
 		this.setCursor(this.cursors.dragEnd);
 		this.editedFeatureId = undefined;
 		setMapDraggability(true);
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	registerBehaviors(config: BehaviorConfig) {
@@ -228,12 +235,6 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 		);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 
@@ -274,7 +275,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 	}
 
 	private onLeftClick(event: TerraDrawMouseEvent) {
-		this.mutateFeature.createPoint({
+		const feature = this.mutateFeature.createPoint({
 			coordinates: [event.lng, event.lat],
 			properties: {
 				mode: this.mode,
@@ -282,6 +283,13 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 			},
 			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});
+
+		if (feature) {
+			this.onFinish(feature.id, {
+				mode: this.mode,
+				action: FinishActions.Draw,
+			});
+		}
 	}
 
 	private onRightClick(event: TerraDrawMouseEvent) {

--- a/packages/terra-draw/src/modes/mutate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/mutate-feature.behavior.spec.ts
@@ -17,7 +17,6 @@ describe("mutateFeatureBehavior", () => {
 		it("constructs", () => {
 			new MutateFeatureBehavior(MockBehaviorConfig("test"), {
 				validate: undefined,
-				onFinish: jest.fn(),
 			});
 		});
 	});
@@ -29,7 +28,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const coords: Polygon["coordinates"][0] = [
@@ -57,7 +55,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				// @ts-expect-error testing missing id path
@@ -72,7 +69,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const pointId = createStorePoint(config);
@@ -95,7 +91,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original ring length 5
@@ -127,7 +122,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original ring length 5
@@ -160,7 +154,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original ring length 5
@@ -190,7 +183,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // ring length 5
@@ -227,7 +219,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				// original length 5: [ [0, 0], [0, 1], [1, 1], [1, 0], [0, 0]],
@@ -263,7 +254,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original length 5
@@ -285,7 +275,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original length 5
@@ -315,7 +304,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config); // original ring
@@ -348,7 +336,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config);
@@ -362,7 +349,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				// should not throw
@@ -373,7 +359,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config);
@@ -393,7 +378,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config);
@@ -407,7 +391,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const pointId = createStorePoint(config);
@@ -427,7 +410,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config);
@@ -445,14 +427,12 @@ describe("mutateFeatureBehavior", () => {
 				const configHigh = MockBehaviorConfig("test", "web-mercator", 9);
 				const behaviorHigh = new MutateFeatureBehavior(configHigh, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 				expect(behaviorHigh.epsilonOffset()).toBeCloseTo(0.000001, 10);
 
 				const configLow = MockBehaviorConfig("test", "web-mercator", 5);
 				const behaviorLow = new MutateFeatureBehavior(configLow, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 				expect(behaviorLow.epsilonOffset()).toBeCloseTo(0.0001, 10);
 			});
@@ -464,7 +444,6 @@ describe("mutateFeatureBehavior", () => {
 
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const coords = [
@@ -489,7 +468,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				// @ts-expect-error testing missing id path
@@ -505,7 +483,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const polygonId = createStorePolygon(config);
@@ -527,7 +504,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2: [[0,0],[0,1]]
@@ -555,7 +531,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2: [[0,0],[0,1]]
@@ -584,7 +559,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2: [[0,0],[0,1]]
@@ -609,7 +583,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2: [[0,0],[0,1]]
@@ -641,7 +614,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2
@@ -665,7 +637,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config); // original length 2
@@ -695,7 +666,6 @@ describe("mutateFeatureBehavior", () => {
 				const config = MockBehaviorConfig("test");
 				const behavior = new MutateFeatureBehavior(config, {
 					validate: undefined,
-					onFinish: jest.fn(),
 				});
 
 				const lineId = createStoreLineString(config);

--- a/packages/terra-draw/src/modes/mutate-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/mutate-feature.behavior.ts
@@ -18,7 +18,6 @@ import { ensureRightHandRule } from "../geometry/ensure-right-hand-rule";
 
 type MutateFeatureBehaviorOptions = {
 	validate: Validation | undefined;
-	onFinish: (featureId: FeatureId, context: FinishContext) => void;
 };
 
 export const Mutations = {
@@ -111,10 +110,6 @@ export class MutateFeatureBehavior extends TerraDrawModeBehavior {
 			geometry: { type: "Point", coordinates },
 			properties,
 		});
-
-		if (context?.updateType === UpdateTypes.Finish) {
-			this.options.onFinish(created.id, context as FinishContext);
-		}
 
 		return created;
 	}
@@ -353,8 +348,6 @@ export class MutateFeatureBehavior extends TerraDrawModeBehavior {
 					return null;
 				}
 			}
-
-			this.options.onFinish(featureId, context as FinishContext);
 		}
 
 		return feature;

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -216,9 +216,16 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			return;
 		}
 
+		const featureId = this.editedFeatureId;
+
 		this.setCursor(this.cursors.dragEnd);
 		this.editedFeatureId = undefined;
 		setMapDraggability(true);
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	registerBehaviors(config: BehaviorConfig) {
@@ -231,12 +238,6 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 		);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 
@@ -294,7 +295,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 	}
 
 	private onLeftClick(event: TerraDrawMouseEvent) {
-		this.mutateFeature.createPoint({
+		const feature = this.mutateFeature.createPoint({
 			coordinates: [event.lng, event.lat],
 			properties: {
 				mode: this.mode,
@@ -302,6 +303,13 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			},
 			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});
+
+		if (feature) {
+			this.onFinish(feature.id, {
+				mode: this.mode,
+				action: FinishActions.Draw,
+			});
+		}
 	}
 
 	private onRightClick(event: TerraDrawMouseEvent) {

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -143,7 +143,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	}
 
 	private close() {
-		if (!this.endPosition) {
+		if (!this.currentRectangleId || !this.endPosition) {
 			return;
 		}
 
@@ -153,6 +153,8 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			return;
 		}
 
+		const featureId = this.currentRectangleId;
+
 		this.startPosition = undefined;
 		this.currentRectangleId = undefined;
 		this.drawType = undefined;
@@ -160,6 +162,11 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	private beginDrawing(
@@ -391,12 +398,6 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 }

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	Z_INDEX,
 	COMMON_PROPERTIES,
+	FinishActions,
 } from "../../common";
 import { Polygon, Position } from "geojson";
 import {
@@ -137,13 +138,15 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 			},
 			context: {
 				updateType: UpdateTypes.Finish,
-				action: "draw",
+				action: FinishActions.Draw,
 			},
 		});
 
 		if (!updated) {
 			return;
 		}
+
+		const featureId = this.currentId;
 
 		this.currentCoordinate = 0;
 		this.currentId = undefined;
@@ -153,6 +156,11 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 		if (this.state === "drawing") {
 			this.setStarted();
 		}
+
+		this.onFinish(featureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
 	}
 
 	private getSectorCoordinates(event: TerraDrawMouseEvent) {
@@ -503,12 +511,6 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 	}
 }

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -22,8 +22,6 @@ describe("CoordinatePointBehavior", () => {
 				config,
 				new ReadFeatureBehavior(config),
 				new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
-
 					validate: jest.fn(() => ({ valid: true })),
 				}),
 			);
@@ -40,8 +38,6 @@ describe("CoordinatePointBehavior", () => {
 				config,
 				new ReadFeatureBehavior(config),
 				new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
-
 					validate: jest.fn(() => ({ valid: true })),
 				}),
 			);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -41,8 +41,6 @@ describe("DragCoordinateResizeBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -85,7 +83,6 @@ describe("DragCoordinateResizeBehavior", () => {
 			beforeEach(() => {
 				config = MockBehaviorConfig("test");
 				const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
 					validate,
 				});
 				const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -44,8 +44,6 @@ describe("DragCoordinateBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -102,7 +100,6 @@ describe("DragCoordinateBehavior", () => {
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
 				validate,
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -18,8 +18,6 @@ describe("DragFeatureBehavior", () => {
 			const config = MockBehaviorConfig("test");
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const selectionPointBehavior = new SelectionPointBehavior(
@@ -70,8 +68,6 @@ describe("DragFeatureBehavior", () => {
 				projection as "web-mercator" | "globe",
 			);
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: validate,
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
@@ -23,7 +23,6 @@ describe("MidPointBehavior", () => {
 	describe("constructor", () => {
 		it("constructs", () => {
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -49,7 +48,6 @@ describe("MidPointBehavior", () => {
 				jest.resetAllMocks();
 				config = MockBehaviorConfig("test");
 				const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-					onFinish: jest.fn(),
 					validate: jest.fn(() => ({ valid: true })),
 				});
 				const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -27,8 +27,6 @@ describe("RotateFeatureBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -68,8 +66,6 @@ describe("RotateFeatureBehavior", () => {
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -20,7 +20,6 @@ describe("ScaleFeatureBehavior", () => {
 		it("constructs", () => {
 			const config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -63,8 +62,6 @@ describe("ScaleFeatureBehavior", () => {
 			config = MockBehaviorConfig("test");
 
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
-
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
@@ -19,7 +19,6 @@ describe("SelectionPointBehavior", () => {
 		it("constructs", () => {
 			config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
@@ -35,7 +34,6 @@ describe("SelectionPointBehavior", () => {
 		beforeEach(() => {
 			config = MockBehaviorConfig("test");
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
-				onFinish: jest.fn(),
 				validate: jest.fn(() => ({ valid: true })),
 			});
 			const readFeatureBehavior = new ReadFeatureBehavior(config);

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -247,12 +247,6 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 				return this.validations[mode](feature, context);
 			},
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, {
-					mode: this.mode,
-					action: context.action,
-				});
-			},
 		});
 
 		this.pixelDistance = new PixelDistanceBehavior(config);

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -8,6 +8,7 @@ import {
 	UpdateTypes,
 	Z_INDEX,
 	COMMON_PROPERTIES,
+	FinishActions,
 } from "../../common";
 import { LineString, Point, Polygon, Position } from "geojson";
 import {
@@ -399,9 +400,6 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
-			onFinish: (featureId, context) => {
-				this.onFinish(featureId, { mode: this.mode, action: context.action });
-			},
 		});
 	}
 
@@ -426,13 +424,15 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 						.coordinates,
 					type: Mutations.Replace,
 				},
-				context: { updateType: UpdateTypes.Finish, action: "draw" },
+				context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 			});
 
 			if (!updated) {
 				return;
 			}
 		}
+
+		const featureId = this.currentId;
 
 		this.mutateFeature.deleteFeatureIfPresent(finishedCurrentStartingPointId);
 		this.mutateFeature.deleteFeatureIfPresent(finishedInitialArcId);
@@ -446,6 +446,10 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 		// Go back to started state
 		if (this.state === "drawing") {
 			this.setStarted();
+		}
+
+		if (featureId) {
+			this.onFinish(featureId, { mode: this.mode, action: FinishActions.Draw });
 		}
 	}
 

--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -3996,6 +3996,65 @@ describe("Terra Draw", () => {
 				expect(draw.getSnapshot()).toHaveLength(0);
 				expect(draw.stop).toHaveBeenCalledTimes(1);
 			});
+
+			it("setMode to static does not clear current features", async () => {
+				const polygonMode = new TerraDrawPolygonMode();
+				const draw = new TerraDraw({
+					adapter,
+					modes: [polygonMode],
+				});
+
+				jest.spyOn(draw, "stop");
+
+				draw.start();
+
+				draw.on("finish", () => {
+					draw.setMode("static");
+				});
+
+				draw.setMode("polygon");
+
+				polygonMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000001, lat: 0.000001 }));
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000002, lat: 0.000002 }));
+
+				// Close the polygon
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000002, lat: 0.000002 }));
+
+				const features = draw.getSnapshot();
+				expect(features).toHaveLength(1);
+				expect(features[0].geometry.type).toBe("Polygon");
+			});
+
+			it("setMode to static does not clear current features", async () => {
+				const polygonMode = new TerraDrawPolygonMode();
+				const lineStringMode = new TerraDrawLineStringMode();
+				const draw = new TerraDraw({
+					adapter,
+					modes: [polygonMode, lineStringMode],
+				});
+
+				jest.spyOn(draw, "stop");
+
+				draw.start();
+
+				draw.on("finish", () => {
+					draw.setMode("linestring");
+				});
+
+				draw.setMode("polygon");
+
+				polygonMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000001, lat: 0.000001 }));
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000002, lat: 0.000002 }));
+
+				// Close the polygon
+				polygonMode.onClick(MockCursorEvent({ lng: 0.000002, lat: 0.000002 }));
+
+				const features = draw.getSnapshot();
+				expect(features).toHaveLength(1);
+				expect(features[0].geometry.type).toBe("Polygon");
+			});
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

I noticed that `cleanUp` was being called from `setMode` when you use it in a callback in onFinish. However in the current approach that means it happens before the close is finished. This whole approach is just proving to be way to complicated and error prone, so I am removing onFinish from `MutateFeatureBehavior` and just handling at the end of the onClick, onDragEnd etc.

## Link to Issue

No specific issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 