### PR TITLE
fix(terra-draw): fix midpoint not being update correctly on coordinate drag

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -46,7 +46,6 @@ describe("DragCoordinateResizeBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
@@ -88,7 +87,6 @@ describe("DragCoordinateResizeBehavior", () => {
 				const readFeatureBehavior = new ReadFeatureBehavior(config);
 				const selectionPointBehavior = new SelectionPointBehavior(
 					config,
-					readFeatureBehavior,
 					mutateFeatureBehavior,
 				);
 				const pixelDistanceBehavior = new PixelDistanceBehavior(config);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -49,7 +49,6 @@ describe("DragCoordinateBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
@@ -105,7 +104,6 @@ describe("DragCoordinateBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const pixelDistanceBehavior = new PixelDistanceBehavior(config);
@@ -196,6 +194,28 @@ describe("DragCoordinateBehavior", () => {
 		});
 
 		describe("drag", () => {
+			it("updates the previous midpoint with index -1 when dragging index 0", () => {
+				const id = createStorePolygon(config);
+
+				dragCoordinateBehavior.startDragging(id, 0);
+
+				const midPointSpy = jest.spyOn(
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					(dragCoordinateBehavior as any).midPoints,
+					"updateOneAtIndex",
+				);
+
+				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
+					toCoordinate: false,
+				});
+
+				// First call should be the "previous" midpoint update.
+				expect(midPointSpy).toHaveBeenNthCalledWith(1, -1, expect.any(Array));
+
+				// Sanity: we should also update the midpoint at index 0.
+				expect(midPointSpy).toHaveBeenCalledWith(0, expect.any(Array));
+			});
+
 			it("returns early if nothing is being dragged", () => {
 				jest.spyOn(config.store, "updateGeometry");
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -268,8 +268,12 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		}
 
 		// Perform the update to the midpoints and selection points
+		if (index > 0) {
+			this.midPoints.updateOneAtIndex(index - 1, updatedCoordinates);
+		} else {
+			this.midPoints.updateOneAtIndex(-1, updatedCoordinates);
+		}
 		this.midPoints.updateOneAtIndex(index, updatedCoordinates);
-		this.midPoints.updateOneAtIndex(index + 1, updatedCoordinates);
 		this.selectionPoints.updateOneAtIndex(index, updatedCoordinate);
 		this.coordinatePoints.updateOneAtIndex(featureId, index, updatedCoordinate);
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -22,7 +22,6 @@ describe("DragFeatureBehavior", () => {
 			});
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(
@@ -73,7 +72,6 @@ describe("DragFeatureBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const featureAtPointerEventBehavior = new FeatureAtPointerEventBehavior(

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
@@ -28,11 +28,7 @@ describe("MidPointBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			midPointBehavior = new MidPointBehavior(
 				config,
-				new SelectionPointBehavior(
-					config,
-					readFeatureBehavior,
-					mutateFeatureBehavior,
-				),
+				new SelectionPointBehavior(config, mutateFeatureBehavior),
 				new CoordinatePointBehavior(
 					config,
 					readFeatureBehavior,
@@ -53,11 +49,7 @@ describe("MidPointBehavior", () => {
 				const readFeatureBehavior = new ReadFeatureBehavior(config);
 				midPointBehavior = new MidPointBehavior(
 					config,
-					new SelectionPointBehavior(
-						config,
-						readFeatureBehavior,
-						mutateFeatureBehavior,
-					),
+					new SelectionPointBehavior(config, mutateFeatureBehavior),
 					new CoordinatePointBehavior(
 						config,
 						readFeatureBehavior,
@@ -232,6 +224,58 @@ describe("MidPointBehavior", () => {
 								selectionPoint: true,
 								selectionPointFeatureId: expect.any(String),
 							});
+						});
+					});
+
+					describe("updateOneAtIndex", () => {
+						it("should return undefined if index is negative and out of bounds", () => {
+							// no midpoints exist
+							const result = midPointBehavior.updateOneAtIndex(-1, [
+								[0, 0],
+								[0, 1],
+							]);
+
+							expect(result).toBe(undefined);
+						});
+
+						it("should update the final midpoint when using index -1", () => {
+							const createdId = createStorePolygon(config);
+
+							// This closed polygon ring generates 4 midpoints
+							midPointBehavior.create({
+								featureCoordinates: [
+									[0, 0],
+									[0, 1],
+									[1, 1],
+									[1, 0],
+									[0, 0],
+								],
+								featureId: createdId,
+							});
+
+							// New polygon coordinates so we can assert midpoint changes
+							const updatedCoords: Position[] = [
+								[0, 0],
+								[0, 2],
+								[2, 2],
+								[2, 0],
+								[0, 0],
+							];
+
+							// Capture current last midpoint coordinate
+							const lastMidPointId =
+								midPointBehavior.ids[midPointBehavior.ids.length - 1];
+							const lastMidPointBefore = config.store.getGeometryCopy(
+								lastMidPointId,
+							).coordinates as Position;
+
+							midPointBehavior.updateOneAtIndex(-1, updatedCoords);
+
+							const lastMidPointAfter = config.store.getGeometryCopy(
+								lastMidPointId,
+							).coordinates as Position;
+
+							expect(lastMidPointAfter).not.toEqual(lastMidPointBefore);
 						});
 					});
 

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.ts
@@ -187,9 +187,15 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 		index: number,
 		featureCoordinates: Position[] | Position[][],
 	) {
+		if (index < 0) {
+			// -1 would be the final index
+			index = this._midPoints.length + index;
+		}
+
 		if (this._midPoints[index] === undefined) {
 			return undefined;
 		}
+
 		const coordinates = getClosedCoordinates(featureCoordinates);
 		const midpoints = getMidPointCoordinates(
 			this.getMidpointConfig(coordinates),

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -32,7 +32,6 @@ describe("RotateFeatureBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const coordinatePointBehavior = new CoordinatePointBehavior(
@@ -71,7 +70,6 @@ describe("RotateFeatureBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const coordinatePointBehavior = new CoordinatePointBehavior(

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -25,7 +25,6 @@ describe("ScaleFeatureBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const coordinatePointBehavior = new CoordinatePointBehavior(
@@ -67,7 +66,6 @@ describe("ScaleFeatureBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			const selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 			const coordinatePointBehavior = new CoordinatePointBehavior(

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
@@ -24,7 +24,6 @@ describe("SelectionPointBehavior", () => {
 			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 		});
@@ -36,10 +35,8 @@ describe("SelectionPointBehavior", () => {
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
 				validate: jest.fn(() => ({ valid: true })),
 			});
-			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			selectionPointBehavior = new SelectionPointBehavior(
 				config,
-				readFeatureBehavior,
 				mutateFeatureBehavior,
 			);
 		});

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
@@ -16,16 +16,13 @@ export type SelectionPointProperties = {
 export class SelectionPointBehavior extends TerraDrawModeBehavior {
 	constructor(
 		config: BehaviorConfig,
-		readFeatureBehavior: ReadFeatureBehavior,
 		mutateFeatureBehavior: MutateFeatureBehavior,
 	) {
 		super(config);
 		this.mutateFeature = mutateFeatureBehavior;
-		this.readFeature = readFeatureBehavior;
 	}
 
 	private mutateFeature: MutateFeatureBehavior;
-	private readFeature: ReadFeatureBehavior;
 
 	private _selectionPoints: FeatureId[] = [];
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -259,7 +259,6 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 		this.selectionPoints = new SelectionPointBehavior(
 			config,
-			this.readFeature,
 			this.mutateFeature,
 		);
 		this.coordinatePoints = new CoordinatePointBehavior(


### PR DESCRIPTION
## Description of Changes

Midpoints were not updating as expected when coordinates on a polygon are dragged

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 