### PR TITLE
fix(terra-draw): ensure points do not set marker property to true

### DIFF
--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -164,6 +164,20 @@ describe("TerraDrawPointMode", () => {
 				"create",
 				undefined,
 			);
+
+			const features = mockConfig.store.copyAll();
+			expect(features.length).toBe(1);
+
+			expect(features[0]).toEqual({
+				type: "Feature",
+				id: expect.any(String),
+				geometry: { type: "Point", coordinates: [0, 0] },
+				properties: {
+					mode: pointMode.mode,
+					createdAt: expect.any(Number),
+					updatedAt: expect.any(Number),
+				},
+			});
 		});
 
 		it("right click can delete a point if editable is true", () => {
@@ -278,7 +292,7 @@ describe("TerraDrawPointMode", () => {
 				const pointMode = new TerraDrawPointMode({
 					validation: (feature) => {
 						return {
-							valid: feature.properties[COMMON_PROPERTIES.MARKER] === true,
+							valid: feature.properties[COMMON_PROPERTIES.MARKER] === undefined,
 						};
 					},
 				});

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -299,7 +299,6 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			coordinates: [event.lng, event.lat],
 			properties: {
 				mode: this.mode,
-				[COMMON_PROPERTIES.MARKER]: true,
 			},
 			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
 		});


### PR DESCRIPTION
## Description of Changes

Fixes an issue where points were incorrectly recieving a `marker` property being set to true.

## Link to Issue

#780 


## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 