### PR TITLE
fix(terra-draw): ensure resizable updates coordinate and midpoints correctly

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -29,7 +29,6 @@ import {
 	MutateFeatureBehavior,
 	Mutations,
 } from "../../mutate-feature.behavior";
-import { getUnclosedCoordinates } from "../../../geometry/get-coordinates";
 
 export type ResizeOptions =
 	| "center"
@@ -738,7 +737,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 
 		const featureId = feature.id as FeatureId;
 
-		let updated: GeoJSONStoreFeatures | null = null;
+		let updated: GeoJSONStoreFeatures<Polygon | LineString> | null = null;
 
 		if (feature.geometry.type === "Polygon") {
 			updated = this.mutateFeature.updatePolygon({
@@ -768,9 +767,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			return false;
 		}
 
-		const featureCoordinates = getUnclosedCoordinates(
-			feature.geometry.coordinates,
-		);
+		const featureCoordinates = updated.geometry.coordinates;
 
 		// Perform the update to the midpoints and selection points
 		this.midPoints.updateAllInPlace({ featureCoordinates });


### PR DESCRIPTION
## Description of Changes

Fixes issue where resizable was not updating coordinates and midpoints as expected

## Link to Issue

 https://github.com/JamesLMilner/terra-draw/issues/792

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 