### PR TITLE
chore(terra-draw-arcgis-adapter): add support for polygon outline opacity

### DIFF
--- a/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
+++ b/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
@@ -278,6 +278,10 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawExtend.TerraDrawBase
 				});
 				break;
 			case "Polygon":
+				const polygonOutlineOpacity = (
+					style as { polygonOutlineOpacity?: number }
+				).polygonOutlineOpacity;
+
 				geometry = new this._lib.Polygon({ rings: coordinates });
 				symbol = new this._lib.SimpleFillSymbol({
 					color: this.getColorFromHex(
@@ -285,7 +289,10 @@ export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawExtend.TerraDrawBase
 						style.polygonFillOpacity,
 					),
 					outline: {
-						color: this.getColorFromHex(style.polygonOutlineColor),
+						color: this.getColorFromHex(
+							style.polygonOutlineColor,
+							polygonOutlineOpacity,
+						),
 						width: style.polygonOutlineWidth + "px",
 					},
 				});


### PR DESCRIPTION
## Description of Changes

Adds polygon opacity outline support for the TerraDrawArcGISAdapter

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 