### PR TITLE
chore(terra-draw): use Node v24 and npm 11 where possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Run linting
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Run unused code checking
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Build terra-draw
@@ -58,7 +58,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Build terra-draw
@@ -82,7 +82,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Ensure no package-lock.json changes
@@ -109,7 +109,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Build terra-draw
@@ -126,7 +126,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: "22.x"
+        node-version: "24.x"
     - name: Install parent directory
       run: npm ci
     - name: Build terra-draw
@@ -164,7 +164,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install Parent Folder
         run: npm ci
       - name: Benchmark

--- a/.github/workflows/commit-lint-prs.yml
+++ b/.github/workflows/commit-lint-prs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
       - name: Install packages
         run: npm ci
       - name: PR Conventional Commit Validation Against Commit Lint Config

--- a/.github/workflows/terra-draw-arcgis-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-arcgis-adapter-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-google-maps-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-google-maps-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-google-maps-adapter-release.yml
+++ b/.github/workflows/terra-draw-google-maps-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-dry-run-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-openlayers-adapter-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-release-dry-run.yml
+++ b/.github/workflows/terra-draw-release-dry-run.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/.github/workflows/terra-draw-release.yml
+++ b/.github/workflows/terra-draw-release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/guides/7.DEVELOPMENT.md
+++ b/guides/7.DEVELOPMENT.md
@@ -7,8 +7,8 @@ How to develop the Terra Draw project locally.
 You will need to have the following installed:
 
 - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Node.js v22.x](https://nodejs.org/en/download/)
-- [npm v10.x](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [Node.js v24.x](https://nodejs.org/en/download/)
+- [npm v11.x](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 ## Folder Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
 			"resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.31.6.tgz",
 			"integrity": "sha512-+NSYtEJy/wRQcEX+f5OHBhg4MX26HeZFYghd7+VMTasalHUAD3y9PPiakLIfhahX/4EiSLuy25m1P93BBlybXg==",
 			"license": "SEE LICENSE IN copyright.txt",
+			"peer": true,
 			"dependencies": {
 				"@esri/arcgis-html-sanitizer": "~4.1.0-next.4",
 				"@esri/calcite-colors": "~6.1.0",
@@ -134,6 +135,7 @@
 			"integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.0",
@@ -2495,6 +2497,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2518,6 +2521,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3249,7 +3253,8 @@
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
 			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@gerrit0/mini-shiki": {
 			"version": "3.15.0",
@@ -4204,8 +4209,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
 			"version": "4.46.0",
@@ -4219,8 +4223,7 @@
 			"optional": true,
 			"os": [
 				"android"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.46.0",
@@ -4234,8 +4237,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
 			"version": "4.46.0",
@@ -4249,8 +4251,7 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
 			"version": "4.46.0",
@@ -4264,8 +4265,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
 			"version": "4.46.0",
@@ -4279,8 +4279,7 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
 			"version": "4.46.0",
@@ -4294,8 +4293,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
 			"version": "4.46.0",
@@ -4309,8 +4307,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
 			"version": "4.46.0",
@@ -4324,8 +4321,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
 			"version": "4.46.0",
@@ -4339,8 +4335,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
 			"version": "4.53.2",
@@ -4368,8 +4363,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
 			"version": "4.46.0",
@@ -4383,8 +4377,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
 			"version": "4.46.0",
@@ -4398,8 +4391,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
 			"version": "4.46.0",
@@ -4413,8 +4405,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
 			"version": "4.46.0",
@@ -4428,8 +4419,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
 			"version": "4.46.0",
@@ -4443,8 +4433,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
 			"version": "4.46.0",
@@ -4458,8 +4447,7 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
 			"version": "4.53.2",
@@ -4487,8 +4475,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
 			"version": "4.46.0",
@@ -4502,8 +4489,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
 			"version": "4.53.2",
@@ -4531,8 +4517,7 @@
 			"optional": true,
 			"os": [
 				"win32"
-			],
-			"peer": true
+			]
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
 			"version": "3.15.0",
@@ -5294,6 +5279,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.17"
@@ -5339,7 +5325,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5357,7 +5342,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5375,7 +5359,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5393,7 +5376,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5411,7 +5393,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5429,7 +5410,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5447,7 +5427,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5465,7 +5444,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5483,7 +5461,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5501,7 +5478,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -5713,6 +5689,7 @@
 			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -5804,7 +5781,6 @@
 			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -5978,6 +5954,7 @@
 			"integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -6152,6 +6129,7 @@
 			"integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.17.0",
 				"@typescript-eslint/types": "8.17.0",
@@ -6619,7 +6597,6 @@
 			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.13.2",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -6630,24 +6607,21 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
 			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
 			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
 			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.13.2",
@@ -6655,7 +6629,6 @@
 			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -6667,8 +6640,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
 			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.14.1",
@@ -6676,7 +6648,6 @@
 			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -6690,7 +6661,6 @@
 			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -6701,7 +6671,6 @@
 			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -6711,8 +6680,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
 			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.14.1",
@@ -6720,7 +6688,6 @@
 			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -6738,7 +6705,6 @@
 			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -6753,7 +6719,6 @@
 			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -6767,7 +6732,6 @@
 			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -6783,7 +6747,6 @@
 			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
@@ -6800,16 +6763,14 @@
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/@zeit/schemas": {
 			"version": "2.36.0",
@@ -6857,6 +6818,7 @@
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6935,6 +6897,7 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -6952,7 +6915,6 @@
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -6971,7 +6933,6 @@
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			},
@@ -7710,6 +7671,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001688",
 				"electron-to-chromium": "^1.5.73",
@@ -8057,7 +8019,6 @@
 			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -8897,6 +8858,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
 			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -8906,6 +8868,7 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
 			"integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"meow": "^13.0.0"
 			},
@@ -9012,6 +8975,7 @@
 			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
@@ -9317,8 +9281,7 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
@@ -10154,8 +10117,7 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
 			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.0.0",
@@ -10218,6 +10180,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -10314,6 +10277,7 @@
 			"integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -10374,6 +10338,7 @@
 			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -10627,7 +10592,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -11575,8 +11539,7 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -13177,6 +13140,7 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -13219,6 +13183,7 @@
 			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/environment": "^29.7.0",
 				"@jest/expect": "^29.7.0",
@@ -13653,6 +13618,7 @@
 			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/environment": "^29.7.0",
 				"@jest/fake-timers": "^29.7.0",
@@ -13892,6 +13858,7 @@
 			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/console": "^29.7.0",
 				"@jest/environment": "^29.7.0",
@@ -14211,18 +14178,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/jiti": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-			"integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
 		"node_modules/joi": {
@@ -14554,7 +14509,8 @@
 			"version": "1.9.4",
 			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
 			"integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"peer": true
 		},
 		"node_modules/lerc": {
 			"version": "3.0.0",
@@ -14700,7 +14656,6 @@
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -17605,6 +17560,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -18581,6 +18537,7 @@
 			"integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18591,6 +18548,7 @@
 			"integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.26.0"
 			},
@@ -19136,6 +19094,7 @@
 			"integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -19620,7 +19579,6 @@
 			"integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -19658,7 +19616,6 @@
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
@@ -19668,8 +19625,7 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/secure-compare": {
 			"version": "3.0.1",
@@ -20254,6 +20210,7 @@
 			"integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@storybook/core": "8.6.15"
 			},
@@ -20679,6 +20636,7 @@
 			"integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.8.2",
@@ -20698,7 +20656,6 @@
 			"integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
@@ -20734,7 +20691,6 @@
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -20750,7 +20706,6 @@
 			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -20771,7 +20726,6 @@
 			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -20782,7 +20736,6 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -21180,6 +21133,7 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -21412,6 +21366,7 @@
 			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -21756,7 +21711,6 @@
 			"integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -21824,7 +21778,6 @@
 			"os": [
 				"aix"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21842,7 +21795,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21860,7 +21812,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21878,7 +21829,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21896,7 +21846,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21914,7 +21863,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21932,7 +21880,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21950,7 +21897,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21968,7 +21914,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -21986,7 +21931,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22004,7 +21948,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22022,7 +21965,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22040,7 +21982,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22058,7 +21999,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22076,7 +22016,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22094,7 +22033,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22112,7 +22050,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22130,7 +22067,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22148,7 +22084,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22166,7 +22101,6 @@
 			"os": [
 				"sunos"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22184,7 +22118,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22202,7 +22135,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22220,7 +22152,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -22232,7 +22163,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -22271,7 +22201,6 @@
 			"integrity": "sha512-ONmkT3Ud3IfW15nl7l4qAZko5/2iZ5ALVBDh02ZSZ5IGVLJSYkRcRa3iB58VyEIyoofs9m2xdVrm+lTi97+3pw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -22469,7 +22398,6 @@
 			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -22511,7 +22439,6 @@
 			"integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.6",
@@ -22559,7 +22486,6 @@
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -22577,7 +22503,6 @@
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -22592,7 +22517,6 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -23076,6 +23000,7 @@
 			"integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -23814,6 +23739,7 @@
 			"integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}


### PR DESCRIPTION
## Description of Changes

Uses Node v24 and npm 11 where appropriate across GitHub Actions and docs

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 