### PR TITLE
fix(terra-draw-google-maps-adapter): set ids to strings to avoid incorrect rendering

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -125,7 +125,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			throw new Error("Styling function not defined");
 		}
 
-		const id = feature.getId();
+		const id = String(feature.getId());
 
 		// Style callback has been called for a feature that is not rendered
 		if (!this.renderedFeatureIds.has(id as string)) {


### PR DESCRIPTION
## Description of Changes

If ids were set to numbers in the TerraDrawGoogleMapsAdapter it renders the features incorrectly

<img width="686" height="498" alt="Screenshot 2026-02-10 at 21 59 20" src="https://github.com/user-attachments/assets/86864c43-a845-4cc3-8608-af671ef5d4b1" />

## Link to Issue

#809 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 