### PR TITLE
chore(terra-draw): use OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/terra-draw-release.yml
+++ b/.github/workflows/terra-draw-release.yml
@@ -2,6 +2,7 @@ name: terra-draw Release
 
 permissions:
   contents: write
+  id-token: write  # Required for OIDC
 
 on: workflow_dispatch
 
@@ -64,5 +65,4 @@ jobs:
 
       - run: npm publish
         working-directory: ./packages/terra-draw
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+ 


### PR DESCRIPTION
## Description of Changes

Uses OIDC trusted publishing for npm releases

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 