### PR TITLE
chore(terra-draw): skip testing in dist folders

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
 	testPathIgnorePatterns: [
+		"<rootDir>/packages/.*/dist/",
 		"<rootDir>/node_modules/",
 		"<rootDir>/packages/e2e/",
 		"<rootDir>/packages/packages/",
@@ -14,6 +15,7 @@ module.exports = {
 		"<rootDir>/guides/",
 	],
 	coveragePathIgnorePatterns: [
+		"<rootDir>/packages/.*/dist/",
 		"<rootDir>/packages/.*/src/test",
 		"<rootDir>/packages/e2e/",
 		"<rootDir>/packages/storybook/",


### PR DESCRIPTION
## Description of Changes

Running build then testing will cause failures as jest attempts to test the dist folder. This PR prevents this.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 