### PR TITLE
chore(terra-draw): add way to disable coverage threshold when developing locally

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,12 @@
-// eslint-disable-next-line no-console
-console.log("===== Using ts-jest ======");
+/* eslint-disable no-console */
+
+const CoverageThreshold = process.env.COVERAGE_THRESHOLD !== "false";
+
+console.log("Loading Jest configuration...");
+console.log("Using ts-jest");
+console.log(
+	`Coverage threshold is ${CoverageThreshold ? "enabled" : "disabled"}\n`,
+);
 
 module.exports = {
 	preset: "ts-jest",
@@ -22,12 +29,14 @@ module.exports = {
 	],
 	collectCoverage: true,
 	collectCoverageFrom: ["<rootDir>/packages/**/src/**"],
-	coverageThreshold: {
-		global: {
-			lines: 80,
-			functions: 80,
-			branches: 80,
-			statements: 80,
-		},
-	},
+	coverageThreshold: CoverageThreshold
+		? {
+				global: {
+					lines: 80,
+					functions: 80,
+					branches: 80,
+					statements: 80,
+				},
+			}
+		: undefined,
 };

--- a/jest.nocheck.config.ts
+++ b/jest.nocheck.config.ts
@@ -1,5 +1,7 @@
-// eslint-disable-next-line no-console
-console.log("===== Using @swc/jest ======");
+/* eslint-disable no-console */
+
+console.log("Loading Jest configuration...");
+console.log("Using ts-jest");
 
 module.exports = {
 	transform: {


### PR DESCRIPTION
## Description of Changes

When testing against one file, the threshold will not be met which can get tedious when developing locally. Passing COVERAGE_THRESHOLD will turn off coverage limits for jest when running npm run test.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 