### PR TITLE
feat(terra-draw): emit the update type when updating a geometry

### DIFF
--- a/guides/6.EVENTS.md
+++ b/guides/6.EVENTS.md
@@ -158,6 +158,16 @@ draw.on("deselect", () => {
 });
 ```
 
+# Store Change Events
+
+ The "change" event types that are emitted by the store "delete", "create", "update", "styling". Context can also be passed with these events, which can be used to determine the origin of the event and the type of update. The context is an object that can have the following properties: `origin`, `target` and `updateType`. The `origin` property can be "api" or not set to imply internal changes that are generally originating from user actions. The `target` property can be "geometry" or "properties". The `updateType` property should only be passed when the change type is "update", the possible can be "provisional", "commit" or "finish". Here is an overview of the 3 `updateType` emitted:
+
+- "provisional" updates are those that are not yet committed too, such as a scenario where the pointer is moved whilst drawing and having a provisional point that follows the cursor. Similarly if a point was dragged, but the pointer is not yet released this would also be considered provisional. "provisional" is essentially any update which is not yet committed too and could change again shortly. 
+
+- "commit" updates are those that are made when an interaction is completed, such as adding a point whilst drawing, or when the pointer is released after dragging a point, or scaling a feature but there are still further updates to come before the feature is considered finished. 
+
+- "finish" updates are those that are made when an interaction is completed and the changes to the feature are finalized for the current session of interactions. For example, when drawing a polygon and the user clicks to add the final point and complete the polygon, this would be a "finish" update. Similarly, if a feature is being scaled and the user releases the pointer and there are no further updates to be made to the feature, this would also be a "finish" update.
+
 ---
 
 **Guides**

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -106,8 +106,13 @@ export type Actions = (typeof FinishActions)[keyof typeof FinishActions];
 export type OnFinishContext = { mode: string; action: Actions };
 
 export type TerraDrawOnChangeContext =
-	| { origin: "api"; target?: "geometry" | "properties" }
-	| { target?: "geometry" | "properties" };
+	| {
+			origin: "api";
+			target?: "geometry" | "properties";
+			updateType: UpdateTypes;
+	  }
+	| { origin: "api" }
+	| { target?: "geometry" | "properties"; updateType: UpdateTypes };
 
 export type TerraDrawGeoJSONStore = GeoJSONStore<
 	TerraDrawOnChangeContext | undefined,

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -122,7 +122,7 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {

--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -662,7 +662,7 @@ describe("TerraDrawCircleMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			const updatedFeature = store.copyAll()[0];
@@ -916,14 +916,14 @@ describe("TerraDrawCircleMode", () => {
 						2,
 						[expect.any(String)],
 						"update",
-						{ target: "geometry" },
+						{ target: "geometry", updateType: "provisional" },
 					);
 
 					expect(onChange).toHaveBeenNthCalledWith(
 						3,
 						[expect.any(String)],
 						"update",
-						{ target: "properties" },
+						{ target: "properties", updateType: "provisional" },
 					);
 
 					const updatedFeature = store.copyAll()[0];

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -443,12 +443,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 					}
 				: undefined,
 			propertyMutations,
-			context: isFinish
-				? {
-						updateType,
-						action: FinishActions.Draw,
-					}
-				: { updateType },
+			context: { updateType },
 		});
 	}
 

--- a/packages/terra-draw/src/modes/closing-points.behavior.ts
+++ b/packages/terra-draw/src/modes/closing-points.behavior.ts
@@ -1,6 +1,6 @@
 import { Position } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
-import { COMMON_PROPERTIES, TerraDrawMouseEvent } from "../common";
+import { COMMON_PROPERTIES, TerraDrawMouseEvent, UpdateTypes } from "../common";
 import { PixelDistanceBehavior } from "./pixel-distance.behavior";
 import { MutateFeatureBehavior } from "./mutate-feature.behavior";
 import { FeatureId } from "../extend";
@@ -65,36 +65,45 @@ export class ClosingPointsBehavior extends TerraDrawModeBehavior {
 	}
 
 	public updateOne(index: number, updatedCoordinate: Position) {
-		this.mutateFeatureBehavior.updateGuidancePoints([
-			{
-				featureId: this.ids[index],
-				coordinate: updatedCoordinate,
-			},
-		]);
+		this.mutateFeatureBehavior.updateGuidancePoints(
+			[
+				{
+					featureId: this.ids[index],
+					coordinate: updatedCoordinate,
+				},
+			],
+			UpdateTypes.Provisional,
+		);
 	}
 
 	public update(updatedCoordinates: Position[] | Position[][]) {
 		const coordinates = getClosedCoordinates(updatedCoordinates);
 
 		if (this.ids.length === 1) {
-			this.mutateFeatureBehavior.updateGuidancePoints([
-				{
-					featureId: this.ids[0],
-					coordinate: coordinates[coordinates.length - 2],
-				},
-			]);
+			this.mutateFeatureBehavior.updateGuidancePoints(
+				[
+					{
+						featureId: this.ids[0],
+						coordinate: coordinates[coordinates.length - 2],
+					},
+				],
+				UpdateTypes.Provisional,
+			);
 			return;
 		} else if (this.ids.length === 2) {
-			this.mutateFeatureBehavior.updateGuidancePoints([
-				{
-					featureId: this.ids[0],
-					coordinate: coordinates[0],
-				},
-				{
-					featureId: this.ids[1],
-					coordinate: coordinates[coordinates.length - 3],
-				},
-			]);
+			this.mutateFeatureBehavior.updateGuidancePoints(
+				[
+					{
+						featureId: this.ids[0],
+						coordinate: coordinates[0],
+					},
+					{
+						featureId: this.ids[1],
+						coordinate: coordinates[coordinates.length - 3],
+					},
+				],
+				UpdateTypes.Provisional,
+			);
 		}
 	}
 

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
@@ -540,19 +540,19 @@ describe("TerraDrawFreehandLineStringMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					5,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "finish" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					6,

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -123,7 +123,7 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
@@ -857,13 +857,13 @@ describe("TerraDrawFreehandMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "finish" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					5,

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -300,7 +300,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			propertyMutations: {
 				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -239,7 +239,7 @@ describe("TerraDrawLineStringMode", () => {
 				2,
 				[featureId],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 
 			const coordinatePoints = mockConfig.store.copyAllWhere(
@@ -336,10 +336,13 @@ describe("TerraDrawLineStringMode", () => {
 
 			expect(onSnapshot).toHaveBeenCalledTimes(2);
 			expect(onSnapshot).toHaveBeenNthCalledWith(1, null);
-			expect(onSnapshot).toHaveBeenNthCalledWith(
-				2,
-				expect.objectContaining({ type: "LineString" }),
-			);
+			expect(onSnapshot).toHaveBeenNthCalledWith(2, {
+				type: "LineString",
+				coordinates: [
+					[0, 0],
+					[0, 0],
+				],
+			});
 		});
 	});
 
@@ -883,6 +886,7 @@ describe("TerraDrawLineStringMode", () => {
 
 			expect(onChange).toHaveBeenCalledWith([lineString.id], "update", {
 				target: "geometry",
+				updateType: "finish",
 			});
 
 			// Verify coordinate has been removed
@@ -995,13 +999,13 @@ describe("TerraDrawLineStringMode", () => {
 					1,
 					[lineStringFeature.id],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "commit" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					2,
 					[closingPointFeature.id],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -1242,10 +1246,12 @@ describe("TerraDrawLineStringMode", () => {
 
 				expect(onChange).toHaveBeenNthCalledWith(1, [lineString.id], "update", {
 					target: "geometry",
+					updateType: "finish",
 				});
 
 				expect(onChange).toHaveBeenNthCalledWith(2, [lineString.id], "update", {
 					target: "properties",
+					updateType: "finish",
 				});
 
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -1503,19 +1509,19 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				2,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 				3,
 				[expect.any(String)],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "provisional" },
 			);
 
 			const allFeatures = mockConfig.store.copyAll();
@@ -1660,7 +1666,7 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[expect.any(String)],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "finish" },
 			);
 
 			// Remove the edit drag point
@@ -2089,7 +2095,7 @@ describe("TerraDrawLineStringMode", () => {
 				1,
 				[snapPoint!.id],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			expect(mockConfig.store.has(snapPoint!.id as FeatureId)).toBe(true);

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -195,6 +195,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 					this.coordinatePoints.createOrUpdate({
 						featureId: feature.id as FeatureId,
 						featureCoordinates: feature.geometry.coordinates as Position[],
+						updateType: UpdateTypes.Commit,
 					});
 				});
 			} else if (this.coordinatePoints && this.showCoordinatePoints === false) {
@@ -235,12 +236,15 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 		if (snappedCoordinate) {
 			if (this.snappedPointId) {
-				this.mutateFeature.updateGuidancePoints([
-					{
-						featureId: this.snappedPointId,
-						coordinate: snappedCoordinate,
-					},
-				]);
+				this.mutateFeature.updateGuidancePoints(
+					[
+						{
+							featureId: this.snappedPointId,
+							coordinate: snappedCoordinate,
+						},
+					],
+					UpdateTypes.Provisional,
+				);
 			} else {
 				this.snappedPointId = this.mutateFeature.createGuidancePoint({
 					coordinate: snappedCoordinate,
@@ -265,7 +269,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 		const updated = this.mutateFeature.updateLineString({
 			featureId: this.currentId,
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 			coordinateMutations: [
 				{
 					type: Mutations.Delete,
@@ -285,6 +289,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Finish,
 			});
 		}
 
@@ -373,6 +378,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: created.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 	}
@@ -408,6 +414,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -454,6 +461,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -567,6 +575,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Provisional,
 			});
 		}
 	}
@@ -624,13 +633,14 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		const updated = this.mutateFeature.updateLineString({
 			featureId,
 			coordinateMutations: [{ type: Mutations.Delete, index: coordinateIndex }],
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Edit },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (updated && this.showCoordinatePoints) {
 			this.coordinatePoints.createOrUpdate({
 				featureId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -833,6 +843,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 					this.coordinatePoints.createOrUpdate({
 						featureId: this.editedFeatureId,
 						featureCoordinates: updated.geometry.coordinates,
+						updateType: UpdateTypes.Provisional,
 					});
 				}
 				// Else we are only updating one point
@@ -841,6 +852,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 						this.editedFeatureId,
 						this.editedFeatureCoordinateIndex,
 						[event.lng, event.lat],
+						UpdateTypes.Provisional,
 					);
 				}
 			}
@@ -864,6 +876,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 				this.coordinatePoints.createOrUpdate({
 					featureId: this.editedFeatureId,
 					featureCoordinates: inserted.geometry.coordinates,
+					updateType: UpdateTypes.Provisional,
 				});
 			}
 
@@ -878,12 +891,15 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		}
 
 		if (this.editedPointId) {
-			this.mutateFeature.updateGuidancePoints([
-				{
-					featureId: this.editedPointId,
-					coordinate: [event.lng, event.lat],
-				},
-			]);
+			this.mutateFeature.updateGuidancePoints(
+				[
+					{
+						featureId: this.editedPointId,
+						coordinate: [event.lng, event.lat],
+					},
+				],
+				UpdateTypes.Provisional,
+			);
 		}
 
 		this.mutateFeature.updateLineString({
@@ -911,7 +927,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 		const updated = this.mutateFeature.updateLineString({
 			featureId: this.editedFeatureId,
 			propertyMutations: { [COMMON_PROPERTIES.EDITED]: false },
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Edit },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {
@@ -1173,6 +1189,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: feature.id as FeatureId,
 				featureCoordinates: feature.geometry.coordinates as Position[],
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -1215,6 +1232,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.coordinatePoints.createOrUpdate({
 				featureId: feature.id as FeatureId,
 				featureCoordinates: feature.geometry.coordinates as Position[],
+				updateType: UpdateTypes.Commit,
 			});
 		}
 	}

--- a/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
@@ -487,7 +487,7 @@ describe("TerraDrawMarkerMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			// On finished called from onClick and is then only called after onDragEnd

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -206,7 +206,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 				mode: this.mode,
 				[COMMON_PROPERTIES.EDITED]: false,
 			},
-			context: { updateType: UpdateTypes.Finish, action: "edit" },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {
@@ -281,7 +281,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 				mode: this.mode,
 				[COMMON_PROPERTIES.MARKER]: true,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (feature) {

--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -464,7 +464,7 @@ describe("TerraDrawPointMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			// On finished called from onClick and is then only called after onDragEnd

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -211,7 +211,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 				mode: this.mode,
 				[COMMON_PROPERTIES.EDITED]: false,
 			},
-			context: { updateType: UpdateTypes.Finish, action: "edit" },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {
@@ -316,7 +316,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 			properties: {
 				mode: this.mode,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (feature) {

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -321,7 +321,7 @@ describe("TerraDrawPolygonMode", () => {
 				2,
 				[featureId],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 
 			const coordinatePoints = mockConfig.store.copyAllWhere(
@@ -378,7 +378,7 @@ describe("TerraDrawPolygonMode", () => {
 				2,
 				[featureId],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 		});
 
@@ -461,7 +461,7 @@ describe("TerraDrawPolygonMode", () => {
 				2,
 				[featureId],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 		});
 
@@ -597,7 +597,7 @@ describe("TerraDrawPolygonMode", () => {
 				1,
 				[snapPoint!.id],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			expect(mockConfig.store.has(snapPoint!.id as FeatureId)).toBe(true);
@@ -1295,22 +1295,26 @@ describe("TerraDrawPolygonMode", () => {
 			polygonMode.onClick(thirdPoint);
 
 			// Polygon is now closed and corrected to right hand rule
-			expect(store.updateGeometry).toHaveBeenNthCalledWith(8, [
-				{
-					geometry: {
-						coordinates: [
-							[
-								[1, 1],
-								[3, 3],
-								[2, 2],
-								[1, 1],
+			expect(store.updateGeometry).toHaveBeenNthCalledWith(
+				8,
+				[
+					{
+						geometry: {
+							coordinates: [
+								[
+									[1, 1],
+									[3, 3],
+									[2, 2],
+									[1, 1],
+								],
 							],
-						],
-						type: "Polygon",
+							type: "Polygon",
+						},
+						id: expect.any(String),
 					},
-					id: expect.any(String),
-				},
-			]);
+				],
+				{ updateType: "finish" },
+			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
 			expect(onFinish).toHaveBeenNthCalledWith(1, expect.any(String), {
@@ -2077,13 +2081,13 @@ describe("onDrag", () => {
 			1,
 			[expect.any(String)],
 			"update",
-			{ target: "geometry" },
+			{ target: "geometry", updateType: "provisional" },
 		);
 		expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 			2,
 			[expect.any(String)],
 			"update",
-			{ target: "properties" },
+			{ target: "properties", updateType: "provisional" },
 		);
 
 		const allFeatures = mockConfig.store.copyAll();
@@ -2214,19 +2218,19 @@ describe("onDrag", () => {
 			1,
 			[expect.any(String)],
 			"update",
-			{ target: "geometry" },
+			{ target: "geometry", updateType: "provisional" },
 		);
 		expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 			2,
 			[expect.any(String)],
 			"update",
-			{ target: "properties" },
+			{ target: "properties", updateType: "provisional" },
 		);
 		expect(mockConfig.onChange).toHaveBeenNthCalledWith(
 			3,
 			[expect.any(String)],
 			"update",
-			{ target: "geometry" },
+			{ target: "geometry", updateType: "provisional" },
 		);
 
 		const allFeatures = mockConfig.store.copyAll();
@@ -2323,20 +2327,28 @@ describe("onDrag", () => {
 		expect(coordinatePoints[1].geometry.coordinates).toStrictEqual([1, 1]);
 
 		expect(mockConfig.store.updateProperty).toHaveBeenCalledTimes(2);
-		expect(mockConfig.store.updateProperty).toHaveBeenNthCalledWith(1, [
-			{
-				id: expect.any(String),
-				property: "edited",
-				value: true,
-			},
-		]);
-		expect(mockConfig.store.updateProperty).toHaveBeenNthCalledWith(2, [
-			{
-				id: expect.any(String),
-				property: "coordinatePointIds",
-				value: coordinatePointIds,
-			},
-		]);
+		expect(mockConfig.store.updateProperty).toHaveBeenNthCalledWith(
+			1,
+			[
+				{
+					id: expect.any(String),
+					property: "edited",
+					value: true,
+				},
+			],
+			{ updateType: "provisional" },
+		);
+		expect(mockConfig.store.updateProperty).toHaveBeenNthCalledWith(
+			2,
+			[
+				{
+					id: expect.any(String),
+					property: "coordinatePointIds",
+					value: coordinatePointIds,
+				},
+			],
+			{ updateType: "commit" },
+		);
 	});
 });
 
@@ -2396,7 +2408,7 @@ describe("onDragEnd", () => {
 			1,
 			[expect.any(String)],
 			"update",
-			{ target: "properties" },
+			{ target: "properties", updateType: "finish" },
 		);
 
 		// Remove the edit drag point

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -182,6 +182,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					this.coordinatePoints.createOrUpdate({
 						featureId: feature.id as FeatureId,
 						featureCoordinates: feature.geometry.coordinates as Position[][],
+						updateType: UpdateTypes.Commit,
 					});
 				});
 			} else if (this.coordinatePoints && this.showCoordinatePoints === false) {
@@ -226,7 +227,6 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			},
 			context: {
 				updateType: UpdateTypes.Finish,
-				action: FinishActions.Draw,
 			},
 		});
 
@@ -238,6 +238,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Finish,
 			});
 		}
 
@@ -319,12 +320,15 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 		if (snappedCoordinate) {
 			if (this.snappedPointId) {
-				this.mutateFeature.updateGuidancePoints([
-					{
-						featureId: this.snappedPointId,
-						coordinate: snappedCoordinate,
-					},
-				]);
+				this.mutateFeature.updateGuidancePoints(
+					[
+						{
+							featureId: this.snappedPointId,
+							coordinate: snappedCoordinate,
+						},
+					],
+					UpdateTypes.Provisional,
+				);
 			} else {
 				this.snappedPointId = this.mutateFeature.createGuidancePoint({
 					coordinate: snappedCoordinate,
@@ -418,6 +422,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.coordinatePoints.createOrUpdate({
 				featureId: this.currentId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Provisional,
 			});
 		}
 	}
@@ -547,7 +552,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		const updated = this.mutateFeature.updatePolygon({
 			featureId,
 			coordinateMutations,
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Edit },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {
@@ -558,6 +563,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.coordinatePoints.createOrUpdate({
 				featureId,
 				featureCoordinates: updated.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -615,6 +621,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				this.coordinatePoints.createOrUpdate({
 					featureId: id,
 					featureCoordinates: geometry.coordinates,
+					updateType: UpdateTypes.Commit,
 				});
 			}
 
@@ -655,6 +662,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				this.coordinatePoints.createOrUpdate({
 					featureId: this.currentId,
 					featureCoordinates: updated.geometry.coordinates,
+					updateType: UpdateTypes.Commit,
 				});
 			}
 
@@ -695,6 +703,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				this.coordinatePoints.createOrUpdate({
 					featureId: this.currentId,
 					featureCoordinates: updated.geometry.coordinates,
+					updateType: UpdateTypes.Commit,
 				});
 			}
 
@@ -745,6 +754,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					this.coordinatePoints.createOrUpdate({
 						featureId: this.currentId,
 						featureCoordinates: updated.geometry.coordinates,
+						updateType: UpdateTypes.Commit,
 					});
 				}
 
@@ -962,6 +972,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 				this.coordinatePoints.createOrUpdate({
 					featureId: this.editedFeatureId,
 					featureCoordinates: updated.geometry.coordinates,
+					updateType: UpdateTypes.Provisional,
 				});
 			}
 			// Else we are only updating one point
@@ -970,6 +981,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 					this.editedFeatureId,
 					this.editedFeatureCoordinateIndex,
 					updated.geometry.coordinates[0][this.editedFeatureCoordinateIndex],
+					UpdateTypes.Provisional,
 				);
 			}
 		}
@@ -980,12 +992,15 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 		}
 
 		if (this.editedPointId) {
-			this.mutateFeature.updateGuidancePoints([
-				{
-					featureId: this.editedPointId,
-					coordinate: eventCoordinate,
-				},
-			]);
+			this.mutateFeature.updateGuidancePoints(
+				[
+					{
+						featureId: this.editedPointId,
+						coordinate: eventCoordinate,
+					},
+				],
+				UpdateTypes.Provisional,
+			);
 		}
 	}
 
@@ -1009,7 +1024,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			propertyMutations: {
 				[COMMON_PROPERTIES.EDITED]: false,
 			},
-			context: { updateType: UpdateTypes.Finish, action: FinishActions.Edit },
+			context: { updateType: UpdateTypes.Finish },
 		});
 
 		if (!updated) {
@@ -1226,6 +1241,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.coordinatePoints.createOrUpdate({
 				featureId: feature.id as FeatureId,
 				featureCoordinates: feature.geometry.coordinates as Position[][],
+				updateType: UpdateTypes.Commit,
 			});
 		}
 	}
@@ -1239,6 +1255,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.coordinatePoints.createOrUpdate({
 				featureId: feature.id as FeatureId,
 				featureCoordinates: feature.geometry.coordinates as Position[][],
+				updateType: UpdateTypes.Commit,
 			});
 		}
 

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -325,13 +325,13 @@ describe("TerraDrawRectangleMode", () => {
 						2,
 						[expect.any(String)],
 						"update",
-						{ target: "geometry" },
+						{ target: "geometry", updateType: "finish" },
 					);
 					expect(onChange).toHaveBeenNthCalledWith(
 						3,
 						[expect.any(String)],
 						"update",
-						{ target: "properties" },
+						{ target: "properties", updateType: "finish" },
 					);
 
 					expect(onFinish).toHaveBeenCalledTimes(1);
@@ -487,7 +487,7 @@ describe("TerraDrawRectangleMode", () => {
 				2,
 				[expect.any(String)],
 				"update",
-				{ target: "geometry" },
+				{ target: "geometry", updateType: "provisional" },
 			);
 
 			const updatedFeature = store.copyAll()[0];
@@ -732,7 +732,7 @@ describe("TerraDrawRectangleMode", () => {
 						2,
 						[expect.any(String)],
 						"update",
-						{ target: "geometry" },
+						{ target: "geometry", updateType: "provisional" },
 					);
 
 					const updatedFeature = store.copyAll()[0];

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -28,7 +28,6 @@ import {
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
 import { BehaviorConfig } from "../base.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
-import { ReadFeatureBehavior } from "../read-feature.behavior";
 
 type TerraDrawRectangleModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
@@ -72,7 +71,6 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 	// Behaviors
 	private mutateFeature!: MutateFeatureBehavior;
-	private readFeature!: ReadFeatureBehavior;
 
 	constructor(
 		options?: TerraDrawRectangleModeOptions<RectanglePolygonStyling>,
@@ -134,12 +132,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 						[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
 					}
 				: {},
-			context: isFinish
-				? {
-						updateType,
-						action: FinishActions.Draw,
-					}
-				: { updateType },
+			context: { updateType },
 		});
 	}
 
@@ -402,7 +395,6 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	}
 
 	registerBehaviors(config: BehaviorConfig) {
-		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
 		});

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -138,7 +138,6 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 			},
 			context: {
 				updateType: UpdateTypes.Finish,
-				action: FinishActions.Draw,
 			},
 		});
 

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -1,5 +1,5 @@
 import { Feature, Position } from "geojson";
-import { COMMON_PROPERTIES } from "../../../common";
+import { COMMON_PROPERTIES, UpdateTypes } from "../../../common";
 import { GeoJSONStoreFeatures, JSONObject } from "../../../store/store";
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { MockPolygonSquare } from "../../../test/mock-features";
@@ -58,6 +58,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: mockPolygon.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 
 			const properties = config.store.getPropertiesCopy(featureId);
@@ -100,6 +101,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: mockPolygon.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 
 			const properties = config.store.getPropertiesCopy(featureId);
@@ -110,6 +112,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: mockPolygon.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 			const propertiesAfterDelete = config.store.getPropertiesCopy(featureId);
 			const coordinatePointIdsAfterDelete =
@@ -155,7 +158,11 @@ describe("CoordinatePointBehavior", () => {
 			] as Position[];
 
 			expect(config.store.has(featureId)).toBe(true);
-			coordinatePointBehavior.createOrUpdate({ featureId, featureCoordinates });
+			coordinatePointBehavior.createOrUpdate({
+				featureId,
+				featureCoordinates,
+				updateType: UpdateTypes.Commit,
+			});
 
 			const properties = config.store.getPropertiesCopy(featureId);
 			expect(properties).toBeDefined();
@@ -174,6 +181,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: featureCoordinatesUpdated,
+				updateType: UpdateTypes.Commit,
 			});
 
 			// Ensure all coordinate points are updated
@@ -204,6 +212,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: mockPolygon.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 
 			const properties = config.store.getPropertiesCopy(featureId);
@@ -237,6 +246,7 @@ describe("CoordinatePointBehavior", () => {
 			coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates: mockPolygon.geometry.coordinates,
+				updateType: UpdateTypes.Commit,
 			});
 
 			const properties = config.store.getPropertiesCopy(featureId);

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
@@ -18,9 +18,11 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 	public createOrUpdate({
 		featureId,
 		featureCoordinates,
+		updateType,
 	}: {
 		featureId: FeatureId;
 		featureCoordinates: Position[] | Position[][];
+		updateType: UpdateTypes;
 	}) {
 		// Handle the edge case where the feature is deleted before create or update
 		if (!this.readFeature.hasFeature(featureId)) {
@@ -87,7 +89,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 					});
 				});
 
-				this.mutateFeature.updateGuidancePoints(updates);
+				this.mutateFeature.updateGuidancePoints(updates, updateType);
 			}
 		}
 		// If the existing coordinate points are not present in the store, delete them and recreate
@@ -120,6 +122,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 		featureId: FeatureId,
 		index: number,
 		updatedCoordinate: Position,
+		updateType: UpdateTypes,
 	) {
 		const featureProperties = this.readFeature.getProperties(featureId);
 		const coordinatePointIds =
@@ -133,20 +136,25 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 			return;
 		}
 
-		this.mutateFeature.updateGuidancePoints([
-			{
-				featureId: coordinatePointIds[index],
-				coordinate: updatedCoordinate,
-			},
-		]);
+		this.mutateFeature.updateGuidancePoints(
+			[
+				{
+					featureId: coordinatePointIds[index],
+					coordinate: updatedCoordinate,
+				},
+			],
+			updateType,
+		);
 	}
 
 	public updateAllInPlace({
 		featureId,
 		featureCoordinates,
+		updateType,
 	}: {
 		featureId: FeatureId;
 		featureCoordinates: Position[] | Position[][];
+		updateType: UpdateTypes;
 	}) {
 		const featureProperties = this.readFeature.getProperties(featureId);
 
@@ -167,6 +175,7 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 				featureId: id,
 				coordinate: coordinates[i],
 			})),
+			updateType,
 		);
 	}
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -13,6 +13,7 @@ import { MockCursorEvent } from "../../../test/mock-cursor-event";
 import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MutateFeatureBehavior } from "../../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../../read-feature.behavior";
+import { UpdateTypes } from "../../../common";
 
 describe("DragCoordinateResizeBehavior", () => {
 	const createLineString = (
@@ -175,6 +176,7 @@ describe("DragCoordinateResizeBehavior", () => {
 					dragMaintainedShapeBehavior.drag(
 						MockCursorEvent({ lng: 0, lat: 0 }),
 						"center",
+						UpdateTypes.Provisional,
 					);
 
 					expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -187,6 +189,7 @@ describe("DragCoordinateResizeBehavior", () => {
 					dragMaintainedShapeBehavior.drag(
 						MockCursorEvent({ lng: 0, lat: 0 }),
 						"center",
+						UpdateTypes.Provisional,
 					);
 
 					expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -205,6 +208,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -222,6 +226,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -239,6 +244,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -253,6 +259,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -270,6 +277,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"opposite",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -284,6 +292,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						coordinatePointBehavior.createOrUpdate({
 							featureId: id,
 							featureCoordinates: featureCoordinatesBefore,
+							updateType: UpdateTypes.Commit,
 						});
 						selectionPointBehavior.create({
 							featureId: id,
@@ -315,6 +324,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: -1, lat: -1 }),
 							"opposite",
+							UpdateTypes.Provisional,
 						);
 
 						const coordinatePoints = readFeatureBehavior.getProperties(id)
@@ -369,6 +379,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"opposite",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -386,6 +397,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center-fixed",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -400,6 +412,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center-fixed",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -417,6 +430,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"opposite-fixed",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
@@ -431,6 +445,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.drag(
 							MockCursorEvent({ lng: 0, lat: 0 }),
 							"opposite-fixed",
+							UpdateTypes.Provisional,
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -697,6 +697,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	public drag(
 		event: TerraDrawMouseEvent,
 		resizeOption: ResizeOptions,
+		updateType: UpdateTypes,
 	): boolean {
 		if (!this.draggedCoordinate.id) {
 			return false;
@@ -747,7 +748,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 					coordinates: [updatedCoords],
 				},
 				context: {
-					updateType: UpdateTypes.Provisional as const,
+					updateType,
 				},
 			});
 		} else if (feature.geometry.type === "LineString") {
@@ -758,7 +759,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 					coordinates: updatedCoords,
 				},
 				context: {
-					updateType: UpdateTypes.Provisional as const,
+					updateType,
 				},
 			});
 		}
@@ -770,9 +771,13 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const featureCoordinates = updated.geometry.coordinates;
 
 		// Perform the update to the midpoints and selection points
-		this.midPoints.updateAllInPlace({ featureCoordinates });
-		this.selectionPoints.updateAllInPlace({ featureCoordinates });
-		this.coordinatePoints.updateAllInPlace({ featureId, featureCoordinates });
+		this.midPoints.updateAllInPlace({ featureCoordinates, updateType });
+		this.selectionPoints.updateAllInPlace({ featureCoordinates, updateType });
+		this.coordinatePoints.updateAllInPlace({
+			featureId,
+			featureCoordinates,
+			updateType,
+		});
 
 		return true;
 	}

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.spec.ts
@@ -1,4 +1,5 @@
 import { Position } from "geojson";
+import { UpdateTypes } from "../../../common";
 import {
 	createStorePoint,
 	createStorePolygon,
@@ -207,23 +208,42 @@ describe("DragCoordinateBehavior", () => {
 					"updateOneAtIndex",
 				);
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				// First call should be the "previous" midpoint update.
-				expect(midPointSpy).toHaveBeenNthCalledWith(1, -1, expect.any(Array));
+				expect(midPointSpy).toHaveBeenNthCalledWith(
+					1,
+					-1,
+					expect.any(Array),
+					UpdateTypes.Provisional,
+				);
 
 				// Sanity: we should also update the midpoint at index 0.
-				expect(midPointSpy).toHaveBeenCalledWith(0, expect.any(Array));
+				expect(midPointSpy).toHaveBeenCalledWith(
+					0,
+					expect.any(Array),
+					UpdateTypes.Provisional,
+				);
 			});
 
 			it("returns early if nothing is being dragged", () => {
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -232,9 +252,14 @@ describe("DragCoordinateBehavior", () => {
 				createStorePoint(config);
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -248,9 +273,14 @@ describe("DragCoordinateBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -264,9 +294,14 @@ describe("DragCoordinateBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
@@ -278,9 +313,14 @@ describe("DragCoordinateBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
@@ -309,26 +349,30 @@ describe("DragCoordinateBehavior", () => {
 					true,
 
 					{ toCoordinate: true },
+					UpdateTypes.Provisional,
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[
-									[1, 1],
-									[0, 1],
-									[1, 1],
-									[1, 0],
-									[1, 1],
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[1, 1],
+										[0, 1],
+										[1, 1],
+										[1, 0],
+										[1, 1],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 
 			it("snaps the LineString coordinate if there is a nearby coordinate to snap to and toCoordinate snapping is true", () => {
@@ -349,21 +393,25 @@ describe("DragCoordinateBehavior", () => {
 					MockCursorEvent({ lng: 0.5, lat: 0.5 }),
 					true,
 					{ toCoordinate: true },
+					UpdateTypes.Provisional,
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[1, 1], // [0, 0] -> [1, 1]
-								[0, 1],
-							],
-							type: "LineString",
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[1, 1], // [0, 0] -> [1, 1]
+									[0, 1],
+								],
+								type: "LineString",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 
 			it("does not snap the LineString coordinate if there is a nearby coordinate to snap to and toCoordinate snapping is false", () => {
@@ -385,21 +433,25 @@ describe("DragCoordinateBehavior", () => {
 					true,
 
 					{ toCoordinate: false },
+					UpdateTypes.Provisional,
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[0.5, 0.5],
-								[0, 1],
-							],
-							type: "LineString",
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[0.5, 0.5],
+									[0, 1],
+								],
+								type: "LineString",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 
 			it("snaps the Polygon coordinate if there is a nearby line to snap to and toLine snapping is true", () => {
@@ -426,26 +478,30 @@ describe("DragCoordinateBehavior", () => {
 					true,
 
 					{ toLine: true },
+					UpdateTypes.Provisional,
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[
-									[1, 1],
-									[0, 1],
-									[1, 1],
-									[1, 0],
-									[1, 1],
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[1, 1],
+										[0, 1],
+										[1, 1],
+										[1, 0],
+										[1, 1],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 
 			it("does not snap the Polygon coordinate if there is a nearby coordinate to snap to and toCoordinate snapping is false", () => {
@@ -470,26 +526,30 @@ describe("DragCoordinateBehavior", () => {
 					true,
 
 					{ toCoordinate: false },
+					UpdateTypes.Provisional,
 				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[
-									[0.5, 0.5],
-									[0, 1],
-									[1, 1],
-									[1, 0],
-									[0.5, 0.5],
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[0.5, 0.5],
+										[0, 1],
+										[1, 1],
+										[1, 0],
+										[0.5, 0.5],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 
 			it("updates the LineString coordinate if within pointer distance", () => {
@@ -498,9 +558,14 @@ describe("DragCoordinateBehavior", () => {
 
 				dragCoordinateBehavior.startDragging(id, 0);
 
-				dragCoordinateBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }), true, {
-					toCoordinate: false,
-				});
+				dragCoordinateBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					true,
+					{
+						toCoordinate: false,
+					},
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
@@ -525,6 +590,7 @@ describe("DragCoordinateBehavior", () => {
 					false,
 
 					{ toCoordinate: false },
+					UpdateTypes.Provisional,
 				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -545,6 +611,7 @@ describe("DragCoordinateBehavior", () => {
 					MockCursorEvent({ lng: 100, lat: 0 }),
 					false,
 					{ toCoordinate: false },
+					UpdateTypes.Provisional,
 				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -174,6 +174,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		event: TerraDrawMouseEvent,
 		allowSelfIntersection: boolean,
 		snapping: Snapping,
+		updateType: UpdateTypes,
 	): boolean {
 		const draggedFeatureId = this.draggedCoordinate.id;
 
@@ -254,7 +255,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 					coordinates: [updatedCoordinates],
 				},
 				context: {
-					updateType: UpdateTypes.Provisional as const,
+					updateType,
 				},
 			});
 		} else if (geometry.type === "LineString") {
@@ -265,7 +266,7 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 					coordinates: updatedCoordinates,
 				},
 				context: {
-					updateType: UpdateTypes.Provisional as const,
+					updateType,
 				},
 			});
 		}
@@ -276,13 +277,22 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 
 		// Perform the update to the midpoints and selection points
 		if (index > 0) {
-			this.midPoints.updateOneAtIndex(index - 1, updatedCoordinates);
+			this.midPoints.updateOneAtIndex(
+				index - 1,
+				updatedCoordinates,
+				updateType,
+			);
 		} else {
-			this.midPoints.updateOneAtIndex(-1, updatedCoordinates);
+			this.midPoints.updateOneAtIndex(-1, updatedCoordinates, updateType);
 		}
-		this.midPoints.updateOneAtIndex(index, updatedCoordinates);
-		this.selectionPoints.updateOneAtIndex(index, updatedCoordinate);
-		this.coordinatePoints.updateOneAtIndex(featureId, index, updatedCoordinate);
+		this.midPoints.updateOneAtIndex(index, updatedCoordinates, updateType);
+		this.selectionPoints.updateOneAtIndex(index, updatedCoordinate, updateType);
+		this.coordinatePoints.updateOneAtIndex(
+			featureId,
+			index,
+			updatedCoordinate,
+			updateType,
+		);
 
 		return true;
 	}

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.spec.ts
@@ -11,6 +11,7 @@ import { DragFeatureBehavior } from "./drag-feature.behavior";
 import { FeatureAtPointerEventBehavior } from "./feature-at-pointer-event.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
+import { UpdateTypes } from "../../../common";
 
 describe("DragFeatureBehavior", () => {
 	describe("constructor", () => {
@@ -136,7 +137,7 @@ describe("DragFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragFeatureBehavior.drag(event);
+				dragFeatureBehavior.drag(event, UpdateTypes.Provisional);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -149,7 +150,10 @@ describe("DragFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragFeatureBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }));
+				dragFeatureBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 
@@ -179,7 +183,10 @@ describe("DragFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragFeatureBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }));
+				dragFeatureBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -192,7 +199,10 @@ describe("DragFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				dragFeatureBehavior.drag(MockCursorEvent({ lng: 0, lat: 0 }));
+				dragFeatureBehavior.drag(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.spec.ts
@@ -11,6 +11,7 @@ import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MidPointBehavior } from "./midpoint.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
+import { UpdateTypes } from "../../../common";
 
 describe("MidPointBehavior", () => {
 	let config: BehaviorConfig;
@@ -137,6 +138,7 @@ describe("MidPointBehavior", () => {
 								[1, 1],
 								[1, 0],
 							],
+							updateType: UpdateTypes.Commit,
 						});
 
 						expect(result).toBe(undefined);
@@ -162,6 +164,7 @@ describe("MidPointBehavior", () => {
 								[2, 2],
 								[2, 3],
 							],
+							updateType: UpdateTypes.Commit,
 						});
 
 						const result = midPointBehavior.ids.map(
@@ -233,10 +236,14 @@ describe("MidPointBehavior", () => {
 					describe("updateOneAtIndex", () => {
 						it("should return undefined if index is negative and out of bounds", () => {
 							// no midpoints exist
-							const result = midPointBehavior.updateOneAtIndex(-1, [
-								[0, 0],
-								[0, 1],
-							]);
+							const result = midPointBehavior.updateOneAtIndex(
+								-1,
+								[
+									[0, 0],
+									[0, 1],
+								],
+								UpdateTypes.Commit,
+							);
 
 							expect(result).toBe(undefined);
 						});
@@ -272,7 +279,11 @@ describe("MidPointBehavior", () => {
 								lastMidPointId,
 							).coordinates as Position;
 
-							midPointBehavior.updateOneAtIndex(-1, updatedCoords);
+							midPointBehavior.updateOneAtIndex(
+								-1,
+								updatedCoords,
+								UpdateTypes.Commit,
+							);
 
 							const lastMidPointAfter = config.store.getGeometryCopy(
 								lastMidPointId,

--- a/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/midpoint.behavior.ts
@@ -120,6 +120,7 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 			this.coordinatePointBehavior.createOrUpdate({
 				featureId,
 				featureCoordinates,
+				updateType: UpdateTypes.Commit,
 			});
 		}
 
@@ -183,8 +184,10 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 
 	public updateAllInPlace({
 		featureCoordinates,
+		updateType,
 	}: {
 		featureCoordinates: Position[] | Position[][];
+		updateType: UpdateTypes;
 	}) {
 		if (this._midPoints.length === 0) {
 			return undefined;
@@ -200,12 +203,14 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 				featureId: id,
 				coordinate: midpoints[i],
 			})),
+			updateType,
 		);
 	}
 
 	public updateOneAtIndex(
 		index: number,
 		featureCoordinates: Position[] | Position[][],
+		updateType: UpdateTypes,
 	) {
 		if (index < 0) {
 			// -1 would be the final index
@@ -221,11 +226,14 @@ export class MidPointBehavior extends TerraDrawModeBehavior {
 			this.getMidpointConfig(coordinates),
 		);
 
-		this.mutateFeature.updateGuidancePoints([
-			{
-				featureId: this._midPoints[index],
-				coordinate: midpoints[index],
-			},
-		]);
+		this.mutateFeature.updateGuidancePoints(
+			[
+				{
+					featureId: this._midPoints[index],
+					coordinate: midpoints[index],
+				},
+			],
+			updateType,
+		);
 	}
 }

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.spec.ts
@@ -14,6 +14,7 @@ import { RotateFeatureBehavior } from "./rotate-feature.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 import { webMercatorCentroid } from "../../../geometry/web-mercator-centroid";
 import { PixelDistanceBehavior } from "../../pixel-distance.behavior";
+import { UpdateTypes } from "../../../common";
 
 jest.mock("../../../geometry/web-mercator-centroid", () => {
 	const actual = jest.requireActual("../../../geometry/web-mercator-centroid");
@@ -107,7 +108,11 @@ describe("RotateFeatureBehavior", () => {
 			it("non Polygon or LineStrings do an early return", () => {
 				const id = createStorePoint(config);
 
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				expect(webMercatorCentroid).toHaveBeenCalledTimes(0);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
@@ -116,7 +121,11 @@ describe("RotateFeatureBehavior", () => {
 			it("first event sets the initial bearing and does not update the LineString", () => {
 				const id = createStoreLineString(config);
 
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				// Cached centroid geometry is calculated
 				expect(webMercatorCentroid).toHaveBeenCalledTimes(1);
@@ -126,8 +135,16 @@ describe("RotateFeatureBehavior", () => {
 			it("second event rotates the LineString", () => {
 				const id = createStoreLineString(config);
 
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				// We cache the centroid geometry in the first event
 				// and then use it in the second event
@@ -137,8 +154,16 @@ describe("RotateFeatureBehavior", () => {
 
 			it("second event rotates the Polygon", () => {
 				const id = createStorePolygon(config);
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				// We cache the centroid geometry in the first event
 				// and then use it in the second event
@@ -153,9 +178,17 @@ describe("RotateFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 				rotateFeatureBehavior.reset();
-				rotateFeatureBehavior.rotate(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				rotateFeatureBehavior.rotate(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});

--- a/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/rotate-feature.behavior.ts
@@ -51,7 +51,11 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 		this.selectedGeometryCentroid = undefined;
 	}
 
-	rotate(event: TerraDrawMouseEvent, selectedId: FeatureId) {
+	rotate(
+		event: TerraDrawMouseEvent,
+		selectedId: FeatureId,
+		updateType: UpdateTypes,
+	) {
 		if (!this.selectedGeometry) {
 			this.selectedGeometry = this.readFeature.getGeometry<
 				LineString | Polygon
@@ -145,7 +149,7 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 					geometry.type === "Polygon" ? [updatedCoords] : updatedCoords,
 			},
 			context: {
-				updateType: UpdateTypes.Provisional as const,
+				updateType,
 			},
 		};
 
@@ -169,11 +173,12 @@ export class RotateFeatureBehavior extends TerraDrawModeBehavior {
 		const featureCoordinates = updated.geometry.coordinates;
 
 		// Perform the update to the midpoints and selection points
-		this.midPoints.updateAllInPlace({ featureCoordinates });
-		this.selectionPoints.updateAllInPlace({ featureCoordinates });
+		this.midPoints.updateAllInPlace({ featureCoordinates, updateType });
+		this.selectionPoints.updateAllInPlace({ featureCoordinates, updateType });
 		this.coordinatePoints.updateAllInPlace({
 			featureId: selectedId,
 			featureCoordinates,
+			updateType,
 		});
 
 		if (this.projection === "web-mercator") {

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -1,3 +1,4 @@
+import { UpdateTypes } from "../../../common";
 import {
 	createStorePoint,
 	createStoreLineString,
@@ -104,7 +105,11 @@ describe("ScaleFeatureBehavior", () => {
 			it("non Polygon or LineStrings do an early return", () => {
 				const id = createStorePoint(config);
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(0);
 			});
@@ -112,14 +117,22 @@ describe("ScaleFeatureBehavior", () => {
 			it("scales the LineString", () => {
 				const id = createStoreLineString(config);
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 
 			it("scales the Polygon", () => {
 				const id = createStorePolygon(config);
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 			});
 		});
@@ -138,37 +151,51 @@ describe("ScaleFeatureBehavior", () => {
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 0, lat: 0 }),
+					id,
+					UpdateTypes.Provisional,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[0, 0],
-								[0, 1],
-							],
-							type: "LineString",
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[0, 0],
+									[0, 1],
+								],
+								type: "LineString",
+							},
+							id: id,
 						},
-						id: id,
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 
 				scaleFeatureBehavior.reset();
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 10, lat: 10 }), id2);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 10, lat: 10 }),
+					id2,
+					UpdateTypes.Provisional,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[10, 10],
-								[10, 11],
-							],
-							type: "LineString",
+				expect(config.store.updateGeometry).toHaveBeenCalledWith(
+					[
+						{
+							geometry: {
+								coordinates: [
+									[10, 10],
+									[10, 11],
+								],
+								type: "LineString",
+							},
+							id: id2,
 						},
-						id: id2,
-					},
-				]);
+					],
+					{ updateType: UpdateTypes.Provisional },
+				);
 			});
 		});
 	});

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.ts
@@ -1,4 +1,4 @@
-import { TerraDrawMouseEvent, Validation } from "../../../common";
+import { TerraDrawMouseEvent, UpdateTypes, Validation } from "../../../common";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { FeatureId } from "../../../store/store";
 import { DragCoordinateResizeBehavior } from "./drag-coordinate-resize.behavior";
@@ -11,7 +11,11 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 		super(config);
 	}
 
-	public scale(event: TerraDrawMouseEvent, featureId: FeatureId) {
+	public scale(
+		event: TerraDrawMouseEvent,
+		featureId: FeatureId,
+		updateType: UpdateTypes,
+	) {
 		if (!this.dragCoordinateResizeBehavior.isDragging()) {
 			const index = this.dragCoordinateResizeBehavior.getDraggableIndex(
 				event,
@@ -20,7 +24,7 @@ export class ScaleFeatureBehavior extends TerraDrawModeBehavior {
 			this.dragCoordinateResizeBehavior.startDragging(featureId, index);
 		}
 
-		this.dragCoordinateResizeBehavior.drag(event, "center-fixed");
+		this.dragCoordinateResizeBehavior.drag(event, "center-fixed", updateType);
 	}
 
 	public reset() {

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.spec.ts
@@ -1,9 +1,8 @@
 import { Position } from "geojson";
-import { COMMON_PROPERTIES, SELECT_PROPERTIES } from "../../../common";
+import { SELECT_PROPERTIES, UpdateTypes } from "../../../common";
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
 import { BehaviorConfig } from "../../base.behavior";
 import { MutateFeatureBehavior } from "../../mutate-feature.behavior";
-import { ReadFeatureBehavior } from "../../read-feature.behavior";
 import { SelectionPointBehavior } from "./selection-point.behavior";
 
 describe("SelectionPointBehavior", () => {
@@ -21,7 +20,6 @@ describe("SelectionPointBehavior", () => {
 			const mutateFeatureBehavior = new MutateFeatureBehavior(config, {
 				validate: jest.fn(() => ({ valid: true })),
 			});
-			const readFeatureBehavior = new ReadFeatureBehavior(config);
 			selectionPointBehavior = new SelectionPointBehavior(
 				config,
 				mutateFeatureBehavior,
@@ -99,6 +97,7 @@ describe("SelectionPointBehavior", () => {
 						[1, 1],
 						[1, 0],
 					],
+					updateType: UpdateTypes.Commit,
 				});
 
 				expect(result).toBe(undefined);
@@ -128,6 +127,7 @@ describe("SelectionPointBehavior", () => {
 
 				selectionPointBehavior.updateAllInPlace({
 					featureCoordinates: [featureCoordinatesUpdated],
+					updateType: UpdateTypes.Commit,
 				});
 
 				const selectionPoints = config.store.copyAllWhere((properties) =>
@@ -172,6 +172,7 @@ describe("SelectionPointBehavior", () => {
 						[2, 2],
 						[2, 3],
 					],
+					updateType: UpdateTypes.Commit,
 				});
 
 				const selectionPoints = config.store.copyAllWhere((properties) =>
@@ -194,7 +195,11 @@ describe("SelectionPointBehavior", () => {
 
 		describe("getOneUpdated", () => {
 			it("should return undefined if trying to get updated coordinates when non exist", () => {
-				const result = selectionPointBehavior.updateOneAtIndex(0, [0, 1]);
+				const result = selectionPointBehavior.updateOneAtIndex(
+					0,
+					[0, 1],
+					UpdateTypes.Commit,
+				);
 				expect(result).toBe(undefined);
 			});
 
@@ -209,7 +214,7 @@ describe("SelectionPointBehavior", () => {
 					featureId: "id",
 				});
 
-				selectionPointBehavior.updateOneAtIndex(0, [2, 2]);
+				selectionPointBehavior.updateOneAtIndex(0, [2, 2], UpdateTypes.Commit);
 
 				const selectionPoints = config.store.copyAllWhere((properties) =>
 					Boolean(properties[SELECT_PROPERTIES.SELECTION_POINT]),

--- a/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/selection-point.behavior.ts
@@ -1,7 +1,7 @@
 import { Position } from "geojson";
 import { BehaviorConfig, TerraDrawModeBehavior } from "../../base.behavior";
 import { FeatureId } from "../../../store/store";
-import { SELECT_PROPERTIES } from "../../../common";
+import { SELECT_PROPERTIES, UpdateTypes } from "../../../common";
 import { MutateFeatureBehavior } from "../../mutate-feature.behavior";
 import { getUnclosedCoordinates } from "../../../geometry/get-coordinates";
 import { ReadFeatureBehavior } from "../../read-feature.behavior";
@@ -62,8 +62,10 @@ export class SelectionPointBehavior extends TerraDrawModeBehavior {
 
 	public updateAllInPlace({
 		featureCoordinates,
+		updateType,
 	}: {
 		featureCoordinates: Position[] | Position[][];
+		updateType: UpdateTypes;
 	}) {
 		if (this._selectionPoints.length === 0) {
 			return;
@@ -80,19 +82,27 @@ export class SelectionPointBehavior extends TerraDrawModeBehavior {
 				featureId: id,
 				coordinate: coordinates[i],
 			})),
+			updateType,
 		);
 	}
 
-	public updateOneAtIndex(index: number, updatedCoordinate: Position) {
+	public updateOneAtIndex(
+		index: number,
+		updatedCoordinate: Position,
+		updateType: UpdateTypes,
+	) {
 		if (this._selectionPoints[index] === undefined) {
 			return;
 		}
 
-		this.mutateFeature.updateGuidancePoints([
-			{
-				featureId: this._selectionPoints[index],
-				coordinate: updatedCoordinate,
-			},
-		]);
+		this.mutateFeature.updateGuidancePoints(
+			[
+				{
+					featureId: this._selectionPoints[index],
+					coordinate: updatedCoordinate,
+				},
+			],
+			updateType,
+		);
 	}
 }

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -465,6 +465,7 @@ describe("TerraDrawSelectMode", () => {
 					// Polygon selected set to true
 					expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 						target: "properties",
+						updateType: "commit",
 					});
 
 					// Create selection points
@@ -522,6 +523,7 @@ describe("TerraDrawSelectMode", () => {
 					// Polygon selected set to true
 					expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 						target: "properties",
+						updateType: "commit",
 					});
 
 					// Create selection points
@@ -592,6 +594,7 @@ describe("TerraDrawSelectMode", () => {
 					// Polygon selected set to true
 					expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 						target: "properties",
+						updateType: "commit",
 					});
 
 					// Create midpoint by clicking on it
@@ -815,6 +818,7 @@ describe("TerraDrawSelectMode", () => {
 						// First polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Deselect first polygon, select second
@@ -836,11 +840,13 @@ describe("TerraDrawSelectMode", () => {
 						// First polygon selected set to false
 						expect(onChange).toHaveBeenNthCalledWith(4, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Second polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(5, idTwo, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 					});
 
@@ -904,6 +910,7 @@ describe("TerraDrawSelectMode", () => {
 						// First polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Create selection points
@@ -939,6 +946,7 @@ describe("TerraDrawSelectMode", () => {
 
 						expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Delete first polygon selection points
@@ -958,6 +966,7 @@ describe("TerraDrawSelectMode", () => {
 						// Second polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(7, idTwo, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 					});
 
@@ -1021,6 +1030,7 @@ describe("TerraDrawSelectMode", () => {
 						// First polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Create selection points
@@ -1069,6 +1079,7 @@ describe("TerraDrawSelectMode", () => {
 
 						expect(onChange).toHaveBeenNthCalledWith(6, idOne, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 
 						// Delete first polygon selection points
@@ -1101,6 +1112,7 @@ describe("TerraDrawSelectMode", () => {
 						// Second polygon selected set to true
 						expect(onChange).toHaveBeenNthCalledWith(9, idTwo, "update", {
 							target: "properties",
+							updateType: "commit",
 						});
 					});
 				});
@@ -1170,6 +1182,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "getGeometryCopy");
@@ -1224,6 +1237,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "getGeometryCopy");
@@ -1283,6 +1297,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "delete");
@@ -1331,6 +1346,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "delete");
@@ -1425,6 +1441,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "getGeometryCopy");
@@ -1484,6 +1501,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "getGeometryCopy");
@@ -1549,6 +1567,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "delete");
@@ -1602,6 +1621,7 @@ describe("TerraDrawSelectMode", () => {
 				// First polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				jest.spyOn(store, "delete");
@@ -1638,7 +1658,7 @@ describe("TerraDrawSelectMode", () => {
 					2,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				expect(onSelect).toHaveBeenCalledTimes(1);
@@ -1881,6 +1901,7 @@ describe("TerraDrawSelectMode", () => {
 					expect(onChange).toHaveBeenCalledTimes(3);
 					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 						target: "geometry",
+						updateType: "provisional",
 					});
 				});
 			});
@@ -1924,6 +1945,7 @@ describe("TerraDrawSelectMode", () => {
 					expect(onChange).toHaveBeenCalledTimes(3);
 					expect(onChange).toHaveBeenNthCalledWith(3, idOne, "update", {
 						target: "geometry",
+						updateType: "provisional",
 					});
 				});
 			});
@@ -1957,7 +1979,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -1982,13 +2004,13 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2022,7 +2044,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2052,14 +2074,14 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 
 				expect(onChange).toHaveBeenNthCalledWith(
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2107,7 +2129,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2132,32 +2154,40 @@ describe("TerraDrawSelectMode", () => {
 				);
 
 				expect(store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
-					{
-						geometry: {
-							coordinates: [
-								[
-									[0, 0],
-									[0, 1],
-									[2, 2],
-									[1, 0],
-									[0, 0],
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					1,
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[0, 0],
+										[0, 1],
+										[2, 2],
+										[1, 0],
+										[0, 0],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(2, [
-					{
-						geometry: {
-							coordinates: [2, 2],
-							type: "Point",
+					],
+					{ updateType: "provisional" },
+				);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					2,
+					[
+						{
+							geometry: {
+								coordinates: [2, 2],
+								type: "Point",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
 				// Update polygon position and 1 selection points
 				// that gets moved
@@ -2165,13 +2195,13 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					7,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2217,7 +2247,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2242,29 +2272,37 @@ describe("TerraDrawSelectMode", () => {
 				);
 
 				expect(store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
-					{
-						geometry: {
-							coordinates: [
-								[0, 0],
-								[0, 1],
-								[2, 2],
-								[1, 0],
-							],
-							type: "LineString",
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					1,
+					[
+						{
+							geometry: {
+								coordinates: [
+									[0, 0],
+									[0, 1],
+									[2, 2],
+									[1, 0],
+								],
+								type: "LineString",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(2, [
-					{
-						geometry: {
-							coordinates: [2, 2],
-							type: "Point",
+					],
+					{ updateType: "provisional" },
+				);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					2,
+					[
+						{
+							geometry: {
+								coordinates: [2, 2],
+								type: "Point",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
 				// Update linestring position and 1 selection points
 				// that gets moved
@@ -2272,13 +2310,13 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					7,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2333,7 +2371,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2358,32 +2396,40 @@ describe("TerraDrawSelectMode", () => {
 				);
 
 				expect(store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
-					{
-						geometry: {
-							coordinates: [
-								[
-									[0, 0],
-									[0, 1],
-									[2, 2],
-									[1, 0],
-									[0, 0],
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					1,
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[0, 0],
+										[0, 1],
+										[2, 2],
+										[1, 0],
+										[0, 0],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(2, [
-					{
-						geometry: {
-							coordinates: [2, 2],
-							type: "Point",
+					],
+					{ updateType: "provisional" },
+				);
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					2,
+					[
+						{
+							geometry: {
+								coordinates: [2, 2],
+								type: "Point",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
 				// Update polygon position and 1 selection points
 				// that gets moved
@@ -2391,13 +2437,13 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					7,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2450,7 +2496,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2475,30 +2521,38 @@ describe("TerraDrawSelectMode", () => {
 				);
 
 				expect(store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
-					{
-						geometry: {
-							coordinates: [
-								[0, 0],
-								[0, 1],
-								[2, 2],
-								[1, 0],
-							],
-							type: "LineString",
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					1,
+					[
+						{
+							geometry: {
+								coordinates: [
+									[0, 0],
+									[0, 1],
+									[2, 2],
+									[1, 0],
+								],
+								type: "LineString",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(2, [
-					{
-						geometry: {
-							coordinates: [2, 2],
-							type: "Point",
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					2,
+					[
+						{
+							geometry: {
+								coordinates: [2, 2],
+								type: "Point",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
 				// Update linestring position and 1 selection points
 				// that gets moved
@@ -2506,13 +2560,13 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					7,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2567,7 +2621,7 @@ describe("TerraDrawSelectMode", () => {
 					4,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2592,33 +2646,41 @@ describe("TerraDrawSelectMode", () => {
 				);
 
 				expect(store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(1, [
-					{
-						geometry: {
-							coordinates: [
-								[
-									[0, 0],
-									[0, 1],
-									[45, 45],
-									[1, 0],
-									[0, 0],
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					1,
+					[
+						{
+							geometry: {
+								coordinates: [
+									[
+										[0, 0],
+										[0, 1],
+										[45, 45],
+										[1, 0],
+										[0, 0],
+									],
 								],
-							],
-							type: "Polygon",
+								type: "Polygon",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
-				expect(store.updateGeometry).toHaveBeenNthCalledWith(2, [
-					{
-						geometry: {
-							coordinates: [45, 45],
-							type: "Point",
+				expect(store.updateGeometry).toHaveBeenNthCalledWith(
+					2,
+					[
+						{
+							geometry: {
+								coordinates: [45, 45],
+								type: "Point",
+							},
+							id: expect.any(String),
 						},
-						id: expect.any(String),
-					},
-				]);
+					],
+					{ updateType: "provisional" },
+				);
 
 				// Update polygon position and 1 selection points
 				// that gets moved
@@ -2626,14 +2688,14 @@ describe("TerraDrawSelectMode", () => {
 					6,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 
 				expect(onChange).toHaveBeenNthCalledWith(
 					7,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 		});
@@ -2673,7 +2735,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2703,13 +2765,13 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 				expect(onChange).toHaveBeenNthCalledWith(
 					6,
 					[expect.any(String), expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 
@@ -2752,7 +2814,7 @@ describe("TerraDrawSelectMode", () => {
 					3,
 					[expect.any(String)],
 					"update",
-					{ target: "properties" },
+					{ target: "properties", updateType: "commit" },
 				);
 
 				// Create selection points
@@ -2787,7 +2849,7 @@ describe("TerraDrawSelectMode", () => {
 					5,
 					[expect.any(String)],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 
 				expect(onChange).toHaveBeenNthCalledWith(
@@ -2799,7 +2861,7 @@ describe("TerraDrawSelectMode", () => {
 						expect.any(String),
 					],
 					"update",
-					{ target: "geometry" },
+					{ target: "geometry", updateType: "provisional" },
 				);
 			});
 		});
@@ -2849,6 +2911,7 @@ describe("TerraDrawSelectMode", () => {
 				// Polygon selected set to true
 				expect(onChange).toHaveBeenNthCalledWith(2, idOne, "update", {
 					target: "properties",
+					updateType: "commit",
 				});
 
 				// Create mid points
@@ -2875,6 +2938,7 @@ describe("TerraDrawSelectMode", () => {
 
 				expect(onChange).toHaveBeenNthCalledWith(5, idOne, "update", {
 					target: "geometry",
+					updateType: "commit",
 				});
 
 				// Delete existing midpoints and selection points
@@ -2965,7 +3029,7 @@ describe("TerraDrawSelectMode", () => {
 				3,
 				[expect.any(String)],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 
 			// Create selection points
@@ -2992,6 +3056,18 @@ describe("TerraDrawSelectMode", () => {
 			selectMode.onDragEnd(
 				MockCursorEvent({ lng: 1, lat: 1 }),
 				setMapDraggability,
+			);
+
+			expect(onChange).toHaveBeenCalledTimes(8);
+
+			expect(onChange).toHaveBeenNthCalledWith(
+				8,
+				[expect.any(String)],
+				"update",
+				{
+					target: "geometry",
+					updateType: "finish",
+				},
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);
@@ -3039,6 +3115,16 @@ describe("TerraDrawSelectMode", () => {
 				setMapDraggability,
 			);
 
+			expect(onChange).toHaveBeenNthCalledWith(
+				4,
+				[expect.any(String)],
+				"update",
+				{
+					target: "geometry",
+					updateType: "finish",
+				},
+			);
+
 			expect(onFinish).toHaveBeenCalledTimes(1);
 			expect(onFinish).toHaveBeenCalledWith(expect.any(String), {
 				action: "dragFeature",
@@ -3081,7 +3167,7 @@ describe("TerraDrawSelectMode", () => {
 				3,
 				[expect.any(String)],
 				"update",
-				{ target: "properties" },
+				{ target: "properties", updateType: "commit" },
 			);
 
 			// Create selection points
@@ -3108,6 +3194,16 @@ describe("TerraDrawSelectMode", () => {
 			selectMode.onDragEnd(
 				MockCursorEvent({ lng: 1, lat: 1 }),
 				setMapDraggability,
+			);
+
+			expect(onChange).toHaveBeenNthCalledWith(
+				7,
+				[expect.any(String)],
+				"update",
+				{
+					target: "geometry",
+					updateType: "finish",
+				},
 			);
 
 			expect(onFinish).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -445,7 +445,7 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 						.coordinates,
 					type: Mutations.Replace,
 				},
-				context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+				context: { updateType: UpdateTypes.Finish },
 			});
 
 			if (!updated) {

--- a/packages/terra-draw/src/store/store.spec.ts
+++ b/packages/terra-draw/src/store/store.spec.ts
@@ -681,14 +681,18 @@ describe("GeoJSONStore", () => {
 			);
 
 			expect(afterFeatureAddedMock).toHaveBeenCalledTimes(2);
-			expect(afterFeatureAddedMock).toHaveBeenNthCalledWith(
-				1,
-				expect.objectContaining({ id: result[0].id }),
-			);
-			expect(afterFeatureAddedMock).toHaveBeenNthCalledWith(
-				2,
-				expect.objectContaining({ id: result[1].id }),
-			);
+			expect(afterFeatureAddedMock).toHaveBeenNthCalledWith(1, {
+				type: "Feature",
+				id: result[0].id,
+				geometry: { type: "Point", coordinates: [0, 0] },
+				properties: { mode: "point" },
+			});
+			expect(afterFeatureAddedMock).toHaveBeenNthCalledWith(2, {
+				type: "Feature",
+				id: result[1].id,
+				geometry: { type: "Point", coordinates: [1, 1] },
+				properties: { mode: "point" },
+			});
 
 			// Ensure onChange is called before afterFeatureAdded
 			expect(mockChangeCallback.mock.invocationCallOrder[0]).toBeLessThan(

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -20,6 +20,7 @@ import {
 	TerraDrawOnChangeContext,
 	Projection,
 	TerraDrawHandledEvents,
+	UpdateTypes,
 } from "./common";
 import {
 	ModeTypes,


### PR DESCRIPTION
## Description of Changes

In order to properly handle undo and redo in the future we need to understand what type the event was. This is because we could end up up doing every single drag event, unable to distinguish which was the end event, which is unlikely what the user had in mind with undo/redo.

## Link to Issue

No specific issue, but relates to https://github.com/JamesLMilner/terra-draw/issues/142

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 