### PR TITLE
fix(terra-draw): fix bug when changing showCoordinatePoints with updateOptions in polygon mode

### DIFF
--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -330,6 +330,97 @@ describe("TerraDrawPolygonMode", () => {
 			);
 			expect(coordinatePoints.length).toBe(4);
 		});
+
+		it("does not throw an error when setting showCoordinatePoints true with existing coordinate points", () => {
+			const polygonMode = new TerraDrawPolygonMode({
+				showCoordinatePoints: false,
+			});
+
+			const mockConfig = MockModeConfig(polygonMode.mode);
+
+			polygonMode.register(mockConfig);
+			polygonMode.start();
+
+			const mockPolygon = MockPolygonSquare();
+			mockConfig.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			polygonMode.updateOptions({
+				showCoordinatePoints: true,
+			});
+
+			expect(() => {
+				polygonMode.updateOptions({
+					showCoordinatePoints: true,
+				});
+			}).not.toThrow();
+		});
+
+		it("removes existing coordinate points when setting showCoordinatePoints to false", () => {
+			const polygonMode = new TerraDrawPolygonMode({
+				showCoordinatePoints: false,
+			});
+
+			const mockConfig = MockModeConfig(polygonMode.mode);
+
+			polygonMode.register(mockConfig);
+			polygonMode.start();
+
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = mockConfig.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			polygonMode.updateOptions({
+				showCoordinatePoints: true,
+			});
+
+			let coordinatePoints = mockConfig.store.copyAllWhere(
+				(properties) =>
+					properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+			);
+			expect(coordinatePoints.length).toBe(4);
+
+			mockConfig.onChange.mockClear();
+
+			expect(() => {
+				polygonMode.updateOptions({
+					showCoordinatePoints: false,
+				});
+			}).not.toThrow();
+
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(2);
+			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
+				1,
+				[
+					expect.any(String),
+					expect.any(String),
+					expect.any(String),
+					expect.any(String),
+				],
+				"delete",
+				undefined,
+			);
+			expect(mockConfig.onChange).toHaveBeenNthCalledWith(
+				2,
+				[featureId],
+				"update",
+				{ target: "properties" },
+			);
+
+			coordinatePoints = mockConfig.store.copyAllWhere(
+				(properties) =>
+					properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+			);
+			expect(coordinatePoints.length).toBe(0);
+		});
 	});
 
 	describe("afterFeatureAdded", () => {

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -175,23 +175,28 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 			// If we are not showing coordinate points, we need to add them all
 			if (this.coordinatePoints && options.showCoordinatePoints === true) {
-				const features = this.store.copyAllWhere(
-					(properties) => properties.mode === this.mode,
-				);
-				features.forEach((feature) => {
+				const polygonFeatures = this.store
+					.copyAllWhere((properties) => properties.mode === this.mode)
+					.filter((feature) => feature.geometry.type === "Polygon");
+
+				polygonFeatures.forEach((feature) => {
 					this.coordinatePoints.createOrUpdate({
 						featureId: feature.id as FeatureId,
 						featureCoordinates: feature.geometry.coordinates as Position[][],
 					});
 				});
 			} else if (this.coordinatePoints && this.showCoordinatePoints === false) {
-				const featuresWithCoordinates = this.store.copyAllWhere(
-					(properties) =>
-						properties.mode === this.mode &&
-						Boolean(
-							properties[COMMON_PROPERTIES.COORDINATE_POINT_IDS] as FeatureId[],
-						),
-				);
+				const featuresWithCoordinates = this.store
+					.copyAllWhere(
+						(properties) =>
+							properties.mode === this.mode &&
+							Boolean(
+								properties[
+									COMMON_PROPERTIES.COORDINATE_POINT_IDS
+								] as FeatureId[],
+							),
+					)
+					.filter((feature) => feature.geometry.type === "Polygon");
 
 				this.coordinatePoints.deletePointsByFeatureIds(
 					featuresWithCoordinates.map((f) => f.id as FeatureId),


### PR DESCRIPTION
## Description of Changes

Fixes a bug when updating showCoordinatePoints using updateOptions when coordinate points already exist

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 