### PR TITLE
docs(terra-draw): improve the undo redo documentation

### DIFF
--- a/guides/6.EVENTS.md
+++ b/guides/6.EVENTS.md
@@ -195,11 +195,19 @@ draw.on("history", ({ cause, stack, undoSize, redoSize }) => {
 });
 ```
 
-`modeLevel` and `sessionLevel` are optional and work independently, so you can configure either one on its own or both together.
+By default, all undo/redo behavior is disabled. `modeLevel` and `sessionLevel` are both optional and independent, so you can enable either one on its own or enable both together.
 
-If you want to disable drawing-level undo/redo, omit `modeLevel` from `undoRedo`.
+Think of this as two different history scopes:
 
-To cap memory and interaction history, pass `maxStackSize` to `TerraDrawModeUndoRedo` and/or `TerraDrawSessionUndoRedo`. When the limit is reached, the oldest undo/redo entries are discarded.
+- `modeLevel` (`TerraDrawModeUndoRedo`) is for **in-progress drawing history** inside a mode.
+  - Example: while drawing a polygon or line, undo/redo removes or restores recently added coordinates.
+  - This only works for modes that implement mode-level history (built-in support exists in `TerraDrawPolygonMode` and `TerraDrawLineStringMode`).
+
+- `sessionLevel` (`TerraDrawSessionUndoRedo`) is for **completed edit history** across the session.
+  - Example: undo/redo create, update, and delete operations for features that are not currently being actively drawn.
+  - This does not handle in-progress drawing actions.
+
+To limit memory usage and interaction history, pass `maxStackSize` to `TerraDrawModeUndoRedo` and/or `TerraDrawSessionUndoRedo`. When the limit is reached, the oldest history entries are discarded.
 
 ---
 


### PR DESCRIPTION
## Description of Changes

Improve the explanation of the difference between session and mode level undo redo functionality 

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 