### PR TITLE
feat(terra-draw): add allowManualSelection option to TerraDrawSelectMode

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -328,6 +328,9 @@ new TerraDrawSelectMode({
   // Allow manual deselection of features
   allowManualDeselection: true, // this defaults to true - allows users to deselect by clicking on the map
 
+  // Allow manual selection of features by clicking on the map
+  allowManualSelection: true, // this defaults to true - set to false to require selection via draw.selectFeature(id)
+
   // Enable editing tools by Feature
   flags: {
     // Point

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -410,6 +410,85 @@ describe("TerraDrawSelectMode", () => {
 					expect(onDeselect).toHaveBeenCalledTimes(0);
 				});
 
+				it("does not select if feature is clicked but allowManualSelection is false", () => {
+					setSelectMode({
+						allowManualSelection: false,
+						flags: {
+							polygon: { feature: {} },
+						},
+					});
+
+					// Square Polygon
+					addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					selectMode.onClick(MockCursorEvent({ lng: 0.5, lat: 0.5 }));
+
+					expect(onSelect).toHaveBeenCalledTimes(0);
+				});
+
+				it("does select via selectFeature API even when allowManualSelection is false", () => {
+					setSelectMode({
+						allowManualSelection: false,
+						flags: {
+							polygon: { feature: {} },
+						},
+					});
+
+					const id = addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					selectMode.selectFeature(id);
+
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onSelect).toHaveBeenCalledWith(id);
+				});
+
+				it("does not switch selection to another feature on click when allowManualSelection is false", () => {
+					setSelectMode({
+						allowManualSelection: false,
+						flags: {
+							polygon: { feature: {} },
+						},
+					});
+
+					const id = addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					addPolygonToStore([
+						[2, 2],
+						[2, 3],
+						[3, 3],
+						[3, 2],
+						[2, 2],
+					]);
+
+					// Select first polygon via API
+					selectMode.selectFeature(id);
+					expect(onSelect).toHaveBeenCalledTimes(1);
+
+					// Click second polygon - should not change selection
+					selectMode.onClick(MockCursorEvent({ lng: 2.5, lat: 2.5 }));
+
+					expect(onSelect).toHaveBeenCalledTimes(1);
+					expect(onDeselect).toHaveBeenCalledTimes(0);
+				});
+
 				it("does not select if feature is not clicked", () => {
 					// Square Polygon
 					addPolygonToStore([

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -147,12 +147,14 @@ interface TerraDrawSelectModeOptions<T extends CustomStyling>
 	dragEventThrottle?: number;
 	cursors?: Cursors;
 	allowManualDeselection?: boolean;
+	allowManualSelection?: boolean;
 }
 
 export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStyling> {
 	public mode = "select";
 
 	private allowManualDeselection = true;
+	private allowManualSelection = true;
 	private dragEventThrottle = 5;
 	private dragEventCount = 0;
 	private selected: FeatureId[] = [];
@@ -223,6 +225,10 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 		if (options?.allowManualDeselection !== undefined) {
 			this.allowManualDeselection = options.allowManualDeselection;
+		}
+
+		if (options?.allowManualSelection !== undefined) {
+			this.allowManualSelection = options.allowManualSelection;
 		}
 
 		// Flags and Validations
@@ -661,7 +667,9 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		}
 
 		if (clickedFeature?.id) {
-			this.select(clickedFeature.id, true);
+			if (this.allowManualSelection) {
+				this.select(clickedFeature.id, true);
+			}
 		} else if (this.selected.length && this.allowManualDeselection) {
 			this.deselect(this.selected[0]);
 			return;


### PR DESCRIPTION
## Description of Changes
Adds a new `allowManualSelection` option to `TerraDrawSelectMode`. When set to false, all click-based selection is disabled and features can only be selected programmatically via `draw.selectFeature(id)`. 

When combined with the existing `allowManualDeselection: false`, this enables fully-controlled selection via the api.

The option defaults to true so there is no change to existing behaviour.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/841

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 