### PR TITLE
chore(terra-draw): only call set options once for Google Maps in storybook

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -14,10 +14,8 @@ import {
 	GeoJSONStoreFeatures,
 	HexColor,
 	TerraDrawMarkerMode,
-	TerraDrawSessionUndoRedo,
-	TerraDrawModeUndoRedo,
-	TerraDrawUndoRedoKeyboardShortcuts,
 } from "../../../terra-draw/src/terra-draw";
+
 import {
 	DefaultSize,
 	LocationNewYork,

--- a/packages/storybook/src/stories/google/setup.ts
+++ b/packages/storybook/src/stories/google/setup.ts
@@ -9,20 +9,7 @@ import { TerraDraw } from "../../../../terra-draw/src/terra-draw";
 import { TerraDrawGoogleMapsAdapter } from "../../../../terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter";
 import { StoryArgs } from "../../common/config";
 
-// Check for Google Maps API key (can be set via environment or global)
-const apiKey = (import.meta as any).env.GOOGLE_API_KEY;
-
-// If no API key is provided, use empty string (will still work for development)
-if (!apiKey) {
-	throw new Error(
-		"Google Maps API key is required. Please set it in your environment variables or as a global variable.",
-	);
-}
-
-setOptions({
-	key: apiKey,
-	v: "weekly",
-});
+let setOptionsCalled = false;
 
 const initialiseGoogleMap = async ({
 	mapContainer,
@@ -35,6 +22,25 @@ const initialiseGoogleMap = async ({
 	centerLng: number;
 	zoom: number;
 }) => {
+	if (!setOptionsCalled) {
+		// Check for Google Maps API key (can be set via environment or global)
+		const apiKey = (import.meta as any).env.GOOGLE_API_KEY;
+
+		// If no API key is provided, use empty string (will still work for development)
+		if (!apiKey) {
+			throw new Error(
+				"Google Maps API key is required. Please set it in your environment variables or as a global variable.",
+			);
+		}
+
+		setOptions({
+			key: apiKey,
+			v: "weekly",
+		});
+
+		setOptionsCalled = true;
+	}
+
 	// Load Google Maps API (maps for Map/Data/OverlayView, core for LatLng/Point/Size)
 	await Promise.all([importLibrary("maps"), importLibrary("core")]);
 


### PR DESCRIPTION
## Description of Changes

- Does not throw the error outside of story running for Google Maps

## Link to Issue

<!--- Please provide a link to the issue for reference. If you have not created an issue, please do so before raising a PR so that it is possible to discuss the changes in advance -->

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 