### PR TITLE
fix(select): support circle resize on globe and web-mercator projections

### DIFF
--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -15,7 +15,7 @@ import {
 	MARKER_URL_DEFAULT,
 	FinishActions,
 } from "../../common";
-import { LineString, Point, Polygon, Position } from "geojson";
+import { Feature, LineString, Point, Polygon, Position } from "geojson";
 import {
 	BaseModeOptions,
 	CustomStyling,
@@ -37,6 +37,9 @@ import { RotateFeatureBehavior } from "./behaviors/rotate-feature.behavior";
 import { ScaleFeatureBehavior } from "./behaviors/scale-feature.behavior";
 import { FeatureId, GeoJSONStoreFeatures } from "../../store/store";
 import { getDefaultStyling } from "../../util/styling";
+import { circle, circleWebMercator } from "../../geometry/shape/create-circle";
+import { centroid } from "../../geometry/centroid";
+import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import {
 	DragCoordinateResizeBehavior,
 	ResizeOptions,
@@ -172,6 +175,10 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		| { type: "midpoint"; featureId: FeatureId; midPointId: FeatureId } = {
 		type: "none",
 	};
+
+	// Cached center position for circle resize — captured once at drag start
+	// to avoid centroid drift during progressive updates
+	private circleResizeCenter: Position | null = null;
 
 	// Behaviors
 	private selectionPoints!: SelectionPointBehavior;
@@ -845,6 +852,22 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 				resizableCoordinateIndex,
 			);
 
+			// For circle features, capture the center at drag start so it
+			// stays fixed throughout the resize operation
+			const resizeProps = this.readFeature.getProperties(selectedId);
+			if (
+				resizeProps.mode === "circle" &&
+				typeof resizeProps.radiusKilometers === "number"
+			) {
+				const geometry = this.readFeature.getGeometry<Polygon>(selectedId);
+				const feature = {
+					type: "Feature" as const,
+					geometry,
+					properties: {},
+				};
+				this.circleResizeCenter = centroid(feature as Feature<Polygon>);
+			}
+
 			setMapDraggability(false);
 			return;
 		}
@@ -966,6 +989,19 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			modeFlags.feature.coordinates &&
 			modeFlags.feature.coordinates.resizable
 		) {
+			// Circle features must be resized by regenerating the circle from
+			// center + new radius, not by bbox scaling which distorts the shape.
+			// This applies to both globe and web-mercator projections.
+			const properties = this.readFeature.getProperties(selectedId);
+			if (
+				properties.mode === "circle" &&
+				typeof properties.radiusKilometers === "number"
+			) {
+				setMapDraggability(false);
+				this.resizeCircle(event, selectedId);
+				return;
+			}
+
 			if (this.projection === "globe") {
 				throw new Error(
 					"Globe is currently unsupported projection for resizable",
@@ -1039,6 +1075,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		this.dragCoordinateResizeFeature.stopDragging();
 		this.rotateFeature.reset();
 		this.scaleFeature.reset();
+		this.circleResizeCenter = null;
 		setMapDraggability(true);
 	}
 
@@ -1343,6 +1380,69 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		}
 
 		return styles;
+	}
+
+	/**
+	 * Resize a circle feature by recomputing it from its center and the
+	 * haversine distance to the cursor. Uses geodesic circle for globe
+	 * projection and web-mercator circle for web-mercator projection.
+	 */
+	private resizeCircle(event: TerraDrawMouseEvent, featureId: FeatureId) {
+		const geometry = this.readFeature.getGeometry<Polygon>(featureId);
+
+		// Use the center captured at drag start to avoid drift
+		const center = this.circleResizeCenter;
+		if (!center) {
+			return;
+		}
+
+		const newRadius = haversineDistanceKilometers(center, [
+			event.lng,
+			event.lat,
+		]);
+
+		if (newRadius <= 0) {
+			return;
+		}
+
+		const steps = geometry.coordinates[0].length - 1; // -1 for closing coord
+
+		const updatedCircle =
+			this.projection === "globe"
+				? circle({
+						center,
+						radiusKilometers: newRadius,
+						coordinatePrecision: this.coordinatePrecision,
+						steps,
+					})
+				: circleWebMercator({
+						center,
+						radiusKilometers: newRadius,
+						coordinatePrecision: this.coordinatePrecision,
+						steps,
+					});
+
+		const updated = this.mutateFeature.updatePolygon({
+			featureId,
+			coordinateMutations: {
+				type: Mutations.Replace,
+				coordinates: updatedCircle.geometry.coordinates,
+			},
+			propertyMutations: {
+				radiusKilometers: newRadius,
+			},
+			context: {
+				updateType: UpdateTypes.Provisional,
+			},
+		});
+
+		if (!updated) {
+			return;
+		}
+
+		const featureCoordinates = updated.geometry.coordinates;
+		this.midPoints.updateAllInPlace({ featureCoordinates });
+		this.selectionPoints.updateAllInPlace({ featureCoordinates });
 	}
 
 	afterFeatureUpdated(feature: GeoJSONStoreFeatures) {


### PR DESCRIPTION
## Problem

Circle features created with `TerraDrawCircleMode` are distorted into ovals when resized via `TerraDrawSelectMode` with `resizable: "center"`.

This happens because the resize behavior (`DragCoordinateResizeBehavior`) treats circles as generic polygons and applies bbox-based coordinate scaling. Since a circle is a polygon with 64 evenly-spaced vertices, scaling X and Y independently — especially in Web Mercator where latitude distortion is non-linear — deforms the circle into an ellipse.

On **globe projection**, resizing throws an error entirely:
```
Error: Globe is currently unsupported projection for resizable
```

This is tracked in #436.

## Solution

When a resizable feature is detected as a circle (has `properties.mode === "circle"` and `properties.radiusKilometers`), bypass the generic bbox scaling and instead:

1. **Capture the circle center** at drag start (via centroid of the polygon), stored in a private field `circleResizeCenter`
2. **On each drag event**, compute the new radius as the haversine distance from the stored center to the cursor position
3. **Regenerate the circle** using the existing `circle()` (globe) or `circleWebMercator()` (web-mercator) functions with the new radius
4. **Update the `radiusKilometers` property** on the feature to keep it in sync
5. **Reset the stored center** on drag end

The center is captured once at drag start rather than recomputed each frame to prevent centroid drift — the arithmetic mean of polygon vertices is not exactly the geodesic center, and progressive recomputation causes the circle to slowly migrate.

## Changes

**`packages/terra-draw/src/modes/select/select.mode.ts`** — 1 file, ~100 lines added

- Added `circleResizeCenter: Position | null` field to `TerraDrawSelectMode`
- In `onDragStart`: capture center when starting a circle resize
- In `onDrag`: detect circles and call `resizeCircle()` instead of bbox scaling — for **both** globe and web-mercator projections
- In `onDragEnd`: reset stored center
- Added private method `resizeCircle()` that regenerates the geodesic/web-mercator circle from center + haversine distance to cursor

## Testing

Tested manually with MapLibre GL JS v5.21 + globe projection:

- Draw a circle → Select → Resize by dragging a selection point → **circle stays round**
- Center remains fixed during resize (no drift)
- `radiusKilometers` property updates correctly
- Works on both globe and flat (web-mercator) projections
- Existing rectangle/polygon resize is not affected
- Circle drag/move still works as before