### PR TITLE
chore(terra-draw): retry on when package is still publishing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,86 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    tags:
+      - "terra-draw*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.14.1"
+          cache: npm
+
+      # The package is still publishing to npm, so we need to retry on install failure
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+
+          max_attempts=10
+
+          for attempt in $(seq 1 $max_attempts); do
+            echo "npm ci attempt ${attempt}/${max_attempts}"
+
+            if npm ci; then
+              echo "npm ci succeeded"
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "npm ci failed after ${max_attempts} attempts"
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 15))
+            echo "Retrying in ${sleep_seconds}s..."
+            sleep "${sleep_seconds}"
+          done
+
+      - name: Build docs
+        run: npm run docs
+
+      - name: Publish docs to gh-pages/docs
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # gh-pages branch is expected to exist.
+          git fetch origin gh-pages:gh-pages
+
+          rm -rf /tmp/gh-pages
+
+          git worktree add /tmp/gh-pages gh-pages
+
+          rm -rf /tmp/gh-pages/docs
+          rsync -a docs/ /tmp/gh-pages/docs/
+
+          cd /tmp/gh-pages
+          git add -A docs
+
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+            exit 0
+          fi
+
+          git commit -m "chore(terra-draw): deploy docs from ${GITHUB_SHA}"
+          git push origin gh-pages


### PR DESCRIPTION
## Description of Changes

- npm ci fails because the package isn't quite published yet
- We add some retries to avoid premature failure

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 