### PR TITLE
chore(terra-draw): ensure package-lock.json files are updated on release

### DIFF
--- a/packages/terra-draw-arcgis-adapter/package.json
+++ b/packages/terra-draw-arcgis-adapter/package.json
@@ -7,7 +7,6 @@
 		"@arcgis/core": "^4.31.6"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-arcgis-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw-google-maps-adapter/package.json
+++ b/packages/terra-draw-google-maps-adapter/package.json
@@ -10,7 +10,6 @@
 		"@types/google.maps": "^3.49.2"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-google-maps-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw-leaflet-adapter/package.json
+++ b/packages/terra-draw-leaflet-adapter/package.json
@@ -7,7 +7,6 @@
 		"leaflet": "^1.9.4"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-leaflet-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw-mapbox-gl-adapter/package.json
+++ b/packages/terra-draw-mapbox-gl-adapter/package.json
@@ -7,7 +7,6 @@
 		"mapbox-gl": "^3.9.2"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-mapbox-gl-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw-maplibre-gl-adapter/package.json
+++ b/packages/terra-draw-maplibre-gl-adapter/package.json
@@ -7,7 +7,6 @@
 		"maplibre-gl": ">=4"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-maplibre-gl-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw-openlayers-adapter/package.json
+++ b/packages/terra-draw-openlayers-adapter/package.json
@@ -7,7 +7,6 @@
 		"ol": "^10.3.1"
 	},
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -1,9 +1,8 @@
 {
 	"name": "terra-draw",
-	"version": "1.28.4",
+	"version": "1.28.7",
 	"description": "Frictionless map drawing across mapping provider",
 	"scripts": {
-		"postbump": "cd ../.. && node update.mjs && npm install --package-lock-only && git add packages/*/package.json package-lock.json",
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --release-as $TYPE",
 		"release:dryrun": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --dry-run --release-as $TYPE",
 		"build": "microbundle",

--- a/release.js
+++ b/release.js
@@ -21,6 +21,13 @@ module.exports = (packageName, packageJsonPath, changelogPath) => ({
 			return commit;
 		},
 	},
+	scripts: {
+		// After we bump but before we commit, we want to update all the other packages that have a dependency on the package we just bumped
+		// to make sure they are using the correct version. We also want to update the package-lock.json file to make sure it is in sync with
+		// the updated package.json files.
+		postbump:
+			"cd ../.. && node update.mjs && npm install --package-lock-only --no-audit --no-fund && git add packages/*/package.json package-lock.json",
+	},
 	changelogFile: changelogPath,
 	releaseCommitMessageFormat: `chore(${packageName}): release version {{currentTag}}`,
 });


### PR DESCRIPTION
## Description of Changes

- It appears the postbump scripts were not running. This PR centralises them which has the benefit of being slightly cleaner, and also ensures it actually runs

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 