### PR TITLE
chore(terra-draw): fix package.json versions for Terra Draw

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout main
+      - name: Checkout repository at tag
         uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -28306,7 +28306,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"leaflet": "1.9.4",
-				"terra-draw": "1.28.3",
+				"terra-draw": "1.28.4",
 				"terra-draw-leaflet-adapter": "1.2.0"
 			},
 			"devDependencies": {
@@ -29195,7 +29195,7 @@
 			}
 		},
 		"packages/terra-draw": {
-			"version": "1.28.3",
+			"version": "1.28.4",
 			"license": "MIT"
 		},
 		"packages/terra-draw-arcgis-adapter": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -15,7 +15,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"leaflet": "1.9.4",
-		"terra-draw": "1.28.3",
+		"terra-draw": "1.28.4",
 		"terra-draw-leaflet-adapter": "1.2.0"
 	},
 	"devDependencies": {

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "terra-draw",
-	"version": "1.28.7",
+	"version": "1.28.4",
 	"description": "Frictionless map drawing across mapping provider",
 	"scripts": {
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --release-as $TYPE",


### PR DESCRIPTION
## Description of Changes

Fixes the versions to get CI green again

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 