### PR TITLE
chore(terra-draw): enable commitAll for release.js to ensure files committed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29076,6 +29076,12 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"packages/e2e/node_modules/terra-draw": {
+			"version": "1.28.4",
+			"resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.28.4.tgz",
+			"integrity": "sha512-o26Vpywn92reS9wy6enwM06HiFJEDIkWLVCgPShTTuOzBJlHTNMekLwj46KDSLFCtelVtvtZAKbPrPWHMKZbng==",
+			"license": "MIT"
+		},
 		"packages/e2e/node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -29195,7 +29201,7 @@
 			}
 		},
 		"packages/terra-draw": {
-			"version": "1.28.4",
+			"version": "1.28.5",
 			"license": "MIT"
 		},
 		"packages/terra-draw-arcgis-adapter": {

--- a/release.js
+++ b/release.js
@@ -28,6 +28,8 @@ module.exports = (packageName, packageJsonPath, changelogPath) => ({
 		postbump:
 			"cd ../.. && node update.mjs && npm install --package-lock-only --no-audit --no-fund && git add packages/*/package.json package-lock.json",
 	},
+	// Include files staged by postbump in the release commit.
+	commitAll: true,
 	changelogFile: changelogPath,
 	releaseCommitMessageFormat: `chore(${packageName}): release version {{currentTag}}`,
 });


### PR DESCRIPTION
## Description of Changes

Adds commitAll so that files package.json files are committed appropriately

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 