### PR TITLE
chore(terra-draw): disable husky checks when gh-pages is being commit

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -55,7 +55,7 @@ jobs:
           done
 
       - name: Build docs
-        run: npm run docs
+        run: HUSKY=0 npm run docs
 
       - name: Publish docs to gh-pages/docs
         run: |
@@ -82,5 +82,5 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore(terra-draw): deploy docs from ${GITHUB_SHA}"
+          HUSKY=0 git commit -m "chore(terra-draw): deploy docs from ${GITHUB_SHA}"
           git push origin gh-pages


### PR DESCRIPTION
## Description of Changes

- The commit for the new docs on the gh-pages branch fails because husky isn't present there

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 