### PR TITLE
fix(terra-draw-google-maps-adapter): fix event listeners not being removed on unregister

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -526,6 +526,53 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 	});
 
 	describe("unregister", () => {
+		it("removes all forwardMapElementEvents listeners on unregister", () => {
+			const div = {
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+
+			const mockMap = createMockGoogleMap({
+				getDiv: jest.fn(() => ({
+					id: "map",
+					querySelector: jest.fn(() => div),
+					addEventListener: jest.fn(),
+					removeEventListener: jest.fn(),
+				})) as any,
+				data: {
+					addListener: jest.fn(() => ({ remove: jest.fn() })),
+					setStyle: jest.fn(),
+				} as any,
+			});
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getMap: jest.fn(() => ({})),
+					})),
+				} as any,
+				map: mockMap,
+				forwardMapElementEvents: true,
+			});
+
+			adapter.register(MockCallbacks());
+
+			const registeredListeners = (
+				div.addEventListener as jest.Mock
+			).mock.calls.map(([event, fn]) => ({ event, fn }));
+
+			adapter.unregister();
+
+			const removedListeners = (
+				div.removeEventListener as jest.Mock
+			).mock.calls.map(([event, fn]) => ({ event, fn }));
+
+			for (const { event, fn } of registeredListeners) {
+				expect(removedListeners).toContainEqual({ event, fn });
+			}
+		});
+
 		it("is safe to call without listeners", () => {
 			const div = {
 				addEventListener: jest.fn(),

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -331,14 +331,14 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 
 		if (this._markerClickListener) {
 			this.getMapEventElement().removeEventListener(
-				"click",
+				"pointerdown",
 				this._markerClickListener,
 			);
 		}
 
 		if (this._markerMouseMoveListener) {
 			this.getMapEventElement().removeEventListener(
-				"mousemove",
+				"pointermove",
 				this._markerMouseMoveListener,
 			);
 		}


### PR DESCRIPTION
## Description of Changes

Fix incorrect event names when removing `_markerMouseMoveListener` and `_markerClickListener`.

Added a test to check that all the listeners added by `register()` are removed by `unregister()`.

## Link to Issue

#873 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 