### PR TITLE
chore(terra-draw-openlayers-adapter): bump to ol 10.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5894,9 +5894,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@petamoriken/float16": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.1.tgz",
-			"integrity": "sha512-j+ejhYwY6PeB+v1kn7lZFACUIG97u90WxMuGosILFsl9d4Ovi0sjk0GlPfoEcx+FzvXZDAfioD+NGnnPamXgMA==",
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+			"integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
 			"license": "MIT"
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -9613,6 +9613,16 @@
 			"license": "Apache-2.0",
 			"peer": true
 		},
+		"node_modules/@zarrita/storage": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+			"integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
+			"license": "MIT",
+			"dependencies": {
+				"reference-spec-reader": "^0.2.0",
+				"unzipit": "2.0.0"
+			}
+		},
 		"node_modules/@zeit/schemas": {
 			"version": "2.36.0",
 			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -11247,40 +11257,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"license": "MIT"
-		},
-		"node_modules/color-parse": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-			"integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^2.0.0"
-			}
-		},
-		"node_modules/color-parse/node_modules/color-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-			"integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
-		"node_modules/color-rgba": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-			"integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-parse": "^2.0.0",
-				"color-space": "^2.0.0"
-			}
-		},
-		"node_modules/color-space": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
-			"integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA==",
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
@@ -13888,6 +13864,12 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"license": "MIT"
+		},
 		"node_modules/figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -14328,19 +14310,19 @@
 			"license": "ISC"
 		},
 		"node_modules/geotiff": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-			"integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+			"integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
 			"license": "MIT",
 			"dependencies": {
-				"@petamoriken/float16": "^3.4.7",
+				"@petamoriken/float16": "^3.9.3",
 				"lerc": "^3.0.0",
 				"pako": "^2.0.4",
 				"parse-headers": "^2.0.2",
 				"quick-lru": "^6.1.1",
-				"web-worker": "^1.2.0",
-				"xml-utils": "^1.0.2",
-				"zstddec": "^0.1.0"
+				"web-worker": "^1.5.0",
+				"xml-utils": "^1.10.2",
+				"zstddec": "^0.2.0"
 			},
 			"engines": {
 				"node": ">=10.19"
@@ -21238,6 +21220,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/numcodecs": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+			"integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"fflate": "^0.8.0"
+			}
+		},
 		"node_modules/nwsapi": {
 			"version": "2.2.16",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
@@ -21553,18 +21544,17 @@
 			}
 		},
 		"node_modules/ol": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/ol/-/ol-10.3.1.tgz",
-			"integrity": "sha512-D1nRQVLOBCRempVqBFV8pSI5H13BtnhuLDjGl+3NKdMOFyjx/UqRX/tcMspEw3LhFOSPWn1Ev+1KIRV8AlHM7A==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
+			"integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@types/rbush": "4.0.0",
-				"color-rgba": "^3.0.0",
-				"color-space": "^2.0.1",
 				"earcut": "^3.0.0",
-				"geotiff": "^2.1.3",
+				"geotiff": "^3.0.5 || ^3.1.0-beta.0",
 				"pbf": "4.0.1",
-				"rbush": "^4.0.0"
+				"rbush": "^4.0.0",
+				"zarrita": "^0.7.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -21840,9 +21830,9 @@
 			}
 		},
 		"node_modules/parse-headers": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-			"integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+			"integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
 			"license": "MIT"
 		},
 		"node_modules/parse-json": {
@@ -23401,6 +23391,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/reference-spec-reader": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+			"integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+			"license": "MIT"
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -26742,6 +26738,15 @@
 				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
 			}
 		},
+		"node_modules/unzipit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+			"integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -27615,9 +27620,9 @@
 			}
 		},
 		"node_modules/web-worker": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
-			"integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+			"integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/webidl-conversions": {
@@ -28078,9 +28083,9 @@
 			}
 		},
 		"node_modules/xml-utils": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
-			"integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+			"integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
 			"license": "CC0-1.0"
 		},
 		"node_modules/xmlchars": {
@@ -28236,6 +28241,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/zarrita": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.2.tgz",
+			"integrity": "sha512-BHP+Z+yemkl9pOogkO1XMOrJ5qI4RNqrmheqJeYtIhpiaW4uvqplYx/jGkMD6edQjIZRQhniFigJZE2oTh7dwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@zarrita/storage": "^0.2.0",
+				"numcodecs": "^0.3.2"
+			}
+		},
 		"node_modules/zod": {
 			"version": "3.24.1",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
@@ -28260,9 +28275,9 @@
 			}
 		},
 		"node_modules/zstddec": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-			"integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
 			"license": "MIT AND BSD-3-Clause"
 		},
 		"node_modules/zwitch": {
@@ -29169,7 +29184,7 @@
 				"leaflet": "1.9.4",
 				"mapbox-gl": "3.9.2",
 				"maplibre-gl": "5.6.1",
-				"ol": "10.3.1"
+				"ol": "10.9.0"
 			},
 			"devDependencies": {
 				"@storybook/addon-essentials": "8.6.14",
@@ -29248,7 +29263,7 @@
 			"version": "1.2.0",
 			"license": "MIT",
 			"peerDependencies": {
-				"ol": "^10.3.1",
+				"ol": "^10.9.0",
 				"terra-draw": "^1.0.0"
 			}
 		}

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,7 +21,7 @@
 		"leaflet": "1.9.4",
 		"mapbox-gl": "3.9.2",
 		"maplibre-gl": "5.6.1",
-		"ol": "10.3.1"
+		"ol": "10.9.0"
 	},
 	"devDependencies": {
 		"@storybook/addon-essentials": "8.6.14",

--- a/packages/terra-draw-openlayers-adapter/package.json
+++ b/packages/terra-draw-openlayers-adapter/package.json
@@ -4,7 +4,7 @@
 	"description": "Terra Draw Adapter to OpenLayers",
 	"peerDependencies": {
 		"terra-draw": "^1.0.0",
-		"ol": "^10.3.1"
+		"ol": "^10.9.0"
 	},
 	"scripts": {
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw-openlayers-adapter@ --release-as $TYPE",


### PR DESCRIPTION
## Description of Changes

I was experiencing an inability to draw with the OpenLayers adapter until I bumped to 10.9.0 so I'm making the change here.

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 