### PR TITLE
chore(terra-draw): remove development package reference from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28276,30 +28276,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"packages/development": {
-			"name": "terra-draw-development",
-			"version": "0.0.1",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"@arcgis/core": "4.31.6",
-				"@googlemaps/js-api-loader": "1.14.3",
-				"@types/leaflet": "1.9.15",
-				"google-maps": "4.1.0",
-				"leaflet": "1.9.4",
-				"mapbox-gl": "3.9.2",
-				"maplibre-gl": "3.6.2",
-				"ol": "10.3.1",
-				"terra-draw": "1.11.0"
-			},
-			"devDependencies": {
-				"dotenv-webpack": "8.0.0",
-				"typescript": "5.6.3",
-				"webpack": "5.73.0",
-				"webpack-cli": "4.10.0",
-				"webpack-dev-server": "4.11.1"
-			}
-		},
 		"packages/e2e": {
 			"name": "terra-draw-e2e",
 			"version": "0.0.1",


### PR DESCRIPTION
## Description of Changes

packages/development was deleted a long time ago but there is still reference to it in the package-lock.json file. This PR removes this reference.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 