### PR TITLE
chore(terra-draw): bump storybook maplibre to 5.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5735,19 +5735,6 @@
 				"@lit-labs/ssr-dom-shim": "^1.2.0"
 			}
 		},
-		"node_modules/@mapbox/geojson-rewind": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
-			"integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-			"license": "ISC",
-			"dependencies": {
-				"get-stream": "^6.0.1",
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"geojson-rewind": "geojson-rewind"
-			}
-		},
 		"node_modules/@mapbox/jsonlint-lines-primitives": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -5769,9 +5756,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@mapbox/tiny-sdf": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-			"integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+			"integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/@mapbox/unitbezier": {
@@ -5798,24 +5785,93 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@maplibre/maplibre-gl-style-spec": {
-			"version": "23.3.0",
-			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz",
-			"integrity": "sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==",
+		"node_modules/@maplibre/geojson-vt": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+			"integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
-				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
-				"@mapbox/unitbezier": "^0.0.1",
-				"json-stringify-pretty-compact": "^4.0.0",
-				"minimist": "^1.2.8",
-				"quickselect": "^3.0.0",
-				"rw": "^1.3.3",
-				"tinyqueue": "^3.0.0"
+				"kdbush": "^4.0.2"
+			}
+		},
+		"node_modules/@maplibre/mlt": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+			"integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+			"license": "(MIT OR Apache-2.0)",
+			"peer": true,
+			"dependencies": {
+				"@mapbox/point-geometry": "^1.1.0"
+			}
+		},
+		"node_modules/@maplibre/mlt/node_modules/@mapbox/point-geometry": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+			"integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@maplibre/vt-pbf": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+			"integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mapbox/point-geometry": "^1.1.0",
+				"@mapbox/vector-tile": "^2.0.4",
+				"@maplibre/geojson-vt": "^5.0.4",
+				"@types/geojson": "^7946.0.16",
+				"@types/supercluster": "^7.1.3",
+				"pbf": "^4.0.1",
+				"supercluster": "^8.0.1"
+			}
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/@mapbox/point-geometry": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+			"integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/@mapbox/vector-tile": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+			"integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@mapbox/point-geometry": "~1.1.0",
+				"@types/geojson": "^7946.0.16",
+				"pbf": "^4.0.1"
+			}
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+			"integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"resolve-protobuf-schema": "^2.1.0"
 			},
 			"bin": {
-				"gl-style-format": "dist/gl-style-format.mjs",
-				"gl-style-migrate": "dist/gl-style-migrate.mjs",
-				"gl-style-validate": "dist/gl-style-validate.mjs"
+				"pbf": "bin/pbf"
 			}
 		},
 		"node_modules/@mdx-js/react": {
@@ -14732,53 +14788,6 @@
 				"which": "bin/which"
 			}
 		},
-		"node_modules/global-prefix": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
-			"integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
-			"license": "MIT",
-			"dependencies": {
-				"ini": "^4.1.3",
-				"kind-of": "^6.0.3",
-				"which": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/global-prefix/node_modules/ini": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/global-prefix/node_modules/isexe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-			"integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/global-prefix/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -19556,37 +19565,31 @@
 			"license": "MIT"
 		},
 		"node_modules/maplibre-gl": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.6.1.tgz",
-			"integrity": "sha512-TTSfoTaF7RqKUR9wR5qDxCHH2J1XfZ1E85luiLOx0h8r50T/LnwAwwfV0WVNh9o8dA7rwt57Ucivf1emyeukXg==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+			"integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
-				"@mapbox/geojson-rewind": "^0.5.2",
 				"@mapbox/jsonlint-lines-primitives": "^2.0.2",
-				"@mapbox/point-geometry": "^0.1.0",
-				"@mapbox/tiny-sdf": "^2.0.6",
+				"@mapbox/point-geometry": "^1.1.0",
+				"@mapbox/tiny-sdf": "^2.1.0",
 				"@mapbox/unitbezier": "^0.0.1",
-				"@mapbox/vector-tile": "^1.3.1",
+				"@mapbox/vector-tile": "^2.0.4",
 				"@mapbox/whoots-js": "^3.1.0",
-				"@maplibre/maplibre-gl-style-spec": "^23.3.0",
+				"@maplibre/geojson-vt": "^6.1.0",
+				"@maplibre/maplibre-gl-style-spec": "^24.8.1",
+				"@maplibre/mlt": "^1.1.8",
+				"@maplibre/vt-pbf": "^4.3.0",
 				"@types/geojson": "^7946.0.16",
-				"@types/geojson-vt": "3.2.5",
-				"@types/mapbox__point-geometry": "^0.1.4",
-				"@types/mapbox__vector-tile": "^1.3.4",
-				"@types/pbf": "^3.0.5",
-				"@types/supercluster": "^7.1.3",
-				"earcut": "^3.0.1",
-				"geojson-vt": "^4.0.2",
-				"gl-matrix": "^3.4.3",
-				"global-prefix": "^4.0.0",
+				"earcut": "^3.0.2",
+				"gl-matrix": "^3.4.4",
 				"kdbush": "^4.0.2",
 				"murmurhash-js": "^1.0.0",
-				"pbf": "^3.3.0",
-				"potpack": "^2.0.0",
+				"pbf": "^4.0.1",
+				"potpack": "^2.1.0",
 				"quickselect": "^3.0.0",
-				"supercluster": "^8.0.1",
-				"tinyqueue": "^3.0.0",
-				"vt-pbf": "^3.1.3"
+				"tinyqueue": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.14.0",
@@ -19596,11 +19599,65 @@
 				"url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
 			}
 		},
+		"node_modules/maplibre-gl/node_modules/@mapbox/point-geometry": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+			"integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/maplibre-gl/node_modules/@mapbox/vector-tile": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+			"integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@mapbox/point-geometry": "~1.1.0",
+				"@types/geojson": "^7946.0.16",
+				"pbf": "^4.0.1"
+			}
+		},
+		"node_modules/maplibre-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
+			"version": "24.8.3",
+			"resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.3.tgz",
+			"integrity": "sha512-e5u6GZXA0t6HnBh63YLefSLy62W1QloF4qVLAo1ae88oH/8+PNK98i7/aVf/XWc4wD9D2lTgW2LaApYLPtM1sA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"@mapbox/jsonlint-lines-primitives": "~2.0.2",
+				"@mapbox/unitbezier": "^0.0.1",
+				"json-stringify-pretty-compact": "^4.0.0",
+				"minimist": "^1.2.8",
+				"quickselect": "^3.0.0",
+				"rw": "^1.3.3",
+				"tinyqueue": "^3.0.0"
+			},
+			"bin": {
+				"gl-style-format": "dist/gl-style-format.mjs",
+				"gl-style-migrate": "dist/gl-style-migrate.mjs",
+				"gl-style-validate": "dist/gl-style-validate.mjs"
+			}
+		},
 		"node_modules/maplibre-gl/node_modules/@types/geojson": {
 			"version": "7946.0.16",
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
 			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/maplibre-gl/node_modules/pbf": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"resolve-protobuf-schema": "^2.1.0"
+			},
+			"bin": {
+				"pbf": "bin/pbf"
+			}
 		},
 		"node_modules/markdown-it": {
 			"version": "14.1.0",
@@ -29159,7 +29216,7 @@
 				"@types/leaflet": "1.9.15",
 				"leaflet": "1.9.4",
 				"mapbox-gl": "3.9.2",
-				"maplibre-gl": "5.6.1",
+				"maplibre-gl": "5.24.0",
 				"ol": "10.9.0"
 			},
 			"devDependencies": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
 		"@types/leaflet": "1.9.15",
 		"leaflet": "1.9.4",
 		"mapbox-gl": "3.9.2",
-		"maplibre-gl": "5.6.1",
+		"maplibre-gl": "5.24.0",
 		"ol": "10.9.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description of Changes

Updates Maplibre GL to the latest version for storybook

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 