### PR TITLE
feat(terra-draw-google-maps-adapter): add initial support for dashed lines

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -297,6 +297,32 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 				const lineStringOpacity = (
 					calculatedStyles as { lineStringOpacity?: number }
 				).lineStringOpacity;
+				// Backwards compatible read: pre Terra Draw v1.24.0 will not have this field in the interface
+				const lineStringDash = (
+					calculatedStyles as {
+						lineStringDash?: [number, number];
+					}
+				).lineStringDash;
+
+				const dashedLineStyles = lineStringDash
+					? {
+							strokeOpacity: 0,
+							icons: [
+								{
+									icon: {
+										path: "M 0,0 0," + lineStringDash[0],
+										strokeOpacity: 1,
+										strokeWeight: calculatedStyles.lineStringWidth,
+										color: calculatedStyles.lineStringColor,
+										scale: 1,
+									},
+									offset: "0",
+									repeat: `${lineStringDash[0] + lineStringDash[1]}px`,
+									fixedRotation: false,
+								},
+							],
+						}
+					: {};
 
 				return {
 					strokeColor: calculatedStyles.lineStringColor,
@@ -304,6 +330,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 					strokeOpacity:
 						lineStringOpacity === undefined ? 1 : lineStringOpacity,
 					zIndex: calculatedStyles.zIndex,
+					...dashedLineStyles,
 				};
 			case "Polygon":
 				const polygonOutlineOpacity = (


### PR DESCRIPTION
## Description of Changes

Adds dashed line support for the Google Maps adapter

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/48

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 