### PR TITLE
feat(terra-draw): add initial support for dashed lines

### DIFF
--- a/guides/5.STYLING.md
+++ b/guides/5.STYLING.md
@@ -68,6 +68,7 @@ The `TerraDrawLineStringMode` is styled using the following properties:
 | `lineStringColor`          | Hex Color    | `#00FFFF`     | The color of the linestring.           |
 | `lineStringOpacity`        | Number (0-1) | `0.7`         | The opacity of the linestring.         |
 | `lineStringWidth`          | Integer      | `3`           | The width of the linestring.           |
+| `lineStringDash`           | `[number, number]` | `[5, 3]` | Dash and gap lengths in pixels.        |
 | `closingPointColor`        | Hex Color    | `#00FFFF`     | The fill color of the closing point    |
 | `closingPointWidth`        | Integer      | `1`           | The width of the closing point         |
 | `closingPointOutlineColor` | Hex Color    | `#00FF00`     | The outline color of the closing point |
@@ -114,6 +115,7 @@ The `TerraDrawFreehandLineStringMode` is styled using the following properties:
 | `lineStringColor`          | Hex Color    | `#00FFFF`     | The color of the linestring.           |
 | `lineStringOpacity`        | Number (0-1) | `0.7`         | The opacity of the linestring.         |
 | `lineStringWidth`          | Integer      | `3`           | The width of the linestring.           |
+| `lineStringDash`           | `[number, number]` | `[5, 3]` | Dash and gap lengths in pixels.        |
 | `closingPointColor`        | Hex Color    | `#00FFFF`     | The fill color of the closing point    |
 | `closingPointWidth`        | Integer      | `1`           | The width of the closing point         |
 | `closingPointOutlineColor` | Hex Color    | `#00FF00`     | The outline color of the closing point |
@@ -384,6 +386,7 @@ Lines added to the `TerraDrawRenderMode` are styled using the following properti
 | `lineStringColor`   | Hex Color    | `#00FFFF`     | The color of the line |
 | `lineStringOpacity` | Number (0-1) | `0.7`         | The opacity of the line |
 | `lineStringWidth`   | Integer      | `3`           | The width of the line |
+| `lineStringDash`    | `[number, number]` | `[5, 3]` | Dash and gap lengths in pixels. |
 
 ### Polygons
 

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -33,6 +33,8 @@ export interface TerraDrawAdapterStyling {
 	lineStringWidth: number;
 	lineStringColor: HexColor;
 	lineStringOpacity?: number;
+	/** lineStringDash - Tuple representing the dash pattern for the line string, where the first number is the length of the dash and the second number is the length of the gap in pixels */
+	lineStringDash?: [number, number];
 	zIndex: number;
 	markerUrl?: string;
 	markerHeight?: number;

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -26,7 +26,12 @@ import { ValidationReasonModeMismatch } from "../validations/common-validations"
 
 export type CustomStyling = Record<
 	string,
-	string | number | HexColorStyling | NumericStyling | UrlStyling
+	| string
+	| number
+	| HexColorStyling
+	| NumericStyling
+	| UrlStyling
+	| [number, number]
 >;
 
 export enum ModeTypes {

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
@@ -606,6 +606,7 @@ describe("TerraDrawFreehandLineStringMode", () => {
 					lineStringColor: "#ffffff",
 					lineStringWidth: 2,
 					lineStringOpacity: 0.5,
+					lineStringDash: [5, 3],
 				},
 			});
 
@@ -619,6 +620,7 @@ describe("TerraDrawFreehandLineStringMode", () => {
 				lineStringColor: "#ffffff",
 				lineStringWidth: 2,
 				lineStringOpacity: 0.5,
+				lineStringDash: [5, 3],
 			});
 		});
 

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -42,6 +42,7 @@ type FreehandLineStringStyling = {
 	lineStringWidth: NumericStyling;
 	lineStringColor: HexColorStyling;
 	lineStringOpacity: NumericStyling;
+	lineStringDash: [number, number];
 	closingPointColor: HexColorStyling;
 	closingPointOpacity: NumericStyling;
 	closingPointWidth: NumericStyling;
@@ -310,6 +311,8 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
+			styles.lineStringDash = this.styles.lineStringDash;
+
 			styles.lineStringColor = this.getHexColorStylingValue(
 				this.styles.lineStringColor,
 				styles.lineStringColor,

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -1963,6 +1963,7 @@ describe("TerraDrawLineStringMode", () => {
 					lineStringColor: "#ffffff",
 					lineStringWidth: 4,
 					lineStringOpacity: 0.5,
+					lineStringDash: [5, 3],
 					closingPointColor: "#111111",
 					closingPointWidth: 3,
 					closingPointOutlineColor: "#222222",
@@ -1980,6 +1981,7 @@ describe("TerraDrawLineStringMode", () => {
 				lineStringColor: "#ffffff",
 				lineStringWidth: 4,
 				lineStringOpacity: 0.5,
+				lineStringDash: [5, 3],
 			});
 		});
 

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -74,6 +74,7 @@ type LineStringStyling = {
 	coordinatePointOutlineColor: HexColorStyling;
 	coordinatePointOutlineWidth: NumericStyling;
 	coordinatePointOutlineOpacity: NumericStyling;
+	lineStringDash: [number, number];
 };
 
 interface Cursors {
@@ -1160,6 +1161,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
+			styles.lineStringDash = this.styles.lineStringDash;
+
 			styles.lineStringColor = this.getHexColorStylingValue(
 				this.styles.lineStringColor,
 				styles.lineStringColor,

--- a/packages/terra-draw/src/modes/render/render.mode.ts
+++ b/packages/terra-draw/src/modes/render/render.mode.ts
@@ -178,6 +178,7 @@ export class TerraDrawRenderMode extends TerraDrawBaseDrawMode<RenderModeStyling
 				defaultStyles.zIndex,
 				feature,
 			),
+			lineStringDash: undefined,
 		};
 	}
 

--- a/packages/terra-draw/src/util/styling.ts
+++ b/packages/terra-draw/src/util/styling.ts
@@ -20,5 +20,6 @@ export const getDefaultStyling = (): TerraDrawAdapterStyling => {
 		markerUrl: undefined,
 		markerHeight: undefined,
 		markerWidth: undefined,
+		lineStringDash: undefined,
 	};
 };


### PR DESCRIPTION
## Description of Changes

Adds initial support for dashed line styling. This can be built on by all adapters to allow styling of dashed lines.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/48

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 