### PR TITLE
feat(terra-draw-google-maps-adapter): Allow multiple instances of `TerraDraw`/`TerraDrawGoogleMapsAdapter` to coexist

### DIFF
--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -1,6 +1,8 @@
 import { AllStories } from "../../common/stories";
 import { DefaultMeta } from "../../common/meta";
 import { SetupGoogle } from "./setup";
+import { SetupGoogleMultipleInstances } from "./multiple-instances";
+import { DefaultSize, LocationNewYork, DefaultZoom } from "../../common/config";
 
 const meta = {
 	...DefaultMeta,
@@ -67,3 +69,14 @@ export const ProgrammaticRotate = AllStories.ProgrammaticRotate;
 export const ProgrammaticScale = AllStories.ProgrammaticScale;
 export const ProgrammaticUpdate = AllStories.ProgrammaticUpdate;
 export const UndoRedo = AllStories.UndoRedo;
+export const MultipleInstances = {
+	args: {
+		id: "multiple-instances",
+		modes: [],
+		...DefaultSize,
+		...LocationNewYork,
+		...DefaultZoom,
+		showButtons: false,
+	},
+	render: SetupGoogleMultipleInstances,
+};

--- a/packages/storybook/src/stories/google/multiple-instances.ts
+++ b/packages/storybook/src/stories/google/multiple-instances.ts
@@ -1,0 +1,239 @@
+import {
+	TerraDraw,
+	TerraDrawPolygonMode,
+} from "../../../../terra-draw/src/terra-draw";
+import { TerraDrawGoogleMapsAdapter } from "../../../../terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter";
+import { whenElementExists } from "../../common/setup";
+import { StoryArgs } from "../../common/config";
+import { initialiseGoogleMap } from "./setup";
+
+const PRIMARY = "#019cfd";
+const BORDER = "#ccc";
+const WARNING = "#f44336";
+const BACKGROUND = "#fff";
+const TEXT = "#333";
+const LIGHT_TEXT = "#fff";
+
+function createButton(
+	label: string,
+	id: string,
+	opts?: { background?: string; color?: string },
+): HTMLButtonElement {
+	const btn = document.createElement("button");
+	btn.id = id;
+	btn.textContent = label;
+	btn.disabled = true;
+	btn.style.padding = "8px 16px";
+	btn.style.margin = "0 4px";
+	btn.style.border = opts?.background
+		? `2px solid ${opts.background}`
+		: `2px solid ${BORDER}`;
+	btn.style.borderRadius = "4px";
+	btn.style.background = opts?.background ?? BACKGROUND;
+	btn.style.color = opts?.color ?? TEXT;
+	btn.style.cursor = "pointer";
+	btn.style.width = "180px";
+	btn.style.fontWeight = "bold";
+	return btn;
+}
+
+function setActive(btn: HTMLButtonElement) {
+	btn.style.border = `solid 2px ${PRIMARY}`;
+}
+
+function setInactive(btn: HTMLButtonElement) {
+	btn.style.border = `1px solid ${BORDER}`;
+}
+
+const rendered: { [key: string]: HTMLElement } = {};
+
+export function SetupGoogleMultipleInstances(args: StoryArgs): HTMLElement {
+	if (rendered[args.id]) {
+		return rendered[args.id];
+	}
+
+	const container = document.createElement("div");
+	container.setAttribute("data-adapter", "google");
+	container.setAttribute("data-testid", "container");
+	container.style.display = "flex";
+	container.style.flexDirection = "column";
+	container.style.gap = "10px";
+
+	const makeControlRow = (label: string) => {
+		const row = document.createElement("div");
+		row.style.display = "flex";
+		row.style.alignItems = "center";
+		row.style.gap = "10px";
+		row.style.height = "40px";
+		const labelEl = document.createElement("strong");
+		labelEl.textContent = label;
+		labelEl.style.minWidth = "90px";
+		row.appendChild(labelEl);
+		return row;
+	};
+
+	const drawBtn1 = createButton("Draw Polygon", "mode-button-polygon-1");
+	const clearBtn1 = createButton("Clear", "clear-1", {
+		background: WARNING,
+		color: LIGHT_TEXT,
+	});
+	const controls1 = makeControlRow("Instance 1:");
+	controls1.appendChild(drawBtn1);
+	controls1.appendChild(clearBtn1);
+
+	const drawBtn2 = createButton("Draw Polygon", "mode-button-polygon-2");
+	const clearBtn2 = createButton("Clear", "clear-2", {
+		background: WARNING,
+		color: LIGHT_TEXT,
+	});
+	const controls2 = makeControlRow("Instance 2:");
+	controls2.appendChild(drawBtn2);
+	controls2.appendChild(clearBtn2);
+
+	const mapContainer = document.createElement("div");
+	mapContainer.id = `map-${args.id}`;
+	mapContainer.style.width = args.width;
+	mapContainer.style.height = args.height;
+	mapContainer.style.border = `1px solid ${BORDER}`;
+
+	container.appendChild(controls1);
+	container.appendChild(controls2);
+	container.appendChild(mapContainer);
+
+	whenElementExists(`#${mapContainer.id}`, () => {
+		initialiseGoogleMap({
+			mapContainer,
+			centerLat: args.centerLat,
+			centerLng: args.centerLng,
+			zoom: args.zoom,
+		})
+			.then((mapConfig) => {
+				mapConfig.map.addListener("projection_changed", () => {
+					const adapter1 = new TerraDrawGoogleMapsAdapter({
+						lib: mapConfig.lib,
+						map: mapConfig.map,
+					});
+					const draw1 = new TerraDraw({
+						adapter: adapter1,
+						modes: [
+							new TerraDrawPolygonMode({
+								styles: {
+									fillColor: "#3b82f6",
+									fillOpacity: 0.3,
+									outlineColor: "#1d4ed8",
+									outlineWidth: 2,
+								},
+							}),
+						],
+					});
+
+					const adapter2 = new TerraDrawGoogleMapsAdapter({
+						lib: mapConfig.lib,
+						map: mapConfig.map,
+					});
+					const draw2 = new TerraDraw({
+						adapter: adapter2,
+						modes: [
+							new TerraDrawPolygonMode({
+								styles: {
+									fillColor: "#ef4444",
+									fillOpacity: 0.3,
+									outlineColor: "#b91c1c",
+									outlineWidth: 2,
+								},
+							}),
+						],
+					});
+
+					draw1.start();
+					draw2.start();
+
+					draw1.on("ready", () => {
+						// Seed instance 1 with a blue polygon (on left)
+						draw1.addFeatures([
+							{
+								type: "Feature",
+								properties: { mode: "polygon" },
+								geometry: {
+									type: "Polygon",
+									coordinates: [
+										[
+											[-74.025, 40.705],
+											[-74.01, 40.705],
+											[-74.01, 40.72],
+											[-74.025, 40.72],
+											[-74.025, 40.705],
+										],
+									],
+								},
+							},
+						]);
+
+						drawBtn1.disabled = false;
+						clearBtn1.disabled = false;
+
+						// Start with instance 1 active
+						draw1.setMode("polygon");
+						draw2.setMode("static");
+						setActive(drawBtn1);
+
+						drawBtn1.addEventListener("click", () => {
+							draw1.setMode("polygon");
+							draw2.setMode("static");
+							setActive(drawBtn1);
+							setInactive(drawBtn2);
+						});
+
+						clearBtn1.addEventListener("click", () => draw1.clear());
+					});
+
+					draw2.on("ready", () => {
+						// Seed instance 2 with a red polygon (on right)
+						draw2.addFeatures([
+							{
+								type: "Feature",
+								properties: { mode: "polygon" },
+								geometry: {
+									type: "Polygon",
+									coordinates: [
+										[
+											[-74.002, 40.705],
+											[-73.987, 40.705],
+											[-73.987, 40.72],
+											[-74.002, 40.72],
+											[-74.002, 40.705],
+										],
+									],
+								},
+							},
+						]);
+
+						drawBtn2.disabled = false;
+						clearBtn2.disabled = false;
+
+						drawBtn2.addEventListener("click", () => {
+							draw2.setMode("polygon");
+							draw1.setMode("static");
+							setActive(drawBtn2);
+							setInactive(drawBtn1);
+						});
+
+						clearBtn2.addEventListener("click", () => draw2.clear());
+					});
+				});
+			})
+			.catch((error) => {
+				// eslint-disable-next-line no-console
+				console.warn("Error initializing Google Maps:", error);
+				const errorDiv = document.createElement("div");
+				errorDiv.style.padding = "20px";
+				errorDiv.style.color = "#d32f2f";
+				errorDiv.textContent =
+					"Failed to load Google Maps. Check console for details.";
+				mapContainer.appendChild(errorDiv);
+			});
+	});
+
+	rendered[args.id] = container;
+	return container;
+}

--- a/packages/storybook/src/stories/google/setup.ts
+++ b/packages/storybook/src/stories/google/setup.ts
@@ -11,7 +11,7 @@ import { StoryArgs } from "../../common/config";
 
 let setOptionsCalled = false;
 
-const initialiseGoogleMap = async ({
+export const initialiseGoogleMap = async ({
 	mapContainer,
 	centerLat,
 	centerLng,

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -8,9 +8,37 @@ import {
 	TerraDrawMouseEvent,
 } from "terra-draw";
 
+const createMockDataLayer = (
+	overrides?: Partial<{
+		addListener: jest.Mock;
+		getStyle: jest.Mock;
+		setStyle: jest.Mock;
+		addGeoJson: jest.Mock;
+		remove: jest.Mock;
+		getFeatureById: jest.Mock;
+		forEach: jest.Mock;
+		setMap: jest.Mock;
+	}>,
+) => {
+	let currentStyle: unknown = null;
+	return {
+		addListener: jest.fn(() => ({ remove: jest.fn() })),
+		getStyle: jest.fn(() => currentStyle),
+		setStyle: jest.fn((s: unknown) => {
+			currentStyle = s;
+		}),
+		addGeoJson: jest.fn(),
+		remove: jest.fn(),
+		getFeatureById: jest.fn(),
+		forEach: jest.fn(),
+		setMap: jest.fn(),
+		...overrides,
+	};
+};
+
 const createMockGoogleMap = (overrides?: Partial<google.maps.Map>) => {
 	// Minimal emulation of google.maps.Data styling behavior.
-	// The adapter calls `map.data.getStyle()` to check if a style function is set.
+	// The adapter calls `_dataLayer.getStyle()` to check if a style function is set.
 	let currentStyle: unknown = null;
 
 	return {
@@ -30,6 +58,7 @@ const createMockGoogleMap = (overrides?: Partial<google.maps.Map>) => {
 			setStyle: jest.fn((style) => {
 				currentStyle = style;
 			}),
+			setMap: jest.fn(),
 		} as unknown as google.maps.Data,
 		fitBounds: jest.fn(),
 		getCenter: jest.fn(),
@@ -217,6 +246,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					OverlayView: jest.fn().mockImplementation(() => ({
 						setMap: jest.fn(),
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as any,
 				map: createMockGoogleMap(),
 				minPixelDragDistance: 1,
@@ -237,7 +267,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 
 	describe("register", () => {
 		it("registers event listeners", () => {
-			const addListenerMock = jest.fn();
+			const addListenerMock = jest.fn(() => ({ remove: jest.fn() }));
 
 			const div = {
 				addEventListener: jest.fn(),
@@ -255,6 +285,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				})) as any,
 				data: {
 					addListener: addListenerMock,
+					setMap: jest.fn(),
 				} as any,
 			});
 			const adapter = new TerraDrawGoogleMapsAdapter({
@@ -262,6 +293,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					OverlayView: jest.fn(() => ({
 						setMap: jest.fn(),
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as any,
 				map: mockMap,
 				forwardMapElementEvents: true,
@@ -296,6 +328,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					addEventListener: jest.fn(),
 				} as unknown as HTMLDivElement;
 
+				const mockDataLayer = createMockDataLayer();
 				const mockMap = createMockGoogleMap({
 					getDiv: jest.fn(() => ({
 						id: "map",
@@ -303,15 +336,13 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						addEventListener: jest.fn(),
 						removeEventListener: jest.fn(),
 					})) as any,
-					data: {
-						addListener: jest.fn(),
-					} as any,
 				});
 
 				const callbacks = MockCallbacks();
 				const adapter = new TerraDrawGoogleMapsAdapter({
 					lib: {
 						OverlayView: jest.fn(() => overlay),
+						Data: jest.fn(() => mockDataLayer),
 					} as any,
 					map: mockMap,
 					forwardMapElementEvents: true,
@@ -342,9 +373,6 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						addEventListener: keyboardDiv.addEventListener,
 						removeEventListener: keyboardDiv.removeEventListener,
 					})) as any,
-					data: {
-						addListener: jest.fn(),
-					} as any,
 				});
 
 				const adapter = new TerraDrawGoogleMapsAdapter({
@@ -352,6 +380,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						OverlayView: jest.fn(() => ({
 							setMap: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 					forwardMapElementEvents: false,
@@ -402,9 +431,6 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						addEventListener: jest.fn(),
 						removeEventListener: jest.fn(),
 					})) as any,
-					data: {
-						addListener: jest.fn(),
-					} as any,
 				});
 
 				const adapter = new TerraDrawGoogleMapsAdapter({
@@ -412,6 +438,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						OverlayView: jest.fn(() => ({
 							setMap: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 					forwardMapElementEvents: true,
@@ -463,9 +490,6 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						addEventListener: jest.fn(),
 						removeEventListener: jest.fn(),
 					})) as any,
-					data: {
-						addListener: jest.fn(),
-					} as any,
 				});
 
 				const callbacks = MockCallbacks();
@@ -474,6 +498,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						OverlayView: jest.fn(() => ({
 							setMap: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 					forwardMapElementEvents: true,
@@ -542,6 +567,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				data: {
 					addListener: jest.fn(() => ({ remove: jest.fn() })),
 					setStyle: jest.fn(),
+					setMap: jest.fn(),
 				} as any,
 			});
 
@@ -551,6 +577,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getMap: jest.fn(() => ({})),
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as any,
 				map: mockMap,
 				forwardMapElementEvents: true,
@@ -585,15 +612,13 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					addEventListener: jest.fn(),
 					removeEventListener: jest.fn(),
 				})) as any,
-				data: {
-					setStyle: jest.fn(),
-				} as any,
 			});
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
 					OverlayView: jest.fn(() => ({
 						setMap: jest.fn(),
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as any,
 				map: mockMap,
 			});
@@ -627,6 +652,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				data: {
 					addListener: addListenerMock,
 					setStyle: jest.fn(),
+					setMap: jest.fn(),
 				} as any,
 			});
 			const adapter = new TerraDrawGoogleMapsAdapter({
@@ -635,6 +661,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getMap: jest.fn(() => ({})),
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as any,
 				map: mockMap,
 				forwardMapElementEvents: true,
@@ -665,6 +692,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(() => undefined),
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -707,6 +735,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -757,6 +786,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -837,6 +867,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -884,6 +915,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(() => undefined),
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -907,6 +939,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(() => undefined),
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -934,6 +967,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -964,6 +998,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -997,6 +1032,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
 				map: mapMock,
 			});
@@ -1023,6 +1059,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as any,
 				map: createMockGoogleMap(),
 			});
@@ -1036,6 +1073,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 
 		it("throws when projection unavailable", () => {
 			const getProjectionMock = jest.fn(() => undefined);
+			const mapMock = createMockGoogleMap();
 
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
@@ -1044,8 +1082,9 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: getProjectionMock,
 					})),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
-				map: createMockGoogleMap(),
+				map: mapMock,
 			});
 
 			adapter.register(MockCallbacks());
@@ -1064,6 +1103,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 					lat: () => testLat,
 				})),
 			}));
+			const mapMock = createMockGoogleMap();
 
 			const adapter = new TerraDrawGoogleMapsAdapter({
 				lib: {
@@ -1073,8 +1113,9 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						getProjection: getProjectionMock,
 					})),
 					Point: jest.fn(),
+					Data: jest.fn(() => mapMock.data),
 				} as any,
-				map: createMockGoogleMap(),
+				map: mapMock,
 			});
 
 			adapter.register(MockCallbacks());
@@ -1106,6 +1147,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as any,
 				map,
 			});
@@ -1139,6 +1181,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as any,
 				map,
 			});
@@ -1179,6 +1222,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as any,
 				map,
 			});
@@ -1219,6 +1263,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: () => {},
 						getProjection: () => {},
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as any,
 				map: mockMap,
 			});
@@ -1279,9 +1324,12 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						getProjection: jest.fn(),
 					})),
 					LatLng: jest.fn(),
-					Data: {
-						Point: jest.fn(),
-					},
+					Data: Object.assign(
+						jest.fn(() => mockMap.data),
+						{
+							Point: jest.fn(),
+						},
+					),
 				} as any,
 				map: mockMap,
 			});
@@ -1346,6 +1394,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -1427,6 +1476,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -1498,6 +1548,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -1566,6 +1617,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -1628,11 +1680,14 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							getProjection: jest.fn(),
 						})),
 						LatLng: jest.fn(),
-						Data: {
-							LineString: jest.fn(),
-							Polygon: jest.fn(),
-							Point: jest.fn(),
-						},
+						Data: Object.assign(
+							jest.fn(() => mockMap.data),
+							{
+								LineString: jest.fn(),
+								Polygon: jest.fn(),
+								Point: jest.fn(),
+							},
+						),
 					} as any,
 					map: mockMap,
 				});
@@ -1694,6 +1749,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as unknown as typeof google.maps,
 					map: mockMap,
 				});
@@ -1773,6 +1829,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as unknown as typeof google.maps,
 					map: mockMap,
 				});
@@ -1841,6 +1898,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -1906,6 +1964,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as unknown as typeof google.maps,
 					map: mockMap,
 				});
@@ -1970,11 +2029,14 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							getProjection: jest.fn(),
 						})),
 						LatLng: jest.fn(),
-						Data: {
-							LineString: jest.fn(),
-							Polygon: jest.fn(),
-							Point: jest.fn(),
-						},
+						Data: Object.assign(
+							jest.fn(() => mockMap.data),
+							{
+								LineString: jest.fn(),
+								Polygon: jest.fn(),
+								Point: jest.fn(),
+							},
+						),
 					} as unknown as typeof google.maps,
 					map: mockMap,
 				});
@@ -2032,6 +2094,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as unknown as typeof google.maps,
 					map: mockMap,
 				});
@@ -2111,6 +2174,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -2165,6 +2229,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							setMap: jest.fn(),
 							getProjection: jest.fn(),
 						})),
+						Data: jest.fn(() => mockMap.data),
 					} as any,
 					map: mockMap,
 				});
@@ -2227,11 +2292,14 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 							getProjection: jest.fn(),
 						})),
 						LatLng: jest.fn(),
-						Data: {
-							LineString: jest.fn(),
-							Polygon: jest.fn(),
-							Point: jest.fn(),
-						},
+						Data: Object.assign(
+							jest.fn(() => mockMap.data),
+							{
+								LineString: jest.fn(),
+								Polygon: jest.fn(),
+								Point: jest.fn(),
+							},
+						),
 					} as any,
 					map: mockMap,
 				});
@@ -2339,11 +2407,14 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						LatLngBounds: jest.fn(),
 						Point: jest.fn(),
 						Size: jest.fn(),
-						Data: {
-							Point: jest.fn(),
-							LineString: jest.fn(),
-							Polygon: jest.fn(),
-						},
+						Data: Object.assign(
+							jest.fn(() => mockMap.data),
+							{
+								Point: jest.fn(),
+								LineString: jest.fn(),
+								Polygon: jest.fn(),
+							},
+						),
 					} as any,
 					map: mockMap,
 				});
@@ -2558,6 +2629,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
+					Data: jest.fn(() => createMockDataLayer()),
 				} as unknown as typeof google.maps,
 				map: createMockGoogleMap(),
 			});
@@ -2582,6 +2654,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 						setMap: jest.fn(),
 						getProjection: jest.fn(),
 					})),
+					Data: jest.fn(() => mockMap.data),
 				} as unknown as typeof google.maps,
 				map: mockMap,
 			});

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -265,6 +265,101 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 		});
 	});
 
+	describe("multiple instances against the same map", () => {
+		it("each adapter creates its own independent data layer", () => {
+			const dataLayerOne = createMockDataLayer();
+			const dataLayerTwo = createMockDataLayer();
+			let callCount = 0;
+			const DataMock = jest.fn(() =>
+				callCount++ === 0 ? dataLayerOne : dataLayerTwo,
+			);
+			const mockMap = createMockGoogleMap();
+			const lib = {
+				OverlayView: jest.fn(() => ({ setMap: jest.fn() })),
+				Data: DataMock,
+			} as any;
+
+			new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+			new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+
+			expect(DataMock).toHaveBeenCalledTimes(2);
+			expect(dataLayerOne).not.toBe(dataLayerTwo);
+		});
+
+		it("registering two adapters attaches each adapter's own data layer to the map independently", () => {
+			const dataLayerOne = createMockDataLayer();
+			const dataLayerTwo = createMockDataLayer();
+			let callCount = 0;
+			const DataMock = jest.fn(() =>
+				callCount++ === 0 ? dataLayerOne : dataLayerTwo,
+			);
+			const div = {
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+			const mockMap = createMockGoogleMap({
+				getDiv: jest.fn(() => ({
+					id: "map",
+					querySelector: jest.fn(() => div),
+					addEventListener: jest.fn(),
+					removeEventListener: jest.fn(),
+				})) as any,
+			});
+			const lib = {
+				OverlayView: jest.fn(() => ({ setMap: jest.fn() })),
+				Data: DataMock,
+			} as any;
+
+			const adapterOne = new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+			const adapterTwo = new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+
+			adapterOne.register(MockCallbacks());
+			adapterTwo.register(MockCallbacks());
+
+			expect(dataLayerOne.setMap).toHaveBeenCalledWith(mockMap);
+			expect(dataLayerTwo.setMap).toHaveBeenCalledWith(mockMap);
+		});
+
+		it("unregistering one adapter only detaches its own data layer", () => {
+			const dataLayerOne = createMockDataLayer();
+			const dataLayerTwo = createMockDataLayer();
+			let callCount = 0;
+			const DataMock = jest.fn(() =>
+				callCount++ === 0 ? dataLayerOne : dataLayerTwo,
+			);
+			const div = {
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+			const mockMap = createMockGoogleMap({
+				getDiv: jest.fn(() => ({
+					id: "map",
+					querySelector: jest.fn(() => div),
+					addEventListener: jest.fn(),
+					removeEventListener: jest.fn(),
+				})) as any,
+			});
+			const lib = {
+				OverlayView: jest.fn(() => ({
+					setMap: jest.fn(),
+					getMap: jest.fn(() => ({})),
+				})),
+				Data: DataMock,
+			} as any;
+
+			const adapterOne = new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+			const adapterTwo = new TerraDrawGoogleMapsAdapter({ lib, map: mockMap });
+
+			adapterOne.register(MockCallbacks());
+			adapterTwo.register(MockCallbacks());
+
+			adapterOne.unregister();
+
+			expect(dataLayerOne.setMap).toHaveBeenLastCalledWith(null);
+			expect(dataLayerTwo.setMap).not.toHaveBeenCalledWith(null);
+		});
+	});
+
 	describe("register", () => {
 		it("registers event listeners", () => {
 			const addListenerMock = jest.fn(() => ({ remove: jest.fn() }));

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -31,6 +31,8 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			typeof config.coordinatePrecision === "number"
 				? config.coordinatePrecision
 				: 9;
+
+		this._dataLayer = new this._lib.Data();
 	}
 
 	private _forwardMapElementEvents: boolean = false;
@@ -38,6 +40,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 	private _cursorStyleSheet: HTMLStyleElement | undefined;
 	private _lib: typeof google.maps;
 	private _map: google.maps.Map;
+	private _dataLayer: google.maps.Data;
 	private _overlay: google.maps.OverlayView | undefined;
 	private _markerClickListener: any | undefined;
 	private _markerMouseMoveListener: ((event: MouseEvent) => void) | undefined;
@@ -94,6 +97,11 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 		this._overlay.onRemove = () => {
 			// No-op
 		};
+
+		// Attach our own data layer to this map instance so multiple adapters
+		// can coexist against the same google.maps.Map without sharing the
+		// default map.data layer.
+		this._dataLayer.setMap(this._map);
 
 		if (this._forwardMapElementEvents) {
 			const AdvancedMarkerElementTag = "gmp-advanced-marker";
@@ -180,7 +188,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 		// Clicking on data geometries triggers
 		// swallows the map onclick event,
 		// so we need to forward it to the click callback handler
-		this._clickEventListener = this._map.data.addListener(
+		this._clickEventListener = this._dataLayer.addListener(
 			"click",
 			(
 				event: google.maps.MapMouseEvent & {
@@ -196,7 +204,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			},
 		);
 
-		this._mouseMoveEventListener = this._map.data.addListener(
+		this._mouseMoveEventListener = this._dataLayer.addListener(
 			"mousemove",
 			(
 				event: google.maps.MapMouseEvent & {
@@ -392,6 +400,9 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			this._overlay.setMap(null);
 		}
 		this._overlay = undefined;
+
+		this._dataLayer.setMap(null);
+
 		this._readyCalled = false;
 	}
 
@@ -581,8 +592,8 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 	render(changes: TerraDrawChanges, styling: TerraDrawStylingFunction) {
 		this.styling = styling;
 
-		if (!this._map.data.getStyle()) {
-			this._map.data.setStyle((feature) => this.style(feature));
+		if (!this._dataLayer.getStyle()) {
+			this._dataLayer.setStyle((feature) => this.style(feature));
 		}
 
 		// Ensure scheduler state exists
@@ -656,9 +667,9 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 				if (this._hasRenderedFeatures) {
 					// Deletes
 					for (const deletedId of deletedIds) {
-						const featureToDelete = this._map.data.getFeatureById(deletedId);
+						const featureToDelete = this._dataLayer.getFeatureById(deletedId);
 						if (featureToDelete) {
-							this._map.data.remove(featureToDelete);
+							this._dataLayer.remove(featureToDelete);
 							this.renderedFeatureIds.delete(deletedId);
 						}
 					}
@@ -667,7 +678,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 					for (const updatedFeature of updated) {
 						if (!updatedFeature?.id) throw new Error("Feature is not valid");
 
-						const featureToUpdate = this._map.data.getFeatureById(
+						const featureToUpdate = this._dataLayer.getFeatureById(
 							String(updatedFeature.id),
 						);
 
@@ -730,7 +741,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 					// Creates
 					for (const createdFeature of created) {
 						this.renderedFeatureIds.add(String(createdFeature.id));
-						this._map.data.addGeoJson(createdFeature);
+						this._dataLayer.addGeoJson(createdFeature);
 					}
 				} else {
 					// First render: treat everything as a feature collection create
@@ -744,7 +755,7 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 					}
 
 					if (features.length) {
-						this._map.data.addGeoJson({
+						this._dataLayer.addGeoJson({
 							type: "FeatureCollection",
 							features,
 						} as GeoJsonObject);
@@ -769,11 +780,11 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 
 	private clearLayers() {
 		if (this._hasRenderedFeatures) {
-			this._map.data.forEach((feature) => {
+			this._dataLayer.forEach((feature) => {
 				const id = feature.getId() as string;
 				const hasFeature = this.renderedFeatureIds.has(id);
 				if (hasFeature) {
-					this._map.data.remove(feature);
+					this._dataLayer.remove(feature);
 				}
 			});
 			this.renderedFeatureIds = new Set();
@@ -793,10 +804,8 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 			this.clearLayers();
 		}
 
-		// clean up any styles set on the default data layer
-		if (this._map.data) {
-			this._map.data.setStyle(null);
-		}
+		// clean up any styles set on this adapter's data layer
+		this._dataLayer.setStyle(null);
 	}
 
 	public getCoordinatePrecision(): number {


### PR DESCRIPTION
## Description of Changes

Instead of using the default data layer associated with the map instance, the Google Maps adapter now creates and owns a `google.maps.Data` instance. This allows for multiple instances to coexist without colliding.

### Screenshots

<table>
<tr>
<td>
<figure>
<img width="763" height="791" alt="Screenshot 2026-05-15 at 15 42 06" src="https://github.com/user-attachments/assets/c2b0dd10-8296-4b69-9133-454b8931d26e" />
<figcaption>Before change</figcaption>
</figure>
</td>
<td>
<figure>
<img width="763" height="791" alt="Screenshot 2026-05-15 at 15 33 46" src="https://github.com/user-attachments/assets/71417774-5f35-44e9-9132-e2f6ca21988d" />
<figcaption>After change</figcaption>
</figure></td>
</tr>
</table>

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/891

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 