### PR TITLE
fix(terra-draw-maplibre-gl-adapter): fix linestring rendering

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -19,9 +19,9 @@ import {
 } from "maplibre-gl";
 import { Feature, LineString, Point, Polygon } from "geojson";
 
-export class TerraDrawMapLibreGLAdapter<
-	MapType,
-> extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawMapLibreGLAdapter<MapType>
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	constructor(
 		config: {
 			map: MapType;
@@ -197,7 +197,7 @@ export class TerraDrawMapLibreGLAdapter<
 			paint["line-dasharray"] = [
 				"coalesce",
 				["get", "lineStringDash"],
-				["literal", []],
+				["literal", [1, 0]],
 			];
 		}
 


### PR DESCRIPTION
## Description of Changes

Ensures that lines are rendered correctly when lineDashString is not passed.

## Link to Issue
 
https://github.com/JamesLMilner/terra-draw/issues/889

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 