### PR TITLE
fix(terra-draw-mapbox-gl-adapter): use version off of map rather than getVersion import

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -627,6 +627,56 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			deletedIds: [],
 		};
 
+		it("adds line-dasharray support when maplibre version is high enough", () => {
+			const map = createMapLibreGLMap();
+			(map as unknown as { version: string }).version = "5.8.0";
+
+			const adapter = new TerraDrawMapLibreGLAdapter({
+				map: map as maplibregl.Map,
+			});
+
+			adapter.register(MockCallbacks());
+
+			const lineLayerCall = (map.addLayer as jest.Mock).mock.calls.find(
+				([layer]) => (layer as { id?: string }).id === "td-linestring",
+			);
+
+			expect(lineLayerCall).toBeDefined();
+
+			const lineLayer = lineLayerCall?.[0] as {
+				paint?: { "line-dasharray"?: unknown };
+			};
+
+			expect(lineLayer.paint?.["line-dasharray"]).toEqual([
+				"coalesce",
+				["get", "lineStringDash"],
+				["literal", [1, 0]],
+			]);
+		});
+
+		it("does not add line-dasharray support when maplibre version is too low", () => {
+			const map = createMapLibreGLMap();
+			(map as unknown as { version: string }).version = "5.7.9";
+
+			const adapter = new TerraDrawMapLibreGLAdapter({
+				map: map as maplibregl.Map,
+			});
+
+			adapter.register(MockCallbacks());
+
+			const lineLayerCall = (map.addLayer as jest.Mock).mock.calls.find(
+				([layer]) => (layer as { id?: string }).id === "td-linestring",
+			);
+
+			expect(lineLayerCall).toBeDefined();
+
+			const lineLayer = lineLayerCall?.[0] as {
+				paint?: { "line-dasharray"?: unknown };
+			};
+
+			expect(lineLayer.paint?.["line-dasharray"]).toBeUndefined();
+		});
+
 		it("can register then unregister successfully", () => {
 			jest.spyOn(window, "requestAnimationFrame");
 

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -9,13 +9,12 @@ import {
 	GeoJSONStoreGeometries,
 } from "terra-draw";
 import {
-	CircleLayerSpecification,
-	FillLayerSpecification,
-	GeoJSONSource,
-	LineLayerSpecification,
-	Map as MaplibreMap,
-	PointLike,
-	getVersion,
+	type CircleLayerSpecification,
+	type FillLayerSpecification,
+	type GeoJSONSource,
+	type LineLayerSpecification,
+	type Map as MaplibreMap,
+	type PointLike,
 } from "maplibre-gl";
 import { Feature, LineString, Point, Polygon } from "geojson";
 
@@ -106,13 +105,12 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 		return [onPx / width, offPx / width];
 	}
 
-	private isMapLibreAtLeast(minVersion = "5.8.0") {
-		const runtimeVersion =
-			getVersion?.() || (this._map as unknown as { version?: string }).version;
+	private isMapLibreAtLeast(minVersion: string): boolean {
+		const runtimeVersion = this._map.version;
 
-		// If version cannot be resolved, prefer enabling dashed lines rather than silently disabling them.
+		// Default to not supporting features if we can't determine the version, as we know some features we use require a minimum version.
 		if (!runtimeVersion) {
-			return true;
+			return false;
 		}
 
 		const parse = (v: string): [number, number, number] | null => {


### PR DESCRIPTION
## Description of Changes

We mistakenly and unnecessarily import `getVersion` from `maplibre-gl`. We should avoid this as imports shouldn't happen directly and instead anything necessary from the library should be injected in. We also never really needed this as the `map` object has `version` which gives you the library version.

## Link to Issue

#888 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 