### PR TITLE
fix(terra-draw): capture programmatic geometry and property edits in undo redo stack

### DIFF
--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -1897,6 +1897,84 @@ describe("Terra Draw", () => {
 					.anotherProperty,
 			).toBe(undefined);
 		});
+
+		it("records property edits for session undo/redo", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPolygonMode()],
+				undoRedo: {
+					sessionLevel: new TerraDrawSessionUndoRedo(),
+				},
+			});
+
+			draw.start();
+			draw.addFeatures([{ ...baseFeature }]);
+
+			draw.updateFeatureProperties(baseFeature.id as FeatureId, {
+				customProperty: "customValue",
+			});
+
+			expect(draw.canUndo()).toBe(true);
+			expect(
+				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
+					.customProperty,
+			).toBe("customValue");
+
+			expect(draw.undo()).toBe(true);
+			expect(
+				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
+					.customProperty,
+			).toBe(undefined);
+
+			expect(draw.canRedo()).toBe(true);
+			expect(draw.redo()).toBe(true);
+			expect(
+				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
+					.customProperty,
+			).toBe("customValue");
+		});
+
+		it("emits one history push and no finish callback for api property updates", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPolygonMode()],
+				undoRedo: {
+					sessionLevel: new TerraDrawSessionUndoRedo(),
+				},
+			});
+
+			const onFinish = jest.fn();
+			const onHistory = jest.fn();
+
+			draw.on("finish", onFinish);
+			draw.on("history", onHistory);
+
+			draw.start();
+			draw.addFeatures([{ ...baseFeature }]);
+
+			onFinish.mockClear();
+			onHistory.mockClear();
+
+			draw.updateFeatureProperties(baseFeature.id as FeatureId, {
+				customProperty: "customValue",
+			});
+
+			expect(onFinish).not.toHaveBeenCalled();
+			const sessionHistoryEvents = onHistory.mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.stack === "session");
+
+			expect(sessionHistoryEvents.length).toBeGreaterThan(0);
+			expect(
+				sessionHistoryEvents.every((event) => event.cause === "push"),
+			).toBe(true);
+		});
 	});
 
 	describe("updateFeatureGeometry", () => {
@@ -2429,6 +2507,323 @@ describe("Terra Draw", () => {
 				});
 			}).toThrow("Guidance features are not allowed to be updated directly");
 		});
+
+		it("records coordinate deletion for session undo/redo", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPolygonMode(), new TerraDrawSelectMode()],
+				undoRedo: {
+					sessionLevel: new TerraDrawSessionUndoRedo(),
+				},
+			});
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[26, 33], // This coordinate will be deleted in the update
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			expect(result.valid).toBe(true);
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "Polygon",
+				coordinates: [
+					[
+						[25, 34],
+						[26, 35],
+						[27, 34],
+						// [26, 33] is deleted here!
+						[25, 34],
+					],
+				],
+			});
+
+			expect(draw.canUndo()).toBe(true);
+
+			const undone = draw.undo();
+			expect(undone).toBe(true);
+
+			const snapshotAfterUndo = draw.getSnapshot();
+			expect(snapshotAfterUndo).toHaveLength(1);
+			expect(snapshotAfterUndo[0].geometry).toEqual({
+				type: "Polygon",
+				coordinates: [
+					[
+						[25, 34],
+						[26, 35],
+						[27, 34],
+						[26, 33],
+						[25, 34],
+					],
+				],
+			});
+
+			expect(draw.canRedo()).toBe(true);
+
+			const redone = draw.redo();
+			expect(redone).toBe(true);
+
+			const snapshotAfterRedo = draw.getSnapshot();
+			expect(snapshotAfterRedo).toHaveLength(1);
+			expect(snapshotAfterRedo[0].geometry).toEqual({
+				type: "Polygon",
+				coordinates: [
+					[
+						[25, 34],
+						[26, 35],
+						[27, 34],
+						[25, 34],
+					],
+				],
+			});
+		});
+
+		it("emits one history event for api geometry updates and replay does not push", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [
+					new TerraDrawPolygonMode(),
+					new TerraDrawSelectMode({
+						flags: {
+							polygon: {
+								feature: {
+									coordinates: {
+										draggable: true,
+									},
+								},
+							},
+						},
+					}),
+				],
+				undoRedo: {
+					sessionLevel: new TerraDrawSessionUndoRedo(),
+				},
+			});
+
+			const onHistory = jest.fn();
+			draw.on("history", onHistory);
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			draw.selectFeature(result.id as FeatureId);
+			onHistory.mockClear();
+
+			draw.updateFeatureGeometry(result.id as FeatureId, {
+				type: "Polygon",
+				coordinates: [
+					[
+						[30, 40],
+						[31, 41],
+						[32, 40],
+						[30, 40],
+					],
+				],
+			});
+
+			const updateSessionCauses = onHistory.mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.stack === "session")
+				.map((event) => event.cause);
+
+			expect(updateSessionCauses.length).toBeGreaterThan(0);
+			expect(updateSessionCauses.every((cause) => cause === "push")).toBe(true);
+
+			onHistory.mockClear();
+			expect(draw.undo()).toBe(true);
+			const undoSessionCauses = onHistory.mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.stack === "session")
+				.map((event) => event.cause);
+			expect(undoSessionCauses.length).toBeGreaterThan(0);
+			expect(undoSessionCauses.some((cause) => cause === "undo")).toBe(true);
+			expect(undoSessionCauses.some((cause) => cause === "push")).toBe(false);
+
+			onHistory.mockClear();
+			expect(draw.redo()).toBe(true);
+			const redoSessionCauses = onHistory.mock.calls
+				.map((call) => call[0])
+				.filter((event) => event.stack === "session")
+				.map((event) => event.cause);
+			expect(redoSessionCauses.length).toBeGreaterThan(0);
+			expect(redoSessionCauses.some((cause) => cause === "redo")).toBe(true);
+			expect(redoSessionCauses.some((cause) => cause === "push")).toBe(false);
+		});
+
+		it("replays mixed geometry and property updates in order", () => {
+			const draw = new TerraDraw({
+				adapter: new TerraDrawTestAdapter({
+					lib: {},
+					coordinatePrecision: 3,
+				}),
+				modes: [new TerraDrawPolygonMode()],
+				undoRedo: {
+					sessionLevel: new TerraDrawSessionUndoRedo(),
+				},
+			});
+
+			draw.start();
+			const [result] = draw.addFeatures([
+				{
+					id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+					type: "Feature",
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[25, 34],
+								[26, 35],
+								[27, 34],
+								[25, 34],
+							],
+						],
+					},
+					properties: {
+						mode: "polygon",
+					},
+				},
+			]);
+
+			const featureId = result.id as FeatureId;
+			const initialGeometry: GeoJSONStoreGeometries = {
+				type: "Polygon",
+				coordinates: [
+					[
+						[25, 34],
+						[26, 35],
+						[27, 34],
+						[25, 34],
+					],
+				],
+			};
+
+			const firstGeometry: GeoJSONStoreGeometries = {
+				type: "Polygon",
+				coordinates: [
+					[
+						[28, 34],
+						[29, 35],
+						[30, 34],
+						[28, 34],
+					],
+				],
+			};
+
+			const secondGeometry: GeoJSONStoreGeometries = {
+				type: "Polygon",
+				coordinates: [
+					[
+						[31, 34],
+						[32, 35],
+						[33, 34],
+						[31, 34],
+					],
+				],
+			};
+
+			draw.updateFeatureGeometry(featureId, firstGeometry);
+			draw.updateFeatureProperties(featureId, {
+				customProperty: "v1",
+			});
+			draw.updateFeatureGeometry(featureId, secondGeometry);
+
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				secondGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe("v1");
+
+			expect(draw.undo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				firstGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe("v1");
+
+			expect(draw.undo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				firstGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe(undefined);
+
+			expect(draw.undo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				initialGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe(undefined);
+
+			expect(draw.redo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				firstGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe(undefined);
+
+			expect(draw.redo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				firstGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe("v1");
+
+			expect(draw.redo()).toBe(true);
+			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
+				secondGeometry,
+			);
+			expect(
+				draw.getSnapshotFeature(featureId)?.properties.customProperty,
+			).toBe("v1");
+		});
 	});
 
 	describe("transformFeatureGeometry", () => {
@@ -2874,6 +3269,138 @@ describe("Terra Draw", () => {
 					}).toThrow(
 						"Guidance features are not allowed to be updated directly",
 					);
+				});
+
+				it("records transforms for session undo/redo", () => {
+					const draw = new TerraDraw({
+						adapter: new TerraDrawTestAdapter({
+							lib: {},
+							coordinatePrecision: 3,
+						}),
+						modes: [new TerraDrawLineStringMode(), new TerraDrawSelectMode()],
+						undoRedo: {
+							sessionLevel: new TerraDrawSessionUndoRedo(),
+						},
+					});
+
+					draw.start();
+					const [result] = draw.addFeatures([
+						{
+							id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+							type: "Feature",
+							geometry: {
+								type: "LineString",
+								coordinates: [
+									[25, 34],
+									[26, 35],
+								],
+							},
+							properties: {
+								mode: "linestring",
+							},
+						},
+					]);
+
+					expect(result.valid).toBe(true);
+
+					draw.transformFeatureGeometry(result.id as FeatureId, {
+						type: transformType,
+						projection: "web-mercator",
+						origin: [25, 34],
+						options: options as any,
+					});
+
+					expect(draw.canUndo()).toBe(true);
+
+					const undone = draw.undo();
+					expect(undone).toBe(true);
+
+					const snapshotAfterUndo = draw.getSnapshot();
+					expect(snapshotAfterUndo).toHaveLength(1);
+					expect(snapshotAfterUndo[0].geometry).toEqual({
+						type: "LineString",
+						coordinates: [
+							[25, 34],
+							[26, 35],
+						],
+					});
+
+					expect(draw.canRedo()).toBe(true);
+
+					const redone = draw.redo();
+					expect(redone).toBe(true);
+
+					const snapshotAfterRedo = draw.getSnapshot();
+					expect(snapshotAfterRedo).toHaveLength(1);
+					expect(snapshotAfterRedo[0].geometry).toEqual({
+						type: "LineString",
+						coordinates:
+							transformType === "rotate"
+								? [
+										[26.107, 34.088],
+										[24.893, 34.913],
+									]
+								: [
+										[25, 34],
+										[27, 35.988],
+									],
+					});
+				});
+
+				it("emits one history push and no finish callback for api transforms", () => {
+					const draw = new TerraDraw({
+						adapter: new TerraDrawTestAdapter({
+							lib: {},
+							coordinatePrecision: 3,
+						}),
+						modes: [new TerraDrawLineStringMode(), new TerraDrawSelectMode()],
+						undoRedo: {
+							sessionLevel: new TerraDrawSessionUndoRedo(),
+						},
+					});
+
+					const onFinish = jest.fn();
+					const onHistory = jest.fn();
+
+					draw.on("finish", onFinish);
+					draw.on("history", onHistory);
+
+					draw.start();
+					const [result] = draw.addFeatures([
+						{
+							id: "f8e5a38d-ecfa-4294-8461-d9cff0e0d7f8",
+							type: "Feature",
+							geometry: {
+								type: "LineString",
+								coordinates: [
+									[25, 34],
+									[26, 35],
+								],
+							},
+							properties: {
+								mode: "linestring",
+							},
+						},
+					]);
+
+					onFinish.mockClear();
+					onHistory.mockClear();
+
+					draw.transformFeatureGeometry(result.id as FeatureId, {
+						type: transformType,
+						projection: "web-mercator",
+						origin: [25, 34],
+						options: options as any,
+					});
+
+					expect(onFinish).not.toHaveBeenCalled();
+					const sessionCauses = onHistory.mock.calls
+						.map((call) => call[0])
+						.filter((event) => event.stack === "session")
+						.map((event) => event.cause);
+
+					expect(sessionCauses.length).toBeGreaterThan(0);
+					expect(sessionCauses.every((cause) => cause === "push")).toBe(true);
 				});
 			},
 		);

--- a/packages/terra-draw/src/terra-draw.spec.ts
+++ b/packages/terra-draw/src/terra-draw.spec.ts
@@ -1918,12 +1918,15 @@ describe("Terra Draw", () => {
 			});
 
 			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
 			expect(
 				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
 					.customProperty,
 			).toBe("customValue");
 
 			expect(draw.undo()).toBe(true);
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(true);
 			expect(
 				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
 					.customProperty,
@@ -1931,6 +1934,8 @@ describe("Terra Draw", () => {
 
 			expect(draw.canRedo()).toBe(true);
 			expect(draw.redo()).toBe(true);
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
 			expect(
 				draw.getSnapshotFeature(baseFeature.id as FeatureId)?.properties
 					.customProperty,
@@ -1964,6 +1969,9 @@ describe("Terra Draw", () => {
 			draw.updateFeatureProperties(baseFeature.id as FeatureId, {
 				customProperty: "customValue",
 			});
+
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
 
 			expect(onFinish).not.toHaveBeenCalled();
 			const sessionHistoryEvents = onHistory.mock.calls
@@ -2663,6 +2671,9 @@ describe("Terra Draw", () => {
 				],
 			});
 
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
+
 			const updateSessionCauses = onHistory.mock.calls
 				.map((call) => call[0])
 				.filter((event) => event.stack === "session")
@@ -2673,6 +2684,7 @@ describe("Terra Draw", () => {
 
 			onHistory.mockClear();
 			expect(draw.undo()).toBe(true);
+			expect(draw.canRedo()).toBe(true);
 			const undoSessionCauses = onHistory.mock.calls
 				.map((call) => call[0])
 				.filter((event) => event.stack === "session")
@@ -2683,6 +2695,7 @@ describe("Terra Draw", () => {
 
 			onHistory.mockClear();
 			expect(draw.redo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
 			const redoSessionCauses = onHistory.mock.calls
 				.map((call) => call[0])
 				.filter((event) => event.stack === "session")
@@ -2769,6 +2782,9 @@ describe("Terra Draw", () => {
 			});
 			draw.updateFeatureGeometry(featureId, secondGeometry);
 
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
+
 			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
 				secondGeometry,
 			);
@@ -2777,6 +2793,7 @@ describe("Terra Draw", () => {
 			).toBe("v1");
 
 			expect(draw.undo()).toBe(true);
+			expect(draw.canRedo()).toBe(true);
 			expect(draw.getSnapshotFeature(featureId)?.geometry).toEqual(
 				firstGeometry,
 			);
@@ -2823,6 +2840,8 @@ describe("Terra Draw", () => {
 			expect(
 				draw.getSnapshotFeature(featureId)?.properties.customProperty,
 			).toBe("v1");
+			expect(draw.canUndo()).toBe(true);
+			expect(draw.canRedo()).toBe(false);
 		});
 	});
 
@@ -3311,6 +3330,7 @@ describe("Terra Draw", () => {
 					});
 
 					expect(draw.canUndo()).toBe(true);
+					expect(draw.canRedo()).toBe(false);
 
 					const undone = draw.undo();
 					expect(undone).toBe(true);
@@ -3329,6 +3349,8 @@ describe("Terra Draw", () => {
 
 					const redone = draw.redo();
 					expect(redone).toBe(true);
+					expect(draw.canUndo()).toBe(true);
+					expect(draw.canRedo()).toBe(false);
 
 					const snapshotAfterRedo = draw.getSnapshot();
 					expect(snapshotAfterRedo).toHaveLength(1);
@@ -3392,6 +3414,9 @@ describe("Terra Draw", () => {
 						origin: [25, 34],
 						options: options as any,
 					});
+
+					expect(draw.canUndo()).toBe(true);
+					expect(draw.canRedo()).toBe(false);
 
 					expect(onFinish).not.toHaveBeenCalled();
 					const sessionCauses = onHistory.mock.calls

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -260,7 +260,7 @@ class TerraDraw {
 				listener(finishedId, context);
 			});
 
-			this.emitHistoryChangeAfterFinish();
+			this.undoRedoCoordinator?.emitHistoryPushForCompletedAction();
 		};
 
 		const onChange: StoreChangeHandler<TerraDrawOnChangeContext | undefined> = (
@@ -507,10 +507,6 @@ class TerraDraw {
 		}
 
 		this.drawingUndoRedo.emitPushIfHistoryChanged(before);
-	}
-
-	private emitHistoryChangeAfterFinish() {
-		this.undoRedoCoordinator?.emitPushAfterFinish();
 	}
 
 	private getModeStyles() {
@@ -1122,7 +1118,7 @@ class TerraDraw {
 			{ origin: "api" }, // origin is used to indicate that this update has come from an API call
 		);
 
-		this.emitHistoryChangeAfterFinish();
+		this.undoRedoCoordinator?.emitHistoryPushForCompletedAction();
 	}
 
 	/**
@@ -1192,7 +1188,7 @@ class TerraDraw {
 			}
 		}
 
-		this.emitHistoryChangeAfterFinish();
+		this.undoRedoCoordinator?.emitHistoryPushForCompletedAction();
 	}
 
 	/**
@@ -1313,7 +1309,7 @@ class TerraDraw {
 			}
 		}
 
-		this.emitHistoryChangeAfterFinish();
+		this.undoRedoCoordinator?.emitHistoryPushForCompletedAction();
 	}
 
 	undo(): boolean {

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -797,9 +797,9 @@ class TerraDraw {
 	private isGuidanceFeature(feature: GeoJSONStoreFeatures): boolean {
 		return Boolean(
 			feature.properties[SELECT_PROPERTIES.MID_POINT] ||
-				feature.properties[SELECT_PROPERTIES.SELECTION_POINT] ||
-				feature.properties[COMMON_PROPERTIES.COORDINATE_POINT] ||
-				feature.properties[COMMON_PROPERTIES.SNAPPING_POINT],
+			feature.properties[SELECT_PROPERTIES.SELECTION_POINT] ||
+			feature.properties[COMMON_PROPERTIES.COORDINATE_POINT] ||
+			feature.properties[COMMON_PROPERTIES.SNAPPING_POINT],
 		);
 	}
 
@@ -1121,6 +1121,8 @@ class TerraDraw {
 			})),
 			{ origin: "api" }, // origin is used to indicate that this update has come from an API call
 		);
+
+		this.emitHistoryChangeAfterFinish();
 	}
 
 	/**
@@ -1189,6 +1191,8 @@ class TerraDraw {
 				selectModePresent.afterFeatureUpdated(updatedFeature);
 			}
 		}
+
+		this.emitHistoryChangeAfterFinish();
 	}
 
 	/**
@@ -1308,6 +1312,8 @@ class TerraDraw {
 				selectModePresent.afterFeatureUpdated(feature);
 			}
 		}
+
+		this.emitHistoryChangeAfterFinish();
 	}
 
 	undo(): boolean {

--- a/packages/terra-draw/src/undo-redo/session-undo-redo.ts
+++ b/packages/terra-draw/src/undo-redo/session-undo-redo.ts
@@ -356,6 +356,8 @@ export class TerraDrawSessionUndoRedo implements TerraDrawSessionUndoRedoInterfa
 		return this.draw ? this.draw.getModeState() === "drawing" : false;
 	}
 
+	// When replaying history, we want to apply the snapshot without recording
+	// new undo action or treating it as a user-driven change
 	private applySnapshotDuringReplay(
 		id: FeatureId,
 		snapshot: GeoJSONStoreFeatures,
@@ -518,7 +520,7 @@ export class TerraDrawSessionUndoRedo implements TerraDrawSessionUndoRedoInterfa
 
 		// Revert to the previous geometry for this action and truncate history to that point
 		const nextSnapshot = stack[currentIndex]; // the state we are undoing
-		const prev = stack[currentIndex - 1];
+		const previousSnapshot = stack[currentIndex - 1]; // the state we are reverting to
 
 		// Save redo info before truncating the stack
 		if (nextSnapshot) {
@@ -530,7 +532,7 @@ export class TerraDrawSessionUndoRedo implements TerraDrawSessionUndoRedoInterfa
 			});
 		}
 
-		this.applySnapshotDuringReplay(id, prev);
+		this.applySnapshotDuringReplay(id, previousSnapshot);
 		stack.length = currentIndex; // drop the state we just undid
 		this.emitStackChange(HistoryChangeCause.Undo);
 		return true;

--- a/packages/terra-draw/src/undo-redo/session-undo-redo.ts
+++ b/packages/terra-draw/src/undo-redo/session-undo-redo.ts
@@ -21,8 +21,7 @@ type StackEntryMetadata = {
 	entries: BatchEntry[];
 };
 
-export interface TerraDrawSessionUndoRedoInterface
-	extends TerraDrawUndoRedoInterface {
+export interface TerraDrawSessionUndoRedoInterface extends TerraDrawUndoRedoInterface {
 	register(options: {
 		draw: TerraDraw;
 		onHistoryChange: (historyChange: HistoryChange) => void;
@@ -44,9 +43,7 @@ type UndoStackEntry = {
 	metadata?: StackEntryMetadata;
 };
 
-export class TerraDrawSessionUndoRedo
-	implements TerraDrawSessionUndoRedoInterface
-{
+export class TerraDrawSessionUndoRedo implements TerraDrawSessionUndoRedoInterface {
 	private draw: TerraDraw | undefined;
 	private onHistoryChange: ((historyChange: HistoryChange) => void) | undefined;
 	private readonly maxStackSize: number;
@@ -57,6 +54,7 @@ export class TerraDrawSessionUndoRedo
 	private ignoreProgrammaticDelete: Record<FeatureId, boolean> = {};
 	private deletedFeatureIds: Record<FeatureId, boolean> = {};
 	private redoStack: RedoStackEntry[] = [];
+	private isReplayingHistory = false;
 
 	constructor(options?: TerraDrawUndoRedoOptions) {
 		this.maxStackSize = normaliseMaxStackSize(options?.maxStackSize);
@@ -124,6 +122,51 @@ export class TerraDrawSessionUndoRedo
 		}
 
 		if (this.maxStackSize === 0) {
+			return;
+		}
+
+		if (type === "update") {
+			const isApiOrigin =
+				context !== undefined &&
+				"origin" in context &&
+				context.origin === "api";
+
+			if (!isApiOrigin || this.isReplayingHistory) {
+				return;
+			}
+
+			const changed = Array.isArray(ids) ? ids : [ids];
+			let recordedUpdate = false;
+
+			for (const id of changed) {
+				if (id === undefined || id === null) {
+					continue;
+				}
+
+				const key = String(id);
+				const feature = this.draw.getSnapshotFeature(id);
+				if (!feature) {
+					continue;
+				}
+
+				if (!this.historyById[key]) {
+					this.historyById[key] = [];
+				}
+
+				this.historyById[key].push(feature);
+				this.pushUndoStackEntry({
+					id,
+					toIndex: this.historyById[key].length - 1,
+					action: "single",
+				});
+				recordedUpdate = true;
+			}
+
+			if (recordedUpdate) {
+				this.redoStack.length = 0;
+				this.emitStackChange(HistoryChangeCause.Push);
+			}
+
 			return;
 		}
 
@@ -276,6 +319,10 @@ export class TerraDrawSessionUndoRedo
 			return;
 		}
 
+		if (this.isReplayingHistory) {
+			return;
+		}
+
 		const changed = Array.isArray(ids) ? ids : [ids];
 		let recordedFinishAction = false;
 		for (const id of changed) {
@@ -307,6 +354,29 @@ export class TerraDrawSessionUndoRedo
 
 	private isDrawing() {
 		return this.draw ? this.draw.getModeState() === "drawing" : false;
+	}
+
+	private applySnapshotDuringReplay(
+		id: FeatureId,
+		snapshot: GeoJSONStoreFeatures,
+	) {
+		if (!this.draw) {
+			return;
+		}
+
+		this.isReplayingHistory = true;
+		try {
+			if (this.draw.hasFeature(id)) {
+				this.ignoreProgrammaticDelete[id] = true;
+				this.draw.removeFeatures([id]);
+			}
+
+			this.ignoreProgrammaticCreate[id] = true;
+			delete this.deletedFeatureIds[id];
+			this.draw.addFeatures([snapshot]);
+		} finally {
+			this.isReplayingHistory = false;
+		}
 	}
 
 	canUndo() {
@@ -460,7 +530,7 @@ export class TerraDrawSessionUndoRedo
 			});
 		}
 
-		this.draw.updateFeatureGeometry(id, prev.geometry);
+		this.applySnapshotDuringReplay(id, prev);
 		stack.length = currentIndex; // drop the state we just undid
 		this.emitStackChange(HistoryChangeCause.Undo);
 		return true;
@@ -577,7 +647,7 @@ export class TerraDrawSessionUndoRedo
 			stack.length = toIndex + 1;
 		}
 
-		this.draw.updateFeatureGeometry(id, next.geometry);
+		this.applySnapshotDuringReplay(id, next);
 
 		// Restore the action into the history stacks so it can be undone again
 		this.pushUndoStackEntry({ id, toIndex, action: "single" });

--- a/packages/terra-draw/src/undo-redo/undo-redo-coordinator.spec.ts
+++ b/packages/terra-draw/src/undo-redo/undo-redo-coordinator.spec.ts
@@ -244,7 +244,7 @@ describe("TerraDrawUndoRedoCoordinator", () => {
 			onHistoryChange,
 		});
 
-		coordinator.emitPushAfterFinish();
+		coordinator.emitHistoryPushForCompletedAction();
 
 		expect(onHistoryChange).toHaveBeenCalledWith({
 			cause: "push",
@@ -267,7 +267,7 @@ describe("TerraDrawUndoRedoCoordinator", () => {
 			onHistoryChange,
 		});
 
-		coordinator.emitPushAfterFinish();
+		coordinator.emitHistoryPushForCompletedAction();
 
 		expect(onHistoryChange).toHaveBeenCalledWith({
 			cause: "push",

--- a/packages/terra-draw/src/undo-redo/undo-redo-coordinator.ts
+++ b/packages/terra-draw/src/undo-redo/undo-redo-coordinator.ts
@@ -138,7 +138,7 @@ export class TerraDrawUndoRedoCoordinator {
 		}
 	}
 
-	emitPushAfterFinish() {
+	emitHistoryPushForCompletedAction() {
 		if (this.sessionLevel) {
 			this.emitStackHistoryChange({
 				cause: HistoryChangeCause.Push,


### PR DESCRIPTION
## Description of Changes

We want to capture programmatic updates in the undo/redo stack but these were being overlooked. Since we capture programmatic additions and deletions it feels consistent to also support updates in the undo redo stack.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/890

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 