### PR TITLE
feat(terra-draw): add polyline mode

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -113,7 +113,7 @@ Terra Draw comes with the following built-in Drawing Modes out of the box:
 | Angled Rectangle        | [TerraDrawRectangleMode](https://jameslmilner.github.io/terra-draw/classes/terra-draw.TerraDrawAngledRectangleMode.html)     | `angled-rectangle`   |
 | Sector                  | [TerraDrawSector](https://jameslmilner.github.io/terra-draw/classes/terra-draw.TerraDrawSectorMode.html)     | `sector`   |
 | Sensor                  | [TerraDrawSensor](https://jameslmilner.github.io/terra-draw/classes/terra-draw.TerraDrawSensorMode.html)     | `sensor`   |
-
+| PolyLine                | [TerraDrawPolyLine](https://jameslmilner.github.io/terra-draw/classes/terra-draw.TerraDrawPolyLineMode.html) | `polyline`   |
 #### Validation in Drawing Modes
 
 All built in drawing modes have a base level of validation that runs when a feature is added programmatically i.e. addFeatures (see the [store guide](./2.STORE.md) for more details).  This attempts to prohibit adding corrupt or invalid data to the mode. Terra Draw works on the assumption that features created on the mode are correct to the validation built-in standard. As an end developer we can also take this a step further, by using the `validation` property available on all built in modes. `validation` simply takes a function that returns `true` if the Feature is valid or `false` if it is not. You can write any logic you require to validate the geometry. For example, let's say we wanted to ensure all drawn polygons did not self intersect, we could something like this:

--- a/guides/5.STYLING.md
+++ b/guides/5.STYLING.md
@@ -188,6 +188,32 @@ The `TerraDrawSensorMode` is styled using the following properties:
 | `outlineWidth`               | Integer      | `2`           | The outline width of the sensor                 |
 | `fillOpacity`                | Number (0-1) | `0.9`         | The fill opacity of the sensor                  |
 
+### PolyLine
+
+The `TerraDrawPolyLineMode` is styled using the following properties:
+
+| Property                      | Type         | Example Value | Description                                                 |
+| ----------------------------- | ------------ | ------------- | ----------------------------------------------------------- |
+| `lineStringColor`             | Hex Color    | `#00FFFF`     | The color of the polyline while drawing.                    |
+| `lineStringOpacity`           | Number (0-1) | `0.7`         | The opacity of the polyline while drawing.                  |
+| `lineStringWidth`             | Integer      | `3`           | The width of the polyline while drawing.                    |
+| `polygonFillColor`            | Hex Color    | `#00FFFF`     | The fill color used when the polyline is closed.            |
+| `polygonFillOpacity`          | Number (0-1) | `0.3`         | The fill opacity used when the polyline is closed.          |
+| `polygonOutlineColor`         | Hex Color    | `#00FFFF`     | The outline color used when the polyline is closed.         |
+| `polygonOutlineOpacity`       | Number (0-1) | `1`           | The outline opacity used when the polyline is closed.       |
+| `polygonOutlineWidth`         | Integer      | `2`           | The outline width used when the polyline is closed.         |
+| `closingPointColor`           | Hex Color    | `#00FFFF`     | The fill color of the closing point.                        |
+| `closingPointOpacity`         | Number (0-1) | `0.7`         | The fill opacity of the closing point.                      |
+| `closingPointWidth`           | Integer      | `2`           | The width of the closing point.                             |
+| `closingPointOutlineColor`    | Hex Color    | `#FFFFFF`     | The outline color of the closing point.                     |
+| `closingPointOutlineOpacity`  | Number (0-1) | `1`           | The outline opacity of the closing point.                   |
+| `closingPointOutlineWidth`    | Integer      | `1`           | The outline width of the closing point.                     |
+| `snappingPointColor`          | Hex Color    | `#00FFFF`     | The fill color of the snapping guidance point.              |
+| `snappingPointOpacity`        | Number (0-1) | `0.7`         | The fill opacity of the snapping guidance point.            |
+| `snappingPointWidth`          | Integer      | `2`           | The width of the snapping guidance point.                   |
+| `snappingPointOutlineColor`   | Hex Color    | `#FFFFFF`     | The outline color of the snapping guidance point.           |
+| `snappingPointOutlineOpacity` | Number (0-1) | `1`           | The outline opacity of the snapping guidance point.         |
+| `snappingPointOutlineWidth`   | Integer      | `1`           | The outline width of the snapping guidance point.           |
 
 ## Dynamically Changing Styling
 

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -14,6 +14,7 @@ import {
 	GeoJSONStoreFeatures,
 	HexColor,
 	TerraDrawMarkerMode,
+	TerraDrawPolyLineMode,
 } from "../../../terra-draw/src/terra-draw";
 
 import {
@@ -404,6 +405,24 @@ const LineString: Story = {
 	},
 };
 
+// Polyline drawing story
+const PolyLine: Story = {
+	...DefaultStory,
+	args: {
+		id: "polyline",
+		modes: [
+			() =>
+				new TerraDrawPolyLineMode({
+					snapping: {
+						toCoordinate: true,
+						toLine: true,
+					},
+				}),
+		],
+		...DefaultStory.args,
+	},
+};
+
 // Linestring drawing story
 const LineStringFinishOnNthCoordinate: Story = {
 	...DefaultStory,
@@ -550,6 +569,7 @@ const Select: Story = {
 	args: {
 		id: "select",
 		modes: [
+			() => new TerraDrawPolyLineMode(),
 			() =>
 				new TerraDrawPolygonMode({
 					showCoordinatePoints: true,
@@ -563,6 +583,14 @@ const Select: Story = {
 						selectionPointColor: "#0000ff",
 					},
 					flags: {
+						polyline: {
+							feature: {
+								draggable: true,
+								coordinates: {
+									draggable: true,
+								},
+							},
+						},
 						polygon: {
 							feature: {
 								draggable: true,
@@ -1028,6 +1056,7 @@ const AllStories = {
 	RectangleWithClickMoveOrDragInteraction,
 	AngledRectangle,
 	Sector,
+	PolyLine,
 	LineString,
 	LineStringFinishOnNthCoordinate,
 	LineStringWithCoordinatePoints,

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -569,7 +569,6 @@ const Select: Story = {
 	args: {
 		id: "select",
 		modes: [
-			() => new TerraDrawPolyLineMode(),
 			() =>
 				new TerraDrawPolygonMode({
 					showCoordinatePoints: true,
@@ -583,14 +582,6 @@ const Select: Story = {
 						selectionPointColor: "#0000ff",
 					},
 					flags: {
-						polyline: {
-							feature: {
-								draggable: true,
-								coordinates: {
-									draggable: true,
-								},
-							},
-						},
 						polygon: {
 							feature: {
 								draggable: true,

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -39,6 +39,7 @@ export const RectangleWithClickMoveOrDragInteraction =
 	AllStories.RectangleWithClickMoveOrDragInteraction;
 export const AngledRectangle = AllStories.AngledRectangle;
 export const Sector = AllStories.Sector;
+export const PolyLine = AllStories.PolyLine;
 export const LineString = AllStories.LineString;
 export const LineStringFinishOnNthCoordinate =
 	AllStories.LineStringFinishOnNthCoordinate;

--- a/packages/terra-draw/src/modes/mutate-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/mutate-feature.behavior.ts
@@ -133,17 +133,49 @@ export class MutateFeatureBehavior extends TerraDrawModeBehavior {
 	}: {
 		coordinates: Polygon["coordinates"][0];
 		properties: JSONObject;
-	}) {
+	}): GeoJSONStoreFeatures<Polygon> & { id: FeatureId };
+	public createPolygon({
+		coordinates,
+		properties,
+		context,
+	}: {
+		coordinates: Polygon["coordinates"][0];
+		properties: JSONObject;
+		context: FinishContext;
+	}): (GeoJSONStoreFeatures<Polygon> & { id: FeatureId }) | undefined;
+	public createPolygon({
+		coordinates,
+		properties,
+		context,
+	}: {
+		coordinates: Polygon["coordinates"][0];
+		properties: JSONObject;
+		context?: FinishContext;
+	}): (GeoJSONStoreFeatures<Polygon> & { id: FeatureId }) | undefined {
 		const corrected = ensureRightHandRule({
 			type: "Polygon",
 			coordinates: [coordinates],
 		});
 
+		const polygon = {
+			type: "Polygon",
+			coordinates: corrected ? corrected.coordinates : [coordinates],
+		} as Polygon;
+
+		if (context?.updateType === UpdateTypes.Finish) {
+			const valid = this.validateGeometryWithUpdateType({
+				geometry: polygon,
+				properties,
+				updateType: UpdateTypes.Finish,
+			});
+
+			if (!valid) {
+				return;
+			}
+		}
+
 		return this.handleCreateFeature({
-			geometry: {
-				type: "Polygon",
-				coordinates: corrected ? corrected.coordinates : [coordinates],
-			},
+			geometry: polygon,
 			properties,
 		});
 	}

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
@@ -2,6 +2,8 @@ import { MockCursorEvent } from "../../test/mock-cursor-event";
 import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
 import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawPolyLineMode } from "./polyline.mode";
+import { COMMON_PROPERTIES } from "../../common";
+import { MockLineString } from "../../test/mock-features";
 
 describe("TerraDrawPolyLineMode", () => {
 	describe("constructor", () => {
@@ -171,8 +173,8 @@ describe("TerraDrawPolyLineMode", () => {
 		});
 	});
 
-	describe("drawing", () => {
-		it("finishes as a LineString when finish key is used", () => {
+	describe("onMouseMove", () => {
+		it("updates the live coordinate while drawing", () => {
 			const polyLineMode = new TerraDrawPolyLineMode();
 			const config = MockModeConfig(polyLineMode.mode);
 
@@ -180,12 +182,7 @@ describe("TerraDrawPolyLineMode", () => {
 			polyLineMode.start();
 
 			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
-			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
-			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
 			polyLineMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 0 }));
-			polyLineMode.onClick(MockCursorEvent({ lng: 2, lat: 0 }));
-
-			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
 
 			const features = config.store.copyAllWhere(
 				(properties) => properties.mode === polyLineMode.mode,
@@ -195,12 +192,12 @@ describe("TerraDrawPolyLineMode", () => {
 			expect(features[0].geometry.type).toBe("LineString");
 			expect(features[0].geometry.coordinates).toEqual([
 				[0, 0],
-				[1, 0],
 				[2, 0],
 			]);
-			expect(config.onFinish).toHaveBeenCalledTimes(1);
 		});
+	});
 
+	describe("onClick", () => {
 		it("converts to a Polygon when closing on the starting point", () => {
 			const polyLineMode = new TerraDrawPolyLineMode();
 			const config = MockModeConfig(polyLineMode.mode);
@@ -265,21 +262,22 @@ describe("TerraDrawPolyLineMode", () => {
 			]);
 			expect(config.onFinish).toHaveBeenCalledTimes(1);
 		});
+	});
 
-		it("supports snapping via toCustom snapping behavior", () => {
-			const polyLineMode = new TerraDrawPolyLineMode({
-				snapping: {
-					toCustom: (_event, context) =>
-						context.currentCoordinate === 0 ? [10, 10] : [20, 20],
-				},
-			});
+	describe("onKeyUp", () => {
+		it("finishes as a LineString when finish key is used", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
 			const config = MockModeConfig(polyLineMode.mode);
 
 			polyLineMode.register(config);
 			polyLineMode.start();
 
 			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
-			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 2, lat: 0 }));
+
 			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
 
 			const features = config.store.copyAllWhere(
@@ -289,9 +287,124 @@ describe("TerraDrawPolyLineMode", () => {
 			expect(features).toHaveLength(1);
 			expect(features[0].geometry.type).toBe("LineString");
 			expect(features[0].geometry.coordinates).toEqual([
-				[10, 10],
-				[20, 20],
+				[0, 0],
+				[1, 0],
+				[2, 0],
 			]);
+			expect(config.onFinish).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("cleanUp", () => {
+		it("removes in-progress features", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			let features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+			expect(features).toHaveLength(1);
+
+			polyLineMode.cleanUp();
+
+			features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+			expect(features).toHaveLength(0);
+		});
+	});
+
+	describe("styleFeature", () => {
+		it("styles a closing point with a white default outline", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const feature = {
+				id: "test",
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [0, 0] },
+				properties: {
+					mode: "polyline",
+					[COMMON_PROPERTIES.CLOSING_POINT]: true,
+				},
+			} as any;
+
+			const styles = polyLineMode.styleFeature(feature);
+			expect(styles.pointOutlineColor).toBe("#ffffff");
+		});
+	});
+
+	describe("afterFeatureAdded", () => {
+		it("does not throw when called", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.register(MockModeConfig(polyLineMode.mode));
+
+			expect(() => {
+				polyLineMode.afterFeatureAdded(MockLineString() as any);
+			}).not.toThrow();
+		});
+	});
+
+	describe("afterFeatureUpdated", () => {
+		it("resets drawing state when the current drawing feature is externally updated", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			expect(polyLineMode.state).toBe("drawing");
+
+			const currentFeature = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			)[0];
+
+			polyLineMode.afterFeatureUpdated(currentFeature as any);
+
+			expect(polyLineMode.state).toBe("started");
+		});
+
+		it("clears snapped guidance point when a feature is externally updated", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				snapping: {
+					toCustom: () => [10, 10],
+				},
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			const snappingPointsBefore = config.store.copyAllWhere((properties) =>
+				Boolean(properties[COMMON_PROPERTIES.SNAPPING_POINT] as boolean),
+			);
+			expect(snappingPointsBefore).toHaveLength(1);
+
+			polyLineMode.afterFeatureUpdated(MockLineString() as any);
+
+			const snappingPointsAfter = config.store.copyAllWhere((properties) =>
+				Boolean(properties[COMMON_PROPERTIES.SNAPPING_POINT] as boolean),
+			);
+			expect(snappingPointsAfter).toHaveLength(0);
+		});
+	});
+
+	describe("validateFeature", () => {
+		it("returns invalid for unsupported geometry type", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.register(MockModeConfig(polyLineMode.mode));
+
+			const validation = polyLineMode.validateFeature({
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [0, 0] },
+				properties: { mode: "polyline" },
+			});
+
+			expect(validation.valid).toBe(false);
 		});
 	});
 });

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
@@ -1,0 +1,297 @@
+import { MockCursorEvent } from "../../test/mock-cursor-event";
+import { MockKeyboardEvent } from "../../test/mock-keyboard-event";
+import { MockModeConfig } from "../../test/mock-mode-config";
+import { TerraDrawPolyLineMode } from "./polyline.mode";
+
+describe("TerraDrawPolyLineMode", () => {
+	describe("constructor", () => {
+		it("constructs with no options", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			expect(polyLineMode.mode).toBe("polyline");
+			expect(polyLineMode.styles).toStrictEqual({});
+		});
+
+		it("constructs with options", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				styles: { lineStringColor: "#ffffff" },
+				snapping: { toCoordinate: true, toLine: true },
+				keyEvents: { cancel: "Backspace", finish: "Enter" },
+			});
+			expect(polyLineMode.styles).toStrictEqual({ lineStringColor: "#ffffff" });
+		});
+
+		it("constructs with null key events", () => {
+			new TerraDrawPolyLineMode({ keyEvents: null });
+			new TerraDrawPolyLineMode({
+				keyEvents: { cancel: null, finish: null },
+			});
+		});
+
+		it("supports mode name override", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				modeName: "custom-polyline",
+			});
+			expect(polyLineMode.mode).toBe("custom-polyline");
+		});
+	});
+
+	describe("lifecycle", () => {
+		it("registers correctly", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			expect(polyLineMode.state).toBe("unregistered");
+			polyLineMode.register(MockModeConfig(polyLineMode.mode));
+			expect(polyLineMode.state).toBe("registered");
+		});
+
+		it("setting state directly throws error", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+
+			expect(() => {
+				polyLineMode.state = "started";
+			}).toThrow();
+		});
+
+		it("stopping before registering throws error", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+
+			expect(() => {
+				polyLineMode.stop();
+			}).toThrow();
+		});
+
+		it("starting before registering throws error", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+
+			expect(() => {
+				polyLineMode.start();
+			}).toThrow();
+		});
+
+		it("registering multiple times throws an error", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+
+			expect(() => {
+				polyLineMode.register(MockModeConfig(polyLineMode.mode));
+				polyLineMode.register(MockModeConfig(polyLineMode.mode));
+			}).toThrow();
+		});
+
+		it("can start correctly", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.register(MockModeConfig(polyLineMode.mode));
+			polyLineMode.start();
+
+			expect(polyLineMode.state).toBe("started");
+		});
+
+		it("can stop correctly", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.register(MockModeConfig(polyLineMode.mode));
+			polyLineMode.start();
+			polyLineMode.stop();
+
+			expect(polyLineMode.state).toBe("stopped");
+		});
+	});
+
+	describe("updateOptions", () => {
+		it("can change cursors", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.updateOptions({
+				cursors: { start: "pointer", close: "pointer" },
+			});
+
+			const mockConfig = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(mockConfig);
+			polyLineMode.start();
+
+			expect(mockConfig.setCursor).toHaveBeenCalledWith("pointer");
+		});
+
+		it("can change key events", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.updateOptions({
+				keyEvents: { cancel: "C", finish: "F" },
+			});
+
+			const mockConfig = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(mockConfig);
+			polyLineMode.start();
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			let features = mockConfig.store.copyAll();
+			expect(features.length).toBe(1);
+
+			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "C" }));
+			features = mockConfig.store.copyAll();
+			expect(features.length).toBe(0);
+		});
+
+		it("can update styles", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const mockConfig = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(mockConfig);
+			polyLineMode.start();
+
+			polyLineMode.updateOptions({
+				styles: { lineStringColor: "#ffffff" },
+			});
+
+			expect(polyLineMode.styles).toStrictEqual({ lineStringColor: "#ffffff" });
+			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
+		});
+
+		it("can set snapping", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.updateOptions({
+				snapping: {
+					toCustom: (_event, context) =>
+						context.currentCoordinate === 0 ? [10, 10] : [20, 20],
+				},
+			});
+
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
+
+			const features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("LineString");
+			expect(features[0].geometry.coordinates).toEqual([
+				[10, 10],
+				[20, 20],
+			]);
+		});
+	});
+
+	describe("drawing", () => {
+		it("finishes as a LineString when finish key is used", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 2, lat: 0 }));
+
+			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
+
+			const features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("LineString");
+			expect(features[0].geometry.coordinates).toEqual([
+				[0, 0],
+				[1, 0],
+				[2, 0],
+			]);
+			expect(config.onFinish).toHaveBeenCalledTimes(1);
+		});
+
+		it("converts to a Polygon when closing on the starting point", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			// Move onto the start point and click to close.
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			const features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("Polygon");
+			expect(features[0].geometry.coordinates).toEqual([
+				[
+					[0, 0],
+					[1, 0],
+					[1, 1],
+					[0, 0],
+				],
+			]);
+			expect(config.onFinish).toHaveBeenCalledTimes(1);
+		});
+
+		it("finishes as a LineString when closing on the final point", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			// Move onto the final committed point and click to finish as a line.
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			const features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("LineString");
+			expect(features[0].geometry.coordinates).toEqual([
+				[0, 0],
+				[1, 0],
+				[1, 1],
+			]);
+			expect(config.onFinish).toHaveBeenCalledTimes(1);
+		});
+
+		it("supports snapping via toCustom snapping behavior", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				snapping: {
+					toCustom: (_event, context) =>
+						context.currentCoordinate === 0 ? [10, 10] : [20, 20],
+				},
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
+
+			const features = config.store.copyAllWhere(
+				(properties) => properties.mode === polyLineMode.mode,
+			);
+
+			expect(features).toHaveLength(1);
+			expect(features[0].geometry.type).toBe("LineString");
+			expect(features[0].geometry.coordinates).toEqual([
+				[10, 10],
+				[20, 20],
+			]);
+		});
+	});
+});

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -626,6 +626,25 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 		return styles;
 	}
 
+	afterFeatureAdded(_feature: GeoJSONStoreFeatures) {}
+
+	afterFeatureUpdated(feature: GeoJSONStoreFeatures) {
+		if (this.snappedPointId) {
+			this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
+			this.snappedPointId = undefined;
+		}
+
+		if (this.currentId === feature.id) {
+			this.currentCoordinate = 0;
+			this.currentId = undefined;
+			this.closingPoints.delete();
+
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+		}
+	}
+
 	validateFeature(feature: unknown): StoreValidation {
 		return this.validateModeFeature(feature, (validatedFeature) => {
 			if (validatedFeature.geometry.type === "LineString") {

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -221,26 +221,22 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 		const featureIdToRemove = this.currentId;
 		const closedCoordinates = [...committed, committed[0]];
 
-		this.mutateFeature.deleteFeatureIfPresent(featureIdToRemove);
-
 		const created = this.mutateFeature.createPolygon({
 			coordinates: closedCoordinates,
 			properties: {
 				mode: this.mode,
 			},
+			context: {
+				updateType: UpdateTypes.Finish,
+				action: FinishActions.Draw,
+			},
 		});
 
 		if (!created) {
-			this.currentCoordinate = 0;
-			this.currentId = undefined;
-			this.closingPoints.delete();
-
-			if (this.state === "drawing") {
-				this.setStarted();
-			}
-
 			return;
 		}
+
+		this.mutateFeature.deleteFeatureIfPresent(featureIdToRemove);
 
 		this.currentCoordinate = 0;
 		this.currentId = undefined;

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -1,0 +1,651 @@
+import {
+	TerraDrawAdapterStyling,
+	TerraDrawKeyboardEvent,
+	TerraDrawMouseEvent,
+	HexColorStyling,
+	NumericStyling,
+	Cursor,
+	UpdateTypes,
+	Z_INDEX,
+	COMMON_PROPERTIES,
+	FinishActions,
+	Snapping,
+} from "../../common";
+import { LineString, Polygon, Position } from "geojson";
+import {
+	BaseModeOptions,
+	CustomStyling,
+	ModeUpdateOptions,
+	TerraDrawBaseDrawMode,
+} from "../base.mode";
+import { BehaviorConfig } from "../base.behavior";
+import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
+import { PixelDistanceBehavior } from "../pixel-distance.behavior";
+import { LineSnappingBehavior } from "../line-snapping.behavior";
+import { CoordinateSnappingBehavior } from "../coordinate-snapping.behavior";
+import { getDefaultStyling } from "../../util/styling";
+import {
+	FeatureId,
+	GeoJSONStoreFeatures,
+	StoreValidation,
+} from "../../store/store";
+import { ValidateLineStringFeature } from "../../validations/linestring.validation";
+import { ValidatePolygonFeature } from "../../validations/polygon.validation";
+import { ClosingPointsBehavior } from "../closing-points.behavior";
+import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
+import { ReadFeatureBehavior } from "../read-feature.behavior";
+
+type TerraDrawPolyLineModeKeyEvents = {
+	cancel: KeyboardEvent["key"] | null;
+	finish: KeyboardEvent["key"] | null;
+};
+
+const defaultKeyEvents = { cancel: "Escape", finish: "Enter" } as const;
+
+type PolyLineStyling = {
+	lineStringWidth: NumericStyling;
+	lineStringColor: HexColorStyling;
+	lineStringOpacity: NumericStyling;
+	polygonFillColor: HexColorStyling;
+	polygonFillOpacity: NumericStyling;
+	polygonOutlineColor: HexColorStyling;
+	polygonOutlineWidth: NumericStyling;
+	polygonOutlineOpacity: NumericStyling;
+	closingPointColor: HexColorStyling;
+	closingPointWidth: NumericStyling;
+	closingPointOpacity: NumericStyling;
+	closingPointOutlineColor: HexColorStyling;
+	closingPointOutlineWidth: NumericStyling;
+	closingPointOutlineOpacity: NumericStyling;
+	snappingPointColor: HexColorStyling;
+	snappingPointWidth: NumericStyling;
+	snappingPointOpacity: NumericStyling;
+	snappingPointOutlineColor: HexColorStyling;
+	snappingPointOutlineWidth: NumericStyling;
+	snappingPointOutlineOpacity: NumericStyling;
+};
+
+interface Cursors {
+	start?: Cursor;
+	close?: Cursor;
+}
+
+const defaultCursors = {
+	start: "crosshair",
+	close: "pointer",
+} as Required<Cursors>;
+
+interface TerraDrawPolyLineModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
+	snapping?: Snapping;
+	keyEvents?: TerraDrawPolyLineModeKeyEvents | null;
+	cursors?: Cursors;
+}
+
+export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling> {
+	mode = "polyline";
+
+	private currentCoordinate = 0;
+	private currentId: FeatureId | undefined;
+	private keyEvents: TerraDrawPolyLineModeKeyEvents = defaultKeyEvents;
+	private cursors: Required<Cursors> = defaultCursors;
+	private mouseMove = false;
+	private snapping: Snapping | undefined;
+	private snappedPointId: FeatureId | undefined;
+
+	private mutateFeature!: MutateFeatureBehavior;
+	private readFeature!: ReadFeatureBehavior;
+	private pixelDistance!: PixelDistanceBehavior;
+	private closingPoints!: ClosingPointsBehavior;
+	private clickBoundingBox!: ClickBoundingBoxBehavior;
+	private lineSnapping!: LineSnappingBehavior;
+	private coordinateSnapping!: CoordinateSnappingBehavior;
+
+	constructor(options?: TerraDrawPolyLineModeOptions<PolyLineStyling>) {
+		super(options, true);
+		this.updateOptions(options);
+	}
+
+	override updateOptions(
+		options?: ModeUpdateOptions<TerraDrawPolyLineModeOptions<PolyLineStyling>>,
+	) {
+		super.updateOptions(options);
+
+		if (options?.cursors) {
+			this.cursors = { ...this.cursors, ...options.cursors };
+		}
+
+		if (options?.snapping) {
+			this.snapping = options.snapping;
+		}
+
+		if (options?.keyEvents === null) {
+			this.keyEvents = { cancel: null, finish: null };
+		} else if (options?.keyEvents) {
+			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
+		}
+	}
+
+	/** @internal */
+	registerBehaviors(config: BehaviorConfig) {
+		this.clickBoundingBox = new ClickBoundingBoxBehavior(config);
+		this.pixelDistance = new PixelDistanceBehavior(config);
+		this.lineSnapping = new LineSnappingBehavior(
+			config,
+			this.pixelDistance,
+			this.clickBoundingBox,
+		);
+		this.coordinateSnapping = new CoordinateSnappingBehavior(
+			config,
+			this.pixelDistance,
+			this.clickBoundingBox,
+		);
+		this.readFeature = new ReadFeatureBehavior(config);
+		this.mutateFeature = new MutateFeatureBehavior(config, {
+			validate: this.validate,
+		});
+		this.closingPoints = new ClosingPointsBehavior(
+			config,
+			this.pixelDistance,
+			this.mutateFeature,
+			this.readFeature,
+		);
+	}
+
+	/** @internal */
+	start() {
+		this.setStarted();
+		this.setCursor(this.cursors.start);
+	}
+
+	/** @internal */
+	stop() {
+		this.cleanUp();
+		this.setStopped();
+		this.setCursor("unset");
+	}
+
+	private finishLine() {
+		if (!this.currentId) {
+			return;
+		}
+
+		const updated = this.mutateFeature.updateLineString({
+			featureId: this.currentId,
+			context: { updateType: UpdateTypes.Finish, action: FinishActions.Draw },
+			coordinateMutations: [{ type: Mutations.Delete, index: -1 }],
+			propertyMutations: {
+				[COMMON_PROPERTIES.CURRENTLY_DRAWING]: undefined,
+			},
+		});
+
+		if (!updated) {
+			return;
+		}
+
+		const featureId = this.currentId;
+		this.currentCoordinate = 0;
+		this.currentId = undefined;
+		this.closingPoints.delete();
+		this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
+		this.snappedPointId = undefined;
+
+		if (this.state === "drawing") {
+			this.setStarted();
+		}
+
+		this.onFinish(featureId, { mode: this.mode, action: FinishActions.Draw });
+	}
+
+	private toPolygonLikeCoordinates(lineCoordinates: Position[]) {
+		if (lineCoordinates.length === 0) {
+			return [lineCoordinates];
+		}
+
+		return [[...lineCoordinates, lineCoordinates[0]]];
+	}
+
+	private closeAsPolygon() {
+		if (!this.currentId) {
+			return;
+		}
+
+		const geometry = this.readFeature.getGeometry<LineString>(this.currentId);
+		const committed = geometry.coordinates.slice(0, -1);
+
+		if (committed.length < 3) {
+			return;
+		}
+
+		const featureIdToRemove = this.currentId;
+		const closedCoordinates = [...committed, committed[0]];
+
+		this.mutateFeature.deleteFeatureIfPresent(featureIdToRemove);
+
+		const created = this.mutateFeature.createPolygon({
+			coordinates: closedCoordinates,
+			properties: {
+				mode: this.mode,
+			},
+		});
+
+		if (!created) {
+			this.currentCoordinate = 0;
+			this.currentId = undefined;
+			this.closingPoints.delete();
+
+			if (this.state === "drawing") {
+				this.setStarted();
+			}
+
+			return;
+		}
+
+		this.currentCoordinate = 0;
+		this.currentId = undefined;
+		this.closingPoints.delete();
+		this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
+		this.snappedPointId = undefined;
+
+		if (this.state === "drawing") {
+			this.setStarted();
+		}
+
+		this.onFinish(created.id as FeatureId, {
+			mode: this.mode,
+			action: FinishActions.Draw,
+		});
+	}
+
+	/** @internal */
+	onMouseMove(event: TerraDrawMouseEvent) {
+		this.mouseMove = true;
+		this.setCursor(this.cursors.start);
+		this.updateSnappedCoordinate(event);
+
+		if (!this.currentId || this.currentCoordinate === 0) {
+			return;
+		}
+
+		const updated = this.mutateFeature.updateLineString({
+			featureId: this.currentId,
+			coordinateMutations: [
+				{
+					type: Mutations.Update,
+					index: -1,
+					coordinate: [event.lng, event.lat],
+				},
+			],
+			context: { updateType: UpdateTypes.Provisional },
+		});
+
+		if (!updated) {
+			return;
+		}
+
+		const { isClosing, isPreviousClosing } =
+			this.closingPoints.isPolygonClosingPoints(event);
+		if (
+			(isClosing && this.currentCoordinate >= 3) ||
+			(isPreviousClosing && this.currentCoordinate >= 2)
+		) {
+			this.setCursor(this.cursors.close);
+		}
+	}
+
+	private onLeftClick(event: TerraDrawMouseEvent) {
+		this.updateSnappedCoordinate(event);
+		const clickedCoordinate: Position = [event.lng, event.lat];
+
+		if (this.currentCoordinate === 0) {
+			const created = this.mutateFeature.createLineString({
+				coordinates: [clickedCoordinate, clickedCoordinate],
+				properties: {
+					mode: this.mode,
+					[COMMON_PROPERTIES.CURRENTLY_DRAWING]: true,
+				},
+			});
+
+			this.currentId = created.id as FeatureId;
+			this.currentCoordinate = 1;
+			this.setDrawing();
+			return;
+		}
+
+		if (!this.currentId) {
+			return;
+		}
+
+		const { isClosing, isPreviousClosing } =
+			this.closingPoints.isPolygonClosingPoints(event);
+
+		if (isClosing && this.currentCoordinate >= 3) {
+			this.closeAsPolygon();
+			return;
+		}
+
+		if (isPreviousClosing && this.currentCoordinate >= 2) {
+			this.finishLine();
+			return;
+		}
+
+		const updated = this.mutateFeature.updateLineString({
+			featureId: this.currentId,
+			context: { updateType: UpdateTypes.Commit },
+			coordinateMutations: [
+				{
+					type: Mutations.InsertAfter,
+					index: -1,
+					coordinate: clickedCoordinate,
+				},
+			],
+		});
+
+		if (!updated) {
+			return;
+		}
+
+		this.currentCoordinate++;
+
+		if (this.currentCoordinate >= 2) {
+			const polygonLikeCoordinates = this.toPolygonLikeCoordinates(
+				updated.geometry.coordinates,
+			);
+
+			if (this.closingPoints.ids.length === 0) {
+				this.closingPoints.create(polygonLikeCoordinates);
+			} else {
+				this.closingPoints.update(polygonLikeCoordinates);
+			}
+		}
+	}
+
+	/** @internal */
+	onClick(event: TerraDrawMouseEvent) {
+		if (
+			event.button === "left" &&
+			this.allowPointerEvent(this.pointerEvents.leftClick, event)
+		) {
+			if (this.currentCoordinate > 0 && !this.mouseMove) {
+				this.onMouseMove(event);
+			}
+			this.mouseMove = false;
+			this.onLeftClick(event);
+		}
+	}
+
+	/** @internal */
+	onKeyUp(event: TerraDrawKeyboardEvent) {
+		if (event.key === this.keyEvents.cancel) {
+			this.cleanUp();
+		} else if (event.key === this.keyEvents.finish) {
+			this.finishLine();
+		}
+	}
+
+	/** @internal */
+	onKeyDown() {}
+
+	/** @internal */
+	onDragStart() {}
+
+	/** @internal */
+	onDrag() {}
+
+	/** @internal */
+	onDragEnd() {}
+
+	/** @internal */
+	cleanUp() {
+		const currentId = this.currentId;
+		this.currentId = undefined;
+		this.currentCoordinate = 0;
+
+		if (this.state === "drawing") {
+			this.setStarted();
+		}
+
+		this.mutateFeature.deleteFeatureIfPresent(currentId);
+		this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
+		this.snappedPointId = undefined;
+		this.closingPoints.delete();
+	}
+
+	private updateSnappedCoordinate(event: TerraDrawMouseEvent) {
+		const snappedCoordinate = this.snapCoordinate(event);
+
+		if (snappedCoordinate) {
+			if (this.snappedPointId) {
+				this.mutateFeature.updateGuidancePoints([
+					{
+						featureId: this.snappedPointId,
+						coordinate: snappedCoordinate,
+					},
+				]);
+			} else {
+				this.snappedPointId = this.mutateFeature.createGuidancePoint({
+					coordinate: snappedCoordinate,
+					type: COMMON_PROPERTIES.SNAPPING_POINT,
+				});
+			}
+
+			event.lng = snappedCoordinate[0];
+			event.lat = snappedCoordinate[1];
+		} else if (this.snappedPointId) {
+			this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
+			this.snappedPointId = undefined;
+		}
+	}
+
+	private snapCoordinate(event: TerraDrawMouseEvent) {
+		let snappedCoordinate: Position | undefined;
+
+		if (this.snapping?.toLine) {
+			let snapped: Position | undefined;
+			if (this.currentId) {
+				snapped = this.lineSnapping.getSnappableCoordinate(
+					event,
+					this.currentId,
+				);
+			} else {
+				snapped = this.lineSnapping.getSnappableCoordinateFirstClick(event);
+			}
+
+			if (snapped) {
+				snappedCoordinate = snapped;
+			}
+		}
+
+		if (this.snapping?.toCoordinate) {
+			let snapped: Position | undefined;
+			if (this.currentId) {
+				snapped = this.coordinateSnapping.getSnappableCoordinate(
+					event,
+					this.currentId,
+				);
+			} else {
+				snapped =
+					this.coordinateSnapping.getSnappableCoordinateFirstClick(event);
+			}
+
+			if (snapped) {
+				snappedCoordinate = snapped;
+			}
+		}
+
+		if (this.snapping?.toCustom) {
+			const snapped = this.snapping.toCustom(event, {
+				currentCoordinate: this.currentCoordinate,
+				currentId: this.currentId,
+				getCurrentGeometrySnapshot: this.currentId
+					? () =>
+							this.readFeature.getGeometry<LineString>(
+								this.currentId as FeatureId,
+							)
+					: () => null,
+				project: this.project,
+				unproject: this.unproject,
+			});
+
+			if (snapped) {
+				snappedCoordinate = snapped;
+			}
+		}
+
+		return snappedCoordinate;
+	}
+
+	/** @internal */
+	styleFeature(feature: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
+		const styles = { ...getDefaultStyling() };
+
+		if (feature.properties.mode !== this.mode) {
+			return styles;
+		}
+
+		if (feature.geometry.type === "LineString") {
+			styles.lineStringColor = this.getHexColorStylingValue(
+				this.styles.lineStringColor,
+				styles.lineStringColor,
+				feature,
+			);
+
+			styles.lineStringWidth = this.getNumericStylingValue(
+				this.styles.lineStringWidth,
+				styles.lineStringWidth,
+				feature,
+			);
+
+			styles.lineStringOpacity = this.getNumericStylingValue(
+				this.styles.lineStringOpacity,
+				1,
+				feature,
+			);
+
+			styles.zIndex = Z_INDEX.LAYER_ONE;
+			return styles;
+		}
+
+		if (feature.geometry.type === "Polygon") {
+			styles.polygonFillColor = this.getHexColorStylingValue(
+				this.styles.polygonFillColor,
+				styles.polygonFillColor,
+				feature,
+			);
+
+			styles.polygonFillOpacity = this.getNumericStylingValue(
+				this.styles.polygonFillOpacity,
+				styles.polygonFillOpacity,
+				feature,
+			);
+
+			styles.polygonOutlineColor = this.getHexColorStylingValue(
+				this.styles.polygonOutlineColor,
+				styles.polygonOutlineColor,
+				feature,
+			);
+
+			styles.polygonOutlineWidth = this.getNumericStylingValue(
+				this.styles.polygonOutlineWidth,
+				styles.polygonOutlineWidth,
+				feature,
+			);
+
+			styles.polygonOutlineOpacity = this.getNumericStylingValue(
+				this.styles.polygonOutlineOpacity,
+				1,
+				feature,
+			);
+
+			styles.zIndex = Z_INDEX.LAYER_ONE;
+			return styles;
+		}
+
+		if (feature.geometry.type === "Point") {
+			const closingPoint =
+				feature.properties[COMMON_PROPERTIES.CLOSING_POINT] === true;
+			const snappingPoint =
+				feature.properties[COMMON_PROPERTIES.SNAPPING_POINT] === true;
+
+			if (!closingPoint && !snappingPoint) {
+				return styles;
+			}
+
+			styles.pointColor = this.getHexColorStylingValue(
+				closingPoint
+					? this.styles.closingPointColor
+					: this.styles.snappingPointColor,
+				styles.pointColor,
+				feature,
+			);
+
+			styles.pointWidth = this.getNumericStylingValue(
+				closingPoint
+					? this.styles.closingPointWidth
+					: this.styles.snappingPointWidth,
+				styles.pointWidth,
+				feature,
+			);
+
+			styles.pointOpacity = this.getNumericStylingValue(
+				closingPoint
+					? this.styles.closingPointOpacity
+					: this.styles.snappingPointOpacity,
+				1,
+				feature,
+			);
+
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				closingPoint
+					? this.styles.closingPointOutlineColor
+					: this.styles.snappingPointOutlineColor,
+				styles.pointOutlineColor,
+				feature,
+			);
+
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				closingPoint
+					? this.styles.closingPointOutlineWidth
+					: this.styles.snappingPointOutlineWidth,
+				2,
+				feature,
+			);
+
+			styles.pointOutlineOpacity = this.getNumericStylingValue(
+				closingPoint
+					? this.styles.closingPointOutlineOpacity
+					: this.styles.snappingPointOutlineOpacity,
+				1,
+				feature,
+			);
+
+			styles.zIndex = Z_INDEX.LAYER_THREE;
+		}
+
+		return styles;
+	}
+
+	validateFeature(feature: unknown): StoreValidation {
+		return this.validateModeFeature(feature, (validatedFeature) => {
+			if (validatedFeature.geometry.type === "LineString") {
+				return ValidateLineStringFeature(
+					validatedFeature,
+					this.coordinatePrecision,
+				);
+			}
+
+			if (validatedFeature.geometry.type === "Polygon") {
+				return ValidatePolygonFeature(
+					validatedFeature,
+					this.coordinatePrecision,
+				);
+			}
+
+			return {
+				valid: false,
+				reason: "Only LineString or Polygon features are valid",
+			};
+		});
+	}
+}

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -293,6 +293,41 @@ describe("TerraDrawSelectMode", () => {
 					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 
+				it("clicks through non-selectable overlays to selectable features", () => {
+					setSelectMode({
+						flags: {
+							polygon: {
+								feature: {},
+							},
+							render: {},
+						},
+					});
+
+					store.create([
+						{
+							geometry: {
+								type: "Point",
+								coordinates: [0, 0],
+							},
+							properties: {
+								mode: "render",
+							},
+						},
+					]);
+
+					addPolygonToStore([
+						[0, 0],
+						[0, 1],
+						[1, 1],
+						[1, 0],
+						[0, 0],
+					]);
+
+					selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+					expect(onSelect).toHaveBeenCalledTimes(1);
+				});
+
 				it("deselects selected when click is not on same or different feature", () => {
 					addPointToStore([0, 0]);
 

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -293,41 +293,6 @@ describe("TerraDrawSelectMode", () => {
 					expect(onSelect).toHaveBeenCalledTimes(0);
 				});
 
-				it("clicks through non-selectable overlays to selectable features", () => {
-					setSelectMode({
-						flags: {
-							polygon: {
-								feature: {},
-							},
-							render: {},
-						},
-					});
-
-					store.create([
-						{
-							geometry: {
-								type: "Point",
-								coordinates: [0, 0],
-							},
-							properties: {
-								mode: "render",
-							},
-						},
-					]);
-
-					addPolygonToStore([
-						[0, 0],
-						[0, 1],
-						[1, 1],
-						[1, 0],
-						[0, 0],
-					]);
-
-					selectMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
-
-					expect(onSelect).toHaveBeenCalledTimes(1);
-				});
-
 				it("deselects selected when click is not on same or different feature", () => {
 					addPointToStore([0, 0]);
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -142,8 +142,9 @@ const defaultCursors = {
 	insertMidpoint: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawSelectModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawSelectModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	pointerDistance?: number;
 	flags?: { [mode: string]: ModeFlags };
 	keyEvents?: TerraDrawSelectModeKeyEvents | null;

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -29,6 +29,7 @@ import {
 import { TerraDrawCircleMode } from "./modes/circle/circle.mode";
 import { TerraDrawFreehandMode } from "./modes/freehand/freehand.mode";
 import { TerraDrawLineStringMode } from "./modes/linestring/linestring.mode";
+import { TerraDrawPolyLineMode } from "./modes/polyline/polyline.mode";
 import { TerraDrawPointMode } from "./modes/point/point.mode";
 import { TerraDrawPolygonMode } from "./modes/polygon/polygon.mode";
 import { TerraDrawRectangleMode } from "./modes/rectangle/rectangle.mode";
@@ -1580,6 +1581,7 @@ export {
 	TerraDrawSelectMode,
 	TerraDrawPointMode,
 	TerraDrawLineStringMode,
+	TerraDrawPolyLineMode,
 	TerraDrawPolygonMode,
 	TerraDrawCircleMode,
 	TerraDrawFreehandMode,


### PR DESCRIPTION
## Description of Changes

This PR adds a new mode to Terra Draw; polyline mode. There has been a recent request to be able to mimic similar drawing modes in other tools and this PR puts in a basic implementation of the mode.

The basic premise of the mode is that you start off by drawing a linestring, but that linestrings first point can be clicked to close it off into a polygon.

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/869

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 