### PR TITLE
chore(terra-draw): rerun prettier to get formatting changes

### DIFF
--- a/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
+++ b/packages/terra-draw-arcgis-adapter/src/terra-draw-arcgis-adapter.ts
@@ -39,7 +39,9 @@ type InjectableArcGISMapsSDK = {
 	PictureMarkerSymbol: typeof PictureMarkerSymbol;
 };
 
-export class TerraDrawArcGISMapsSDKAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawArcGISMapsSDKAdapter
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	private readonly _lib: InjectableArcGISMapsSDK;
 	private readonly _mapView: MapView;
 	private readonly _container: HTMLElement;

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -11,7 +11,9 @@ import {
 
 import { GeoJsonObject } from "geojson";
 
-export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawGoogleMapsAdapter
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	constructor(
 		config: {
 			lib: typeof google.maps;
@@ -275,9 +277,9 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 							scaledSize:
 								calculatedStyles.markerWidth && calculatedStyles.markerHeight
 									? new this._lib.Size(
-										calculatedStyles.markerWidth,
-										calculatedStyles.markerHeight,
-									)
+											calculatedStyles.markerWidth,
+											calculatedStyles.markerHeight,
+										)
 									: undefined,
 						},
 						zIndex: calculatedStyles.zIndex,
@@ -322,22 +324,22 @@ export class TerraDrawGoogleMapsAdapter extends TerraDrawExtend.TerraDrawBaseAda
 
 				const dashedLineStyles = lineStringDash
 					? {
-						strokeOpacity: 0,
-						icons: [
-							{
-								icon: {
-									path: "M 0,0 0," + lineStringDash[0],
-									strokeOpacity: 1,
-									strokeWeight: calculatedStyles.lineStringWidth,
-									color: calculatedStyles.lineStringColor,
-									scale: 1,
+							strokeOpacity: 0,
+							icons: [
+								{
+									icon: {
+										path: "M 0,0 0," + lineStringDash[0],
+										strokeOpacity: 1,
+										strokeWeight: calculatedStyles.lineStringWidth,
+										color: calculatedStyles.lineStringColor,
+										scale: 1,
+									},
+									offset: "0",
+									repeat: `${lineStringDash[0] + lineStringDash[1]}px`,
+									fixedRotation: false,
 								},
-								offset: "0",
-								repeat: `${lineStringDash[0] + lineStringDash[1]}px`,
-								fixedRotation: false,
-							},
-						],
-					}
+							],
+						}
 					: {};
 
 				return {

--- a/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
+++ b/packages/terra-draw-leaflet-adapter/src/terra-draw-leaflet-adapter.ts
@@ -10,7 +10,9 @@ import {
 } from "terra-draw";
 import L from "leaflet";
 
-export class TerraDrawLeafletAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawLeafletAdapter
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	constructor(
 		config: {
 			lib: typeof L;

--- a/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.ts
+++ b/packages/terra-draw-mapbox-gl-adapter/src/terra-draw-mapbox-gl-adapter.ts
@@ -18,7 +18,9 @@ import {
 	PointLike,
 } from "mapbox-gl";
 
-export class TerraDrawMapboxGLAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawMapboxGLAdapter
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	constructor(
 		config: {
 			map: mapboxgl.Map;

--- a/packages/terra-draw-openlayers-adapter/src/terra-draw-openlayers-adapter.ts
+++ b/packages/terra-draw-openlayers-adapter/src/terra-draw-openlayers-adapter.ts
@@ -41,7 +41,9 @@ export type InjectableOL = {
 	toLonLat: typeof toLonLat;
 };
 
-export class TerraDrawOpenLayersAdapter extends TerraDrawExtend.TerraDrawBaseAdapter {
+export class TerraDrawOpenLayersAdapter
+	extends TerraDrawExtend.TerraDrawBaseAdapter
+{
 	constructor(
 		config: {
 			map: Map;

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -69,8 +69,9 @@ const defaultCursors = {
 	close: "pointer",
 } as Required<Cursors>;
 
-interface TerraDrawAngledRectangleModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawAngledRectangleModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	pointerDistance?: number;
 	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
 	cursors?: Cursors;

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -58,8 +58,9 @@ const defaultCursors = {
 	start: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawCircleModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawCircleModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	keyEvents?: TerraDrawCircleModeKeyEvents | null;
 	cursors?: Cursors;
 	startingRadiusKilometers?: number;

--- a/packages/terra-draw/src/modes/coordinate-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/coordinate-snapping.behavior.ts
@@ -32,8 +32,8 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 		const snappable = this.getSnappable(event, (feature) => {
 			return Boolean(
 				feature.properties &&
-					feature.properties.mode === this.mode &&
-					feature.id !== currentFeatureId,
+				feature.properties.mode === this.mode &&
+				feature.id !== currentFeatureId,
 			);
 		});
 

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -61,8 +61,9 @@ const defaultCursors = {
 	close: "pointer",
 } as Required<Cursors>;
 
-interface TerraDrawFreehandLineStringModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawFreehandLineStringModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	minDistance?: number;
 	keyEvents?: TerraDrawFreehandLineStringModeKeyEvents | null;
 	cursors?: Cursors;

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -62,8 +62,9 @@ const defaultCursors = {
 	close: "pointer",
 } as Required<Cursors>;
 
-interface TerraDrawFreehandModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawFreehandModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	minDistance?: number;
 	smoothing?: number;
 	preventPointsNearClose?: boolean;

--- a/packages/terra-draw/src/modes/line-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/line-snapping.behavior.ts
@@ -46,8 +46,8 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 		const snappable = this.getSnappable(event, (feature) => {
 			return Boolean(
 				feature.properties &&
-					feature.properties.mode === this.mode &&
-					feature.id !== currentFeatureId,
+				feature.properties.mode === this.mode &&
+				feature.id !== currentFeatureId,
 			);
 		});
 

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -96,8 +96,9 @@ interface InertCoordinates {
 	value: number;
 }
 
-interface TerraDrawLineStringModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawLineStringModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	snapping?: Snapping;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawLineStringModeKeyEvents | null;
@@ -1291,8 +1292,8 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	private lineStringFilter(feature: Feature) {
 		return Boolean(
 			feature.geometry.type === "LineString" &&
-				feature.properties &&
-				feature.properties.mode === this.mode,
+			feature.properties &&
+			feature.properties.mode === this.mode,
 		);
 	}
 

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -48,8 +48,9 @@ const defaultCursors = {
 	dragEnd: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawMarkerModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawMarkerModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	cursors?: Cursors;
 	editable?: boolean;
 }

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -53,8 +53,9 @@ const defaultCursors = {
 	dragEnd: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawPointModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawPointModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	cursors?: Cursors;
 	editable?: boolean;
 }

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -94,8 +94,9 @@ const defaultCursors = {
 	dragEnd: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawPolygonModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawPolygonModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	snapping?: Snapping;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
@@ -677,8 +678,8 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private polygonFilter(feature: Feature) {
 		return Boolean(
 			feature.geometry.type === "Polygon" &&
-				feature.properties &&
-				feature.properties.mode === this.mode,
+			feature.properties &&
+			feature.properties.mode === this.mode,
 		);
 	}
 

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -53,8 +53,9 @@ const defaultCursors = {
 	start: "crosshair",
 } as Required<Cursors>;
 
-interface TerraDrawRectangleModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawRectangleModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	keyEvents?: TerraDrawRectangleModeKeyEvents | null;
 	cursors?: Cursors;
 	drawInteraction?: DrawInteractions;

--- a/packages/terra-draw/src/modes/render/render.mode.ts
+++ b/packages/terra-draw/src/modes/render/render.mode.ts
@@ -35,8 +35,9 @@ type RenderModeStyling = {
 	zIndex: NumericStyling;
 };
 
-interface TerraDrawRenderModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawRenderModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	// styles need to be there else we could fall back to BaseModeOptions
 	styles: Partial<T>;
 }

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -70,8 +70,9 @@ const defaultCursors = {
 	close: "pointer",
 } as Required<Cursors>;
 
-interface TerraDrawSectorModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawSectorModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	arcPoints?: number;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawSectorModeKeyEvents | null;

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -121,8 +121,8 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		const filter = (feature: Feature) => {
 			return Boolean(
 				feature.properties &&
-					feature.properties.mode === draggedFeature.properties.mode &&
-					feature.id !== this.draggedCoordinate.id,
+				feature.properties.mode === draggedFeature.properties.mode &&
+				feature.id !== this.draggedCoordinate.id,
 			);
 		};
 

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -71,8 +71,9 @@ const defaultCursors = {
 	close: "pointer",
 } as Required<Cursors>;
 
-interface TerraDrawSensorModeOptions<T extends CustomStyling>
-	extends BaseModeOptions<T> {
+interface TerraDrawSensorModeOptions<
+	T extends CustomStyling,
+> extends BaseModeOptions<T> {
 	arcPoints?: number;
 	pointerDistance?: number;
 	keyEvents?: TerraDrawSensorModeKeyEvents | null;

--- a/packages/terra-draw/src/store/store-feature-validation.ts
+++ b/packages/terra-draw/src/store/store-feature-validation.ts
@@ -20,9 +20,9 @@ function isObject(
 ): feature is Record<string | number, unknown> {
 	return Boolean(
 		feature &&
-			typeof feature === "object" &&
-			feature !== null &&
-			!Array.isArray(feature),
+		typeof feature === "object" &&
+		feature !== null &&
+		!Array.isArray(feature),
 	);
 }
 
@@ -31,11 +31,11 @@ export function hasModeProperty(
 ): feature is { properties: { mode: string } } {
 	return Boolean(
 		feature &&
-			typeof feature === "object" &&
-			"properties" in feature &&
-			typeof feature.properties === "object" &&
-			feature.properties !== null &&
-			"mode" in feature.properties,
+		typeof feature === "object" &&
+		"properties" in feature &&
+		typeof feature.properties === "object" &&
+		feature.properties !== null &&
+		"mode" in feature.properties,
 	);
 }
 

--- a/packages/terra-draw/src/store/store.spec.ts
+++ b/packages/terra-draw/src/store/store.spec.ts
@@ -447,9 +447,9 @@ describe("GeoJSONStore", () => {
 				(feature) => ({
 					valid: Boolean(
 						feature &&
-							typeof feature === "object" &&
-							"type" in feature &&
-							feature.type === "Polygon",
+						typeof feature === "object" &&
+						"type" in feature &&
+						feature.type === "Polygon",
 					),
 					reason: "Test",
 				}),
@@ -537,9 +537,9 @@ describe("GeoJSONStore", () => {
 				(feature) => ({
 					valid: Boolean(
 						feature &&
-							typeof feature === "object" &&
-							"type" in feature &&
-							(feature as GeoJSONStoreFeatures).geometry.type === "Point",
+						typeof feature === "object" &&
+						"type" in feature &&
+						(feature as GeoJSONStoreFeatures).geometry.type === "Point",
 					),
 				}),
 			);
@@ -602,9 +602,9 @@ describe("GeoJSONStore", () => {
 				(feature) => ({
 					valid: Boolean(
 						feature &&
-							typeof feature === "object" &&
-							"type" in feature &&
-							(feature as GeoJSONStoreFeatures).geometry.type === "Point", // Must be Point to be valid
+						typeof feature === "object" &&
+						"type" in feature &&
+						(feature as GeoJSONStoreFeatures).geometry.type === "Point", // Must be Point to be valid
 					),
 					reason: "Feature must be valid Point",
 				}),
@@ -653,9 +653,9 @@ describe("GeoJSONStore", () => {
 				(feature) => ({
 					valid: Boolean(
 						feature &&
-							typeof feature === "object" &&
-							"type" in feature &&
-							(feature as GeoJSONStoreFeatures).geometry.type === "Point",
+						typeof feature === "object" &&
+						"type" in feature &&
+						(feature as GeoJSONStoreFeatures).geometry.type === "Point",
 					),
 				}),
 				afterFeatureAddedMock,
@@ -735,9 +735,9 @@ describe("GeoJSONStore", () => {
 				(feature) => ({
 					valid: Boolean(
 						feature &&
-							typeof feature === "object" &&
-							"type" in feature &&
-							(feature as GeoJSONStoreFeatures).geometry.type === "Point", // Must be Point to be valid
+						typeof feature === "object" &&
+						"type" in feature &&
+						(feature as GeoJSONStoreFeatures).geometry.type === "Point", // Must be Point to be valid
 					),
 					reason: "Feature must be valid Point",
 				}),

--- a/packages/terra-draw/src/terra-draw.extensions.spec.ts
+++ b/packages/terra-draw/src/terra-draw.extensions.spec.ts
@@ -169,8 +169,9 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
  * custom draw modes for Terra Draw exclusively relying on the public API of the library.
  */
 
-interface TerraDrawTestModeOptions<T extends CustomStyling>
-	extends TerraDrawExtend.BaseModeOptions<T> {
+interface TerraDrawTestModeOptions<
+	T extends CustomStyling,
+> extends TerraDrawExtend.BaseModeOptions<T> {
 	customProperty: string;
 }
 

--- a/packages/terra-draw/src/test/test-adapter.ts
+++ b/packages/terra-draw/src/test/test-adapter.ts
@@ -94,8 +94,9 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
  * custom draw modes for Terra Draw exclusively relying on the public API of the library.
  */
 
-interface TerraDrawTestModeOptions<T extends CustomStyling>
-	extends TerraDrawExtend.BaseModeOptions<T> {
+interface TerraDrawTestModeOptions<
+	T extends CustomStyling,
+> extends TerraDrawExtend.BaseModeOptions<T> {
 	customProperty: string;
 }
 

--- a/packages/terra-draw/src/undo-redo/keyboard-shortcuts.ts
+++ b/packages/terra-draw/src/undo-redo/keyboard-shortcuts.ts
@@ -54,9 +54,7 @@ export const matchesShortcut = (
 	return true;
 };
 
-export class TerraDrawUndoRedoKeyboardShortcuts
-	implements TerraDrawUndoRedoKeyboardShortcutsInterface
-{
+export class TerraDrawUndoRedoKeyboardShortcuts implements TerraDrawUndoRedoKeyboardShortcutsInterface {
 	private undoKeyboardShortcuts: UndoRedoKeyboardShortcut[];
 	private redoKeyboardShortcuts: UndoRedoKeyboardShortcut[];
 

--- a/packages/terra-draw/src/undo-redo/mode-undo-redo.ts
+++ b/packages/terra-draw/src/undo-redo/mode-undo-redo.ts
@@ -9,8 +9,7 @@ import {
 	TerraDrawUndoRedoOptions,
 } from "./undo-redo-types";
 
-export interface TerraDrawModeUndoRedoInterface
-	extends TerraDrawUndoRedoInterface {
+export interface TerraDrawModeUndoRedoInterface extends TerraDrawUndoRedoInterface {
 	getMaxStackSize?(): number;
 	register(options: {
 		getModeState: () => string;


### PR DESCRIPTION
## Description of Changes

For some reason prettier has started generating different formattings across the codebase even though the package versions are all locked. We're running it once to avoid drift

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 