### PR TITLE
fix(terra-draw): respect zero pointer distance

### DIFF
--- a/packages/terra-draw/src/modes/base.mode.spec.ts
+++ b/packages/terra-draw/src/modes/base.mode.spec.ts
@@ -1,0 +1,60 @@
+import { TerraDrawAdapterStyling } from "../common";
+import { GeoJSONStoreFeatures } from "../store/store";
+import { MockModeConfig } from "../test/mock-mode-config";
+import { getDefaultStyling } from "../util/styling";
+import { BehaviorConfig } from "./base.behavior";
+import { TerraDrawBaseDrawMode } from "./base.mode";
+
+class TestBaseMode extends TerraDrawBaseDrawMode<Record<string, never>> {
+	registeredPointerDistance: number | undefined;
+
+	getPointerDistance() {
+		return this.pointerDistance;
+	}
+
+	start(): void {
+		return;
+	}
+
+	stop(): void {
+		return;
+	}
+
+	cleanUp(): void {
+		return;
+	}
+
+	registerBehaviors(config: BehaviorConfig): void {
+		this.registeredPointerDistance = config.pointerDistance;
+	}
+
+	styleFeature(_: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
+		return getDefaultStyling();
+	}
+}
+
+describe("TerraDrawBaseDrawMode", () => {
+	describe("pointerDistance", () => {
+		it("accepts zero in constructor options", () => {
+			const mode = new TestBaseMode({ pointerDistance: 0 });
+
+			expect(mode.getPointerDistance()).toBe(0);
+		});
+
+		it("accepts zero in updateOptions", () => {
+			const mode = new TestBaseMode({ pointerDistance: 10 });
+
+			mode.updateOptions({ pointerDistance: 0 });
+
+			expect(mode.getPointerDistance()).toBe(0);
+		});
+
+		it("passes zero to registered behavior config", () => {
+			const mode = new TestBaseMode({ pointerDistance: 0 });
+
+			mode.register(MockModeConfig(mode.mode));
+
+			expect(mode.registeredPointerDistance).toBe(0);
+		});
+	});
+});

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -140,7 +140,7 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 			this.styles = { ...this._styles, ...options.styles };
 		}
 
-		if (options?.pointerDistance) {
+		if (options?.pointerDistance !== undefined) {
 			this.pointerDistance = options.pointerDistance;
 		}
 		if (options?.validation) {


### PR DESCRIPTION
## Summary
- respect `pointerDistance: 0` when updating base mode options
- add regression coverage for constructor options, `updateOptions`, and behavior registration

## Root cause
`TerraDrawBaseDrawMode.updateOptions` used a truthy check for `pointerDistance`, so valid numeric input `0` was skipped and the default distance remained active.

Fixes #906.

## Checks
- `npx jest --config packages/terra-draw/jest.nocheck.config.ts packages/terra-draw/src/modes/base.mode.spec.ts --runInBand`
- `npx prettier --ignore-path .gitignore --check packages/terra-draw/src/modes/base.mode.ts packages/terra-draw/src/modes/base.mode.spec.ts`
- `npx eslint --config eslint.config.mjs packages/terra-draw/src/modes/base.mode.ts packages/terra-draw/src/modes/base.mode.spec.ts --quiet`
