### PR TITLE
fix(terra-draw): extend the list of possible cursor types

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -14,7 +14,6 @@ import {
 	GeoJSONStoreFeatures,
 	HexColor,
 	TerraDrawMarkerMode,
-	TerraDrawPolyLineMode,
 } from "../../../terra-draw/src/terra-draw";
 
 import {
@@ -405,24 +404,6 @@ const LineString: Story = {
 	},
 };
 
-// Polyline drawing story
-const PolyLine: Story = {
-	...DefaultStory,
-	args: {
-		id: "polyline",
-		modes: [
-			() =>
-				new TerraDrawPolyLineMode({
-					snapping: {
-						toCoordinate: true,
-						toLine: true,
-					},
-				}),
-		],
-		...DefaultStory.args,
-	},
-};
-
 // Linestring drawing story
 const LineStringFinishOnNthCoordinate: Story = {
 	...DefaultStory,
@@ -588,6 +569,11 @@ const Select: Story = {
 								coordinates: {},
 							},
 						},
+					},
+					cursors: {
+						pointerOver: "default",
+						dragStart: "grabbing",
+						dragEnd: "default",
 					},
 				}),
 		],
@@ -1047,7 +1033,6 @@ const AllStories = {
 	RectangleWithClickMoveOrDragInteraction,
 	AngledRectangle,
 	Sector,
-	PolyLine,
 	LineString,
 	LineStringFinishOnNthCoordinate,
 	LineStringWithCoordinatePoints,

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -14,6 +14,7 @@ import {
 	GeoJSONStoreFeatures,
 	HexColor,
 	TerraDrawMarkerMode,
+	TerraDrawPolyLineMode,
 } from "../../../terra-draw/src/terra-draw";
 
 import {
@@ -404,6 +405,24 @@ const LineString: Story = {
 	},
 };
 
+// Polyline drawing story
+const PolyLine: Story = {
+	...DefaultStory,
+	args: {
+		id: "polyline",
+		modes: [
+			() =>
+				new TerraDrawPolyLineMode({
+					snapping: {
+						toCoordinate: true,
+						toLine: true,
+					},
+				}),
+		],
+		...DefaultStory.args,
+	},
+};
+
 // Linestring drawing story
 const LineStringFinishOnNthCoordinate: Story = {
 	...DefaultStory,
@@ -569,11 +588,6 @@ const Select: Story = {
 								coordinates: {},
 							},
 						},
-					},
-					cursors: {
-						pointerOver: "default",
-						dragStart: "grabbing",
-						dragEnd: "default",
 					},
 				}),
 		],
@@ -1033,6 +1047,7 @@ const AllStories = {
 	RectangleWithClickMoveOrDragInteraction,
 	AngledRectangle,
 	Sector,
+	PolyLine,
 	LineString,
 	LineStringFinishOnNthCoordinate,
 	LineStringWithCoordinatePoints,

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -99,6 +99,7 @@ export type SetCursor = (
 		| "se-resize"
 		| "sw-resize"
 		| "text"
+		| "unset"
 		| "vertical-text"
 		| "w-resize"
 		| "wait"

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -68,13 +68,42 @@ export type Cursor = Parameters<SetCursor>[0];
 
 export type SetCursor = (
 	cursor:
-		| "unset"
+		| "alias"
+		| "all-scroll"
+		| "auto"
+		| "cell"
+		| "col-resize"
+		| "context-menu"
+		| "copy"
+		| "crosshair"
+		| "default"
+		| "e-resize"
+		| "ew-resize"
 		| "grab"
 		| "grabbing"
-		| "crosshair"
+		| "help"
+		| "move"
+		| "n-resize"
+		| "ne-resize"
+		| "nesw-resize"
+		| "no-drop"
+		| "none"
+		| "not-allowed"
+		| "ns-resize"
+		| "nw-resize"
+		| "nwse-resize"
 		| "pointer"
+		| "progress"
+		| "row-resize"
+		| "s-resize"
+		| "se-resize"
+		| "sw-resize"
+		| "text"
+		| "vertical-text"
+		| "w-resize"
 		| "wait"
-		| "move",
+		| "zoom-in"
+		| "zoom-out",
 ) => void;
 
 export type Project = (lng: number, lat: number) => CartesianPoint;

--- a/packages/terra-draw/src/terra-draw.extensions.spec.ts
+++ b/packages/terra-draw/src/terra-draw.extensions.spec.ts
@@ -128,16 +128,7 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 	public unproject(x: number, y: number): ReturnType<Unproject> {
 		return { lng: x, lat: y };
 	}
-	public setCursor(
-		_:
-			| "move"
-			| "unset"
-			| "grab"
-			| "grabbing"
-			| "crosshair"
-			| "pointer"
-			| "wait",
-	): ReturnType<SetCursor> {
+	public setCursor(_: Parameters<SetCursor>[0]): ReturnType<SetCursor> {
 		// pass
 	}
 	public getLngLatFromEvent(


### PR DESCRIPTION
## Description of Changes

The typings for the cursors you can set isn't really exhaustive. Since ultimately this just sets a CSS property, we should probably make it extensive to include whatever someone wants to set it to.

## Link to Issue

No direct issue

I noticed that 'default' was missing because of this issue : https://github.com/JamesLMilner/terra-draw/issues/905

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 