### PR TITLE
chore(terra-draw): run subset of storybook tests when env vars are not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,14 @@ jobs:
         run: cd packages/storybook && npx playwright install
         timeout-minutes: 10
       - name: Run storybook smoke tests
+        if: ${{ secrets.GOOGLE_API_KEY != '' && secrets.MAPBOX_ACCESS_TOKEN != '' }}
         run: cd packages/storybook && npm run storybook:test
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+      - name: Run storybook smoke tests (subset)
+        if: ${{ secrets.GOOGLE_API_KEY == '' || secrets.MAPBOX_ACCESS_TOKEN == '' }}
+        run: cd packages/storybook && npm run storybook:test:subset
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
     
   storybook-smoke-test:
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Use Node
@@ -67,13 +70,10 @@ jobs:
         run: cd packages/storybook && npx playwright install
         timeout-minutes: 10
       - name: Run storybook smoke tests
-        if: ${{ secrets.GOOGLE_API_KEY != '' && secrets.MAPBOX_ACCESS_TOKEN != '' }}
+        if: ${{ env.GOOGLE_API_KEY != '' && env.MAPBOX_ACCESS_TOKEN != '' }}
         run: cd packages/storybook && npm run storybook:test
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
       - name: Run storybook smoke tests (subset)
-        if: ${{ secrets.GOOGLE_API_KEY == '' || secrets.MAPBOX_ACCESS_TOKEN == '' }}
+        if: ${{ env.GOOGLE_API_KEY == '' || env.MAPBOX_ACCESS_TOKEN == '' }}
         run: cd packages/storybook && npm run storybook:test:subset
 
   build:

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -10,6 +10,7 @@
 		"storybook:build:memory": "NODE_OPTIONS=--max-old-space-size=4096 storybook build",
 		"storybook:serve": "http-server storybook-static --port 6006 --silent",
 		"storybook:test": "vitest --project=storybook --maxWorkers=2 --run",
+		"storybook:test:subset": "STORYBOOK_TEST_SUBSET=true vitest --project=storybook --maxWorkers=2 --run",
 		"storybook:help": "test-storybook --help"
 	},
 	"author": "James Milner",

--- a/packages/storybook/vitest.config.ts
+++ b/packages/storybook/vitest.config.ts
@@ -4,6 +4,12 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 
 import { playwright } from "@vitest/browser-playwright";
 
+const shouldRunStorybookSubset = process.env.STORYBOOK_TEST_SUBSET === "true";
+
+const excludedStorybookTags = shouldRunStorybookSubset
+	? ["mapbox", "googlemaps"]
+	: [];
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
 	test: {
@@ -13,7 +19,12 @@ export default defineConfig({
 				plugins: [
 					// The plugin will run tests for the stories defined in your Storybook config
 					// See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-					storybookTest({ configDir: ".storybook" }),
+					storybookTest({
+						configDir: ".storybook",
+						tags: {
+							exclude: excludedStorybookTags,
+						},
+					}),
 				],
 				test: {
 					name: "storybook",


### PR DESCRIPTION
## Description of Changes

At the moment PRs from other people can't access the necessary env vars to run the storybook tests

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 