### PR TITLE
fix(terra-draw-google-maps-adapter): handle info window closing when forwardMapElementEvents enabled

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -451,6 +451,66 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				expect(releasePointerCapture).toHaveBeenCalledWith(2);
 			});
 
+			it("does not capture pointer for native InfoWindow targets", () => {
+				const setPointerCapture = jest.fn();
+
+				const div = {
+					addEventListener: jest.fn(),
+					setPointerCapture,
+				} as unknown as HTMLDivElement;
+
+				const mockMap = createMockGoogleMap({
+					getDiv: jest.fn(() => ({
+						id: "map",
+						querySelector: jest.fn(() => div),
+						addEventListener: jest.fn(),
+						removeEventListener: jest.fn(),
+					})) as any,
+					data: {
+						addListener: jest.fn(),
+					} as any,
+				});
+
+				const adapter = new TerraDrawGoogleMapsAdapter({
+					lib: {
+						OverlayView: jest.fn(() => ({
+							setMap: jest.fn(),
+						})),
+					} as any,
+					map: mockMap,
+					forwardMapElementEvents: true,
+				});
+
+				adapter.register(MockCallbacks());
+
+				const pointerDownListener = (adapter as any)
+					._pointerCaptureDownListener;
+
+				const infoWindow = document.createElement("div");
+				infoWindow.setAttribute("role", "dialog");
+				const infoWindowLink = document.createElement("a");
+				infoWindow.appendChild(infoWindowLink);
+
+				expect(() =>
+					pointerDownListener({
+						isPrimary: true,
+						pointerId: 1,
+						target: infoWindowLink,
+					} as unknown as PointerEvent),
+				).not.toThrow();
+				expect(setPointerCapture).not.toHaveBeenCalled();
+
+				const mapSurface = document.createElement("div");
+				expect(() =>
+					pointerDownListener({
+						isPrimary: true,
+						pointerId: 2,
+						target: mapSurface,
+					} as unknown as PointerEvent),
+				).not.toThrow();
+				expect(setPointerCapture).toHaveBeenCalledWith(2);
+			});
+
 			it("forwards marker pointer events only for advanced marker targets", () => {
 				const div = {
 					addEventListener: jest.fn(),

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -57,8 +57,54 @@ export class TerraDrawGoogleMapsAdapter
 	private _mouseMoveEventListener: google.maps.MapsEventListener | undefined;
 	private _readyCalled = false;
 
+	private _interactiveTargetSelector = [
+		'[role="dialog"]',
+		"a",
+		"button",
+		"input",
+		"select",
+		"textarea",
+		"summary",
+		'[role="button"]',
+		'[role="link"]',
+		'[contenteditable=""]',
+		'[contenteditable="true"]',
+	].join(", ");
+
+	private _advancedMarkerElementTag = "gmp-advanced-marker";
+
 	private get _hasRenderedFeatures(): boolean {
 		return Boolean(this.renderedFeatureIds?.size > 0);
+	}
+
+	private getPointerTargetElement(target: EventTarget | null) {
+		if (!target) {
+			return null;
+		}
+
+		if (target instanceof Element) {
+			return target;
+		}
+
+		if (target instanceof Node) {
+			return target.parentElement;
+		}
+
+		return null;
+	}
+
+	private shouldCapturePointer(event: PointerEvent) {
+		const targetElement = this.getPointerTargetElement(event.target);
+		if (!targetElement) {
+			return true;
+		}
+
+		if (targetElement.closest(this._advancedMarkerElementTag)) {
+			return true;
+		}
+
+		// Avoid pointer capture on interactive controls so native map UI keeps working.
+		return !targetElement.closest(this._interactiveTargetSelector);
 	}
 
 	/**
@@ -102,11 +148,13 @@ export class TerraDrawGoogleMapsAdapter
 		};
 
 		if (this._forwardMapElementEvents) {
-			const AdvancedMarkerElementTag = "gmp-advanced-marker";
-
 			const mapEventElement = this.getMapEventElement();
 			this._pointerCaptureDownListener = (event: PointerEvent) => {
 				if (!event.isPrimary) {
+					return;
+				}
+
+				if (!this.shouldCapturePointer(event)) {
 					return;
 				}
 
@@ -149,7 +197,7 @@ export class TerraDrawGoogleMapsAdapter
 			this._markerClickListener = (event: MouseEvent) => {
 				const target = event.target as HTMLElement;
 
-				if (!target?.closest(AdvancedMarkerElementTag)) {
+				if (!target?.closest(this._advancedMarkerElementTag)) {
 					return;
 				}
 
@@ -167,7 +215,7 @@ export class TerraDrawGoogleMapsAdapter
 			this._markerMouseMoveListener = (event: MouseEvent) => {
 				const target = event.target as HTMLElement;
 
-				if (!target?.closest(AdvancedMarkerElementTag)) {
+				if (!target?.closest(this._advancedMarkerElementTag)) {
 					return;
 				}
 


### PR DESCRIPTION
## Description of Changes

Allows closing of InfoWindows when `forwardMapElementEvents` is set to true

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/900

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 