### PR TITLE
fix(terra-draw-google-maps-adapter): fix issues with undo redo

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -2383,7 +2383,7 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				);
 			});
 
-			it("delete wins over update/create in the same frame", () => {
+			it("preserves delete+create for the same id in the same frame", () => {
 				const { adapter, spies } = createAdapterWithMapSpies();
 				const pointOne = MockPoint("point-1") as GeoJSONStoreFeatures;
 
@@ -2415,9 +2415,10 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 				);
 				flushRaf();
 
-				// Deleted applies, update/create should be suppressed
+				// Deleted applies, update is suppressed, and create is preserved.
 				expect(spies.remove).toHaveBeenCalledTimes(1);
-				expect(spies.addGeoJson).toHaveBeenCalledTimes(0);
+				expect(spies.addGeoJson).toHaveBeenCalledTimes(1);
+				expect(spies.addGeoJson).toHaveBeenCalledWith(pointOne);
 				expect(gmFeature.setGeometry).toHaveBeenCalledTimes(0);
 			});
 

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -653,7 +653,9 @@ export class TerraDrawGoogleMapsAdapter
 			if (!feature?.id) throw new Error("Feature is not valid");
 
 			const id = String(feature.id);
-			if (this._rafState.deletedSet.has(id)) continue; // delete wins
+
+			// Preserve delete+create cycles for the same id in one frame (e.g. undo/redo).
+			// Flush order is delete -> update -> create, so recreation still occurs.
 
 			this._rafState.createdById.set(id, feature); // latest create wins
 			this._rafState.updatedById.delete(id); // creation supersedes update in same frame


### PR DESCRIPTION
## Description of Changes

The Google Maps adapter rAF abased render logic dropped created features when the same feature id also appeared in deletedIds within one frame.  This broke undo/redo behaviour for users.

## Link to Issue

#911 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 