### PR TITLE
chore(terra-draw): override microbundles picomatch to prevent build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6229,9 +6229,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -18420,6 +18420,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/microbundle/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/microbundle/node_modules/rollup-plugin-visualizer": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
 		"typescript": "5.6.3",
 		"vitest": "4.1.8"
 	},
+	"overrides": {
+		"microbundle": {
+			"picomatch": "2.3.1"
+		}
+	},
 	"commitlint": {
 		"extends": [
 			"@commitlint/config-conventional"


### PR DESCRIPTION
## Description of Changes

Every time we release we get a change to picomatch which causes a build error:

```
(babel plugin) SyntaxError: /Users/jamesmilner/Code/terra-draw/packages/terra-draw/src/terra-draw.ts: Unexpected token, expected "," (76:6)

  74 | import {
  75 | 	TerraDrawUndoRedoKeyboardShortcuts,
> 76 | 	type TerraDrawUndoRedoKeyboardShortcutsInterface,
     | 	     ^
  77 | } from "./undo-redo/keyboard-shortcuts";
  78 | import {
  79 | 	TerraDrawModeUndoRedo,

at undefined:76:6
SyntaxError: /Users/jamesmilner/Code/terra-draw/packages/terra-draw/src/terra-draw.ts: Unexpected token, expected "," (76:6)
```

Pinning microbundles `picomatch` dependency resolves the issue.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 