### PR TITLE
feat(terra-draw-maplibre-gl-adapter): add callback to delegate cursor control

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -264,6 +264,38 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			expect(map.getCanvas).toHaveBeenCalledTimes(2);
 			expect(container.style.cursor).toBe("pointer");
 		});
+
+		describe("when an onCursorChange callback is provided", () => {
+			it("forwards the cursor intent to the callback instead of touching the canvas", () => {
+				const map = createMapLibreGLMap();
+				const onCursorChange = jest.fn();
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+					onCursorChange,
+				});
+
+				const container = {
+					offsetLeft: 0,
+					offsetTop: 0,
+					style: { removeProperty: jest.fn(), cursor: "initial" },
+				} as unknown as HTMLCanvasElement;
+
+				map.getCanvas = jest.fn(() => container);
+
+				adapter.setCursor("pointer");
+				expect(onCursorChange).toHaveBeenCalledTimes(1);
+				expect(onCursorChange).toHaveBeenLastCalledWith("pointer");
+
+				adapter.setCursor("unset");
+				expect(onCursorChange).toHaveBeenCalledTimes(2);
+				expect(onCursorChange).toHaveBeenLastCalledWith("unset");
+
+				// Canvas cursor is left untouched — the host owns rendering.
+				expect(map.getCanvas).not.toHaveBeenCalled();
+				expect(container.style.cursor).toBe("initial");
+				expect(container.style.removeProperty).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe("setDoubleClickToZoom", () => {

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -26,6 +26,7 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 			map: MapType;
 			renderBelowLayerId?: string;
 			prefixId?: string;
+			onCursorChange?: (cursor: Parameters<SetCursor>[0]) => void;
 		} & TerraDrawExtend.BaseAdapterConfig,
 	) {
 		super(config);
@@ -38,6 +39,7 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 		this._initialDragPan = this._map.dragPan.isEnabled();
 		this._renderBeforeLayerId = config.renderBelowLayerId;
 		this._prefixId = config.prefixId || "td";
+		this._onCursorChange = config.onCursorChange;
 	}
 
 	private hashCode(str: string): number {
@@ -82,6 +84,9 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 	private _nextRender: number | undefined;
 	private _map: MaplibreMap;
 	private _container: HTMLElement;
+	private _onCursorChange:
+		| ((cursor: Parameters<SetCursor>[0]) => void)
+		| undefined;
 
 	private toGlDashArrayFromPixels(
 		dash: [number, number] | undefined,
@@ -406,6 +411,14 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 	 * @param cursor The CSS cursor style to apply, or 'unset' to remove any previously applied cursor style.
 	 */
 	public setCursor(cursor: Parameters<SetCursor>[0]) {
+		// When a host application opts in via `onCursorChange`, it takes ownership of
+		// cursor rendering (e.g. so a single source of truth drives the map cursor).
+		// Terra Draw then only emits its intent and never mutates the canvas directly.
+		if (this._onCursorChange) {
+			this._onCursorChange(cursor);
+			return;
+		}
+
 		const canvas = this._map.getCanvas();
 		if (cursor === "unset") {
 			canvas.style.removeProperty("cursor");


### PR DESCRIPTION
## Description of Changes

Adds an `onCursorChange` callback to the MapLibre adapter.

When an `onCursorChange` callback is provided, `setCursor` forwards every cursor intent (including "unset") to the callback instead of mutating `map.getCanvas().style.cursor`. This lets a host application treat Terra Draw's cursor changes as intents and resolve the final cursor through a single source of truth.

When the callback is omitted the adapter keeps its existing DOM-mutating behaviour.

I think this strikes a decent balance between the work you've been doing to make terra-draw internal cursor management and configuration better, and giving a complete override for people who have more complex external cursor handling needs.

## Link to Issue

This feels like a more robust solution to the original issue https://github.com/JamesLMilner/terra-draw/issues/688. It also might make some of the other cursor related issues like https://github.com/JamesLMilner/terra-draw/issues/457 and https://github.com/JamesLMilner/terra-draw/issues/855 easier to deal with. 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 