### PR TITLE
fix(terra-draw): ensure line opacity is respected in select mode

### DIFF
--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -3478,6 +3478,28 @@ describe("TerraDrawSelectMode", () => {
 			});
 		});
 
+		it("returns the correct styles for linestring from linestring mode", () => {
+			const selectMode = new TerraDrawSelectMode({
+				styles: {
+					selectedLineStringColor: "#222222",
+					selectedLineStringWidth: 4,
+					selectedLineStringOpacity: 0.5,
+				},
+			});
+
+			expect(
+				selectMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "LineString", coordinates: [] },
+					properties: { mode: "linestring", selected: true },
+				}),
+			).toMatchObject({
+				lineStringColor: "#222222",
+				lineStringWidth: 4,
+				lineStringOpacity: 0.5,
+			});
+		});
+
 		it("returns the correct styles for polygon from polygon mode when using a function", () => {
 			const polygonMode = new TerraDrawSelectMode({
 				styles: {

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -1314,6 +1314,12 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 					feature,
 				);
 
+				styles.lineStringOpacity = this.getNumericStylingValue(
+					this.styles.selectedLineStringOpacity,
+					1,
+					feature,
+				);
+
 				styles.zIndex = Z_INDEX.LAYER_ONE;
 				return styles;
 			} else if (feature.geometry.type === "Point") {


### PR DESCRIPTION
## Description of Changes

Line opacity was not being respected when `selectedLineStringOpacity` was being passed

## Link to Issue

#920 

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 