### PR TITLE
fix(terra-draw): support dash lined styling functions

### DIFF
--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -400,7 +400,14 @@ const LineString: Story = {
 	...DefaultStory,
 	args: {
 		id: "linestring",
-		modes: [() => new TerraDrawLineStringMode()],
+		modes: [
+			() =>
+				new TerraDrawLineStringMode({
+					styles: {
+						lineStringDash: () => [5, 5],
+					},
+				}),
+		],
 		...DefaultStory.args,
 	},
 };

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -16,6 +16,10 @@ export type NumericStyling =
 	| number
 	| ((feature: GeoJSONStoreFeatures) => number | undefined);
 
+export type DashArrayStyling =
+	| [number, number]
+	| ((feature: GeoJSONStoreFeatures) => [number, number] | undefined);
+
 export type UrlStyling = string | ((feature: GeoJSONStoreFeatures) => string);
 
 export interface TerraDrawAdapterStyling {
@@ -34,7 +38,7 @@ export interface TerraDrawAdapterStyling {
 	lineStringColor: HexColor;
 	lineStringOpacity?: number;
 	/** lineStringDash - Tuple representing the dash pattern for the line string, where the first number is the length of the dash and the second number is the length of the gap in pixels */
-	lineStringDash?: [number, number];
+	lineStringDash?: DashArrayStyling;
 	zIndex: number;
 	markerUrl?: string;
 	markerHeight?: number;

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -15,6 +15,7 @@ import {
 	HexColorStyling,
 	NumericStyling,
 	UrlStyling,
+	DashArrayStyling,
 } from "../common";
 import {
 	FeatureId,
@@ -31,7 +32,7 @@ export type CustomStyling = Record<
 	| HexColorStyling
 	| NumericStyling
 	| UrlStyling
-	| [number, number]
+	| DashArrayStyling
 >;
 
 export enum ModeTypes {
@@ -370,7 +371,22 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 		return this.getStylingValue(value, defaultValue, feature);
 	}
 
-	private getStylingValue<T extends string | number>(
+	protected getDashArrayStylingValue(
+		value:
+			| [number, number]
+			| ((feature: GeoJSONStoreFeatures) => [number, number] | undefined)
+			| undefined,
+		defaultValue: [number, number] | undefined,
+		feature: GeoJSONStoreFeatures,
+	): [number, number] | undefined {
+		return this.getStylingValue(
+			value,
+			defaultValue as unknown as [number, number],
+			feature,
+		);
+	}
+
+	private getStylingValue<T extends string | number | [number, number]>(
 		value: T | ((feature: GeoJSONStoreFeatures) => T | undefined) | undefined,
 		defaultValue: T,
 		feature: GeoJSONStoreFeatures,

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
@@ -629,6 +629,7 @@ describe("TerraDrawFreehandLineStringMode", () => {
 				styles: {
 					lineStringColor: () => "#ffffff",
 					lineStringWidth: () => 2,
+					lineStringDash: () => [5, 3],
 				},
 			});
 
@@ -643,6 +644,7 @@ describe("TerraDrawFreehandLineStringMode", () => {
 			).toMatchObject({
 				lineStringColor: "#ffffff",
 				lineStringWidth: 2,
+				lineStringDash: [5, 3],
 			});
 		});
 

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -42,7 +42,7 @@ type FreehandLineStringStyling = {
 	lineStringWidth: NumericStyling;
 	lineStringColor: HexColorStyling;
 	lineStringOpacity: NumericStyling;
-	lineStringDash: [number, number];
+	lineStringDash: DashArrayStyling;
 	closingPointColor: HexColorStyling;
 	closingPointOpacity: NumericStyling;
 	closingPointWidth: NumericStyling;
@@ -312,7 +312,11 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
-			styles.lineStringDash = this.styles.lineStringDash;
+			styles.lineStringDash = this.getDashArrayStylingValue(
+				this.styles.lineStringDash,
+				undefined,
+				feature,
+			);
 
 			styles.lineStringColor = this.getHexColorStylingValue(
 				this.styles.lineStringColor,

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -9,6 +9,7 @@ import {
 	COMMON_PROPERTIES,
 	Z_INDEX,
 	FinishActions,
+	DashArrayStyling,
 } from "../../common";
 
 import {

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -1990,6 +1990,7 @@ describe("TerraDrawLineStringMode", () => {
 				styles: {
 					lineStringColor: () => "#ffffff",
 					lineStringWidth: () => 4,
+					lineStringDash: () => [5, 3],
 					closingPointColor: () => "#111111",
 					closingPointWidth: () => 3,
 					closingPointOutlineColor: () => "#222222",
@@ -2006,6 +2007,7 @@ describe("TerraDrawLineStringMode", () => {
 			).toMatchObject({
 				lineStringColor: "#ffffff",
 				lineStringWidth: 4,
+				lineStringDash: [5, 3],
 			});
 		});
 	});

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -11,6 +11,7 @@ import {
 	Snapping,
 	COMMON_PROPERTIES,
 	FinishActions,
+	DashArrayStyling,
 } from "../../common";
 import { Feature, LineString, Position } from "geojson";
 import {
@@ -74,7 +75,7 @@ type LineStringStyling = {
 	coordinatePointOutlineColor: HexColorStyling;
 	coordinatePointOutlineWidth: NumericStyling;
 	coordinatePointOutlineOpacity: NumericStyling;
-	lineStringDash: [number, number];
+	lineStringDash: DashArrayStyling;
 };
 
 interface Cursors {
@@ -1162,7 +1163,11 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			feature.geometry.type === "LineString" &&
 			feature.properties.mode === this.mode
 		) {
-			styles.lineStringDash = this.styles.lineStringDash;
+			styles.lineStringDash = this.getDashArrayStylingValue(
+				this.styles.lineStringDash,
+				undefined,
+				feature,
+			);
 
 			styles.lineStringColor = this.getHexColorStylingValue(
 				this.styles.lineStringColor,

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
@@ -4,6 +4,7 @@ import { MockModeConfig } from "../../test/mock-mode-config";
 import { TerraDrawPolyLineMode } from "./polyline.mode";
 import { COMMON_PROPERTIES } from "../../common";
 import { MockLineString } from "../../test/mock-features";
+import { GeoJSONStoreFeatures } from "../../terra-draw";
 
 describe("TerraDrawPolyLineMode", () => {
 	describe("constructor", () => {
@@ -329,10 +330,66 @@ describe("TerraDrawPolyLineMode", () => {
 					mode: "polyline",
 					[COMMON_PROPERTIES.CLOSING_POINT]: true,
 				},
-			} as any;
+			} as GeoJSONStoreFeatures;
 
 			const styles = polyLineMode.styleFeature(feature);
 			expect(styles.pointOutlineColor).toBe("#ffffff");
+		});
+
+		it("styles the line with static styling values", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				styles: {
+					lineStringColor: "#ffffff",
+					lineStringWidth: 2,
+					lineStringDash: [5, 3],
+				},
+			});
+			const feature = {
+				id: "test",
+				type: "Feature",
+				geometry: {
+					type: "LineString",
+					coordinates: [
+						[0, 0],
+						[1, 1],
+					],
+				},
+				properties: { mode: "polyline" },
+			} as GeoJSONStoreFeatures;
+
+			expect(polyLineMode.styleFeature(feature)).toMatchObject({
+				lineStringColor: "#ffffff",
+				lineStringWidth: 2,
+				lineStringDash: [5, 3],
+			});
+		});
+
+		it("styles the line with dynamic styling values", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				styles: {
+					lineStringColor: () => "#ffffff",
+					lineStringWidth: () => 2,
+					lineStringDash: () => [5, 3],
+				},
+			});
+			const feature = {
+				id: "test",
+				type: "Feature",
+				geometry: {
+					type: "LineString",
+					coordinates: [
+						[0, 0],
+						[1, 1],
+					],
+				},
+				properties: { mode: "polyline" },
+			} as GeoJSONStoreFeatures;
+
+			expect(polyLineMode.styleFeature(feature)).toMatchObject({
+				lineStringColor: "#ffffff",
+				lineStringWidth: 2,
+				lineStringDash: [5, 3],
+			});
 		});
 	});
 

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -10,6 +10,7 @@ import {
 	COMMON_PROPERTIES,
 	FinishActions,
 	Snapping,
+	DashArrayStyling,
 } from "../../common";
 import { LineString, Polygon, Position } from "geojson";
 import {
@@ -46,6 +47,7 @@ type PolyLineStyling = {
 	lineStringWidth: NumericStyling;
 	lineStringColor: HexColorStyling;
 	lineStringOpacity: NumericStyling;
+	lineStringDash: DashArrayStyling;
 	polygonFillColor: HexColorStyling;
 	polygonFillOpacity: NumericStyling;
 	polygonOutlineColor: HexColorStyling;
@@ -516,6 +518,12 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.lineStringOpacity = this.getNumericStylingValue(
 				this.styles.lineStringOpacity,
 				1,
+				feature,
+			);
+
+			styles.lineStringDash = this.getDashArrayStylingValue(
+				this.styles.lineStringDash,
+				undefined,
 				feature,
 			);
 

--- a/packages/terra-draw/src/modes/select/select.mode.spec.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.spec.ts
@@ -3484,6 +3484,7 @@ describe("TerraDrawSelectMode", () => {
 					selectedLineStringColor: "#222222",
 					selectedLineStringWidth: 4,
 					selectedLineStringOpacity: 0.5,
+					selectedLineStringDash: [2, 2],
 				},
 			});
 
@@ -3497,6 +3498,7 @@ describe("TerraDrawSelectMode", () => {
 				lineStringColor: "#222222",
 				lineStringWidth: 4,
 				lineStringOpacity: 0.5,
+				lineStringDash: [2, 2],
 			});
 		});
 
@@ -3533,6 +3535,30 @@ describe("TerraDrawSelectMode", () => {
 				polygonFillColor: "#3f97e0",
 				polygonFillOpacity: 0.3,
 				polygonOutlineColor: "#3f97e0",
+			});
+		});
+
+		it("returns the correct styles for linestring from linestring mode when using a function", () => {
+			const lineStringMode = new TerraDrawSelectMode({
+				styles: {
+					selectedLineStringColor: () => "#222222",
+					selectedLineStringWidth: () => 4,
+					selectedLineStringOpacity: () => 0.5,
+					selectedLineStringDash: () => [2, 2],
+				},
+			});
+
+			expect(
+				lineStringMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "LineString", coordinates: [] },
+					properties: { mode: "linestring", selected: true },
+				}),
+			).toMatchObject({
+				lineStringColor: "#222222",
+				lineStringWidth: 4,
+				lineStringOpacity: 0.5,
+				lineStringDash: [2, 2],
 			});
 		});
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -14,6 +14,7 @@ import {
 	COMMON_PROPERTIES,
 	MARKER_URL_DEFAULT,
 	FinishActions,
+	DashArrayStyling,
 } from "../../common";
 import { LineString, Point, Polygon, Position } from "geojson";
 import {
@@ -100,6 +101,7 @@ type SelectionStyling = {
 	selectedLineStringColor: HexColorStyling;
 	selectedLineStringWidth: NumericStyling;
 	selectedLineStringOpacity: NumericStyling;
+	selectedLineStringDash: DashArrayStyling;
 
 	// Polygon
 	selectedPolygonColor: HexColorStyling;
@@ -1317,6 +1319,12 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 				styles.lineStringOpacity = this.getNumericStylingValue(
 					this.styles.selectedLineStringOpacity,
 					1,
+					feature,
+				);
+
+				styles.lineStringDash = this.getDashArrayStylingValue(
+					this.styles.selectedLineStringDash,
+					undefined,
 					feature,
 				);
 


### PR DESCRIPTION
## Description of Changes

- Adds line dash support to select mode and also to polyline mode
- Allows functions to be provided for styling as per other styling types

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/48#issuecomment-4751216196

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 