### PR TITLE
chore(terra-draw): add Blocktype as a sponsor

### DIFF
--- a/guides/SPONSORSHIP.md
+++ b/guides/SPONSORSHIP.md
@@ -8,4 +8,6 @@ Terra Draw is primarily maintained by James Milner. You can find his [GitHub spo
 
 ## Current Sponsors
 
-<a href="https://uk.osgeo.org/"><img alt="The OSGeo:UK logo" src="https://www.osgeo.org/wp-content/uploads/sponsor-osgeo-uk_740x412_acf_cropped.png" alt="Description" width="300" ></a>
+<a href="https://uk.osgeo.org/"><img alt="The OSGeo:UK logo" src="https://www.osgeo.org/wp-content/uploads/sponsor-osgeo-uk_740x412_acf_cropped.png" width="300" ></a>
+
+<a href=""><img alt="Blocktype logo" src="https://images.squarespace-cdn.com/content/v1/6400d6f7fe02760fa8d9d7d9/c2c88823-64a0-4a85-aa7e-cbbcaf290b47/Vector.png?format=1500" width="300"> 


### PR DESCRIPTION
## Description of Changes

Adds Blocktype as a sponsor of the project

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 