### PR TITLE
feat(terra-draw): add support for snapping to arbitary features in the store

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -177,6 +177,33 @@ We can also provide a `toCustom` function which allows snapping to some arbitrar
   })
 ```
 
+We can also configure `toFeature` to snap to arbitrary features in the store by supplying a filter and optional snapping strategy overrides.
+
+`toFeature` supports:
+
+- `filter` (required): a function that returns true for features that are snappable
+- `toLine` (optional): snap to nearest point on a line segment for matching features
+- `toCoordinate` (optional): snap to nearest coordinate/vertex for matching features
+
+Example:
+
+```typescript
+new TerraDrawPolygonMode({
+  snapping: {
+    toFeature: {
+      filter: (feature) =>
+        feature.geometry.type === "Point" ||
+        feature.geometry.type === "LineString",
+      toLine: true,
+      toCoordinate: true,
+    },
+  },
+})
+```
+
+> [!NOTE]
+> The currently edited feature is excluded automatically, so a feature will not snap to itself. If neither `toLine` nor `toCoordinate` is provided, both are enabled by default.
+
 In `TerraDrawSelectMode` we can similarly add snapping behaviours like so:
 
 ```typescript

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -234,10 +234,6 @@ const PolygonWithSnapToFeature: Story = {
 					snapping: {
 						toFeature: {
 							filter: (feature) => {
-								console.log(
-									"Snap to feature filter called with feature:",
-									feature,
-								);
 								return (
 									feature.geometry.type === "Point" ||
 									feature.geometry.type === "LineString"

--- a/packages/storybook/src/common/stories.ts
+++ b/packages/storybook/src/common/stories.ts
@@ -219,6 +219,39 @@ const PolygonWithLineSnapping: Story = {
 	...DefaultPlay,
 };
 
+// Polygon with custom snapToFeature story
+const PolygonWithSnapToFeature: Story = {
+	args: {
+		id: "polygon-snap-to-feature",
+		...DefaultSize,
+		...LocationNewYork,
+		...DefaultZoom,
+		modes: [
+			() => new TerraDrawPointMode(),
+			() => new TerraDrawLineStringMode(),
+			() =>
+				new TerraDrawPolygonMode({
+					snapping: {
+						toFeature: {
+							filter: (feature) => {
+								console.log(
+									"Snap to feature filter called with feature:",
+									feature,
+								);
+								return (
+									feature.geometry.type === "Point" ||
+									feature.geometry.type === "LineString"
+								);
+							},
+							toLine: true,
+							toCoordinate: true,
+						},
+					},
+				}),
+		],
+	},
+};
+
 // Polygon styling story - changes fill color based on a property on the feature
 const Styling: Story = {
 	...DefaultStory,
@@ -1042,6 +1075,7 @@ const AllStories = {
 	PolygonWithCoordinatePoints,
 	PolygonWithCoordinateSnapping,
 	PolygonWithLineSnapping,
+	PolygonWithSnapToFeature,
 	PolygonWithEditableEnabled,
 	PolygonWithCoordinateCounts,
 	Styling,

--- a/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
+++ b/packages/storybook/src/stories/arcgis/ArcGIS.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/storybook/src/stories/google/Google.stories.ts
+++ b/packages/storybook/src/stories/google/Google.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
+++ b/packages/storybook/src/stories/leaflet/Leaflet.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
+++ b/packages/storybook/src/stories/mapbox/Mapbox.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
+++ b/packages/storybook/src/stories/maplibre/MapLibre.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
+++ b/packages/storybook/src/stories/openlayers/OpenLayers.stories.ts
@@ -22,6 +22,7 @@ export const PolygonWithCoordinatePoints =
 export const PolygonWithCoordinateSnapping =
 	AllStories.PolygonWithCoordinateSnapping;
 export const PolygonWithLineSnapping = AllStories.PolygonWithLineSnapping;
+export const PolygonWithSnapToFeature = AllStories.PolygonWithSnapToFeature;
 export const PolygonWithEditableEnabled = AllStories.PolygonWithEditableEnabled;
 export const PolygonWithCoordinateCounts =
 	AllStories.PolygonWithCoordinateCounts;

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -1,4 +1,4 @@
-import { LineString, Polygon, Position } from "geojson";
+import { Feature, LineString, Polygon, Position } from "geojson";
 import {
 	StoreChangeHandler,
 	GeoJSONStore,
@@ -186,19 +186,44 @@ export type Validation = (
 	reason?: string;
 };
 
+export type Snappable = {
+	coordinate: Position | undefined;
+	featureId: FeatureId | undefined;
+	featureCoordinateIndex: number | undefined;
+	minDistance: number;
+};
+
+export type SnappableContext = {
+	currentId?: FeatureId;
+	currentCoordinate?: number;
+	getCurrentGeometrySnapshot: () => (Polygon | LineString) | null;
+	project: Project;
+	unproject: Unproject;
+};
+
+export type SnapToCustom = (
+	event: TerraDrawMouseEvent,
+	context: SnappableContext,
+) => Position | undefined;
+
+export type SnapToFeatureBehavior = {
+	getSnappable: (
+		event: TerraDrawMouseEvent,
+		currentFeatureId?: FeatureId,
+		filter?: (feature: Feature) => boolean,
+		options?: { toLine?: boolean; toCoordinate?: boolean },
+	) => Snappable;
+};
+
 export interface Snapping {
 	toLine?: boolean;
 	toCoordinate?: boolean;
-	toCustom?: (
-		event: TerraDrawMouseEvent,
-		context: {
-			currentId?: FeatureId;
-			currentCoordinate?: number;
-			getCurrentGeometrySnapshot: () => (Polygon | LineString) | null;
-			project: Project;
-			unproject: Unproject;
-		},
-	) => Position | undefined;
+	toFeature?: {
+		filter: (feature: Feature) => boolean;
+		toLine?: boolean;
+		toCoordinate?: boolean;
+	};
+	toCustom?: SnapToCustom;
 }
 
 export type TerraDrawModeState =

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -206,23 +206,16 @@ export type SnapToCustom = (
 	context: SnappableContext,
 ) => Position | undefined;
 
-export type SnapToFeatureBehavior = {
-	getSnappable: (
-		event: TerraDrawMouseEvent,
-		currentFeatureId?: FeatureId,
-		filter?: (feature: Feature) => boolean,
-		options?: { toLine?: boolean; toCoordinate?: boolean },
-	) => Snappable;
+type SnapToFeature = {
+	filter: (feature: Feature) => boolean;
+	toLine?: boolean;
+	toCoordinate?: boolean;
 };
 
 export interface Snapping {
 	toLine?: boolean;
 	toCoordinate?: boolean;
-	toFeature?: {
-		filter: (feature: Feature) => boolean;
-		toLine?: boolean;
-		toCoordinate?: boolean;
-	};
+	toFeature?: SnapToFeature;
 	toCustom?: SnapToCustom;
 }
 

--- a/packages/terra-draw/src/modes/coordinate-snapping.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/coordinate-snapping.behavior.spec.ts
@@ -53,6 +53,27 @@ describe("CoordinateSnappingBehavior", () => {
 
 				expect(snappedCoord).toStrictEqual([0, 0]);
 			});
+
+			it("returns a snappable coordinate for point features", () => {
+				config.store.create([
+					{
+						geometry: {
+							type: "Point",
+							coordinates: [10, 10],
+						},
+						properties: {
+							mode: "test",
+						},
+					},
+				]);
+
+				const snappedCoord = coordinateSnappingBehavior.getSnappableCoordinate(
+					MockCursorEvent({ lng: 10, lat: 10 }),
+					"currentId",
+				);
+
+				expect(snappedCoord).toStrictEqual([10, 10]);
+			});
 		});
 	});
 });

--- a/packages/terra-draw/src/modes/coordinate-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/coordinate-snapping.behavior.ts
@@ -1,5 +1,10 @@
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
-import { TerraDrawMouseEvent } from "../common";
+import {
+	COMMON_PROPERTIES,
+	SELECT_PROPERTIES,
+	Snappable,
+	TerraDrawMouseEvent,
+} from "../common";
 import { Feature, Position } from "geojson";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
 import { BBoxPolygon, FeatureId } from "../store/store";
@@ -15,7 +20,7 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 	}
 
 	/** Returns the nearest snappable coordinate - on first click there is no currentId so no need to provide */
-	public getSnappableCoordinateFirstClick = (event: TerraDrawMouseEvent) => {
+	public getSnappableCoordinateFirstClick(event: TerraDrawMouseEvent) {
 		const snappble = this.getSnappable(event, (feature) => {
 			return Boolean(
 				feature.properties && feature.properties.mode === this.mode,
@@ -23,12 +28,12 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 		});
 
 		return snappble.coordinate;
-	};
+	}
 
-	public getSnappableCoordinate = (
+	public getSnappableCoordinate(
 		event: TerraDrawMouseEvent,
 		currentFeatureId: FeatureId,
-	) => {
+	) {
 		const snappable = this.getSnappable(event, (feature) => {
 			return Boolean(
 				feature.properties &&
@@ -38,7 +43,7 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 		});
 
 		return snappable.coordinate;
-	};
+	}
 
 	public getSnappable(
 		event: TerraDrawMouseEvent,
@@ -48,16 +53,11 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 
 		const features = this.store.search(bbox, filter);
 
-		const closest: {
-			coordinate: undefined | Position;
-			minDist: number;
-			featureId: undefined | FeatureId;
-			featureCoordinateIndex: undefined | number;
-		} = {
+		const closest: Snappable = {
 			featureId: undefined,
 			featureCoordinateIndex: undefined,
 			coordinate: undefined,
-			minDist: Infinity,
+			minDistance: Infinity,
 		};
 
 		features.forEach((feature) => {
@@ -66,15 +66,28 @@ export class CoordinateSnappingBehavior extends TerraDrawModeBehavior {
 				coordinates = feature.geometry.coordinates[0];
 			} else if (feature.geometry.type === "LineString") {
 				coordinates = feature.geometry.coordinates;
+			} else if (feature.geometry.type === "Point") {
+				if (
+					feature.properties?.[COMMON_PROPERTIES.EDITED] ||
+					feature.properties?.[COMMON_PROPERTIES.CLOSING_POINT] ||
+					feature.properties?.[COMMON_PROPERTIES.SNAPPING_POINT] ||
+					feature.properties?.[COMMON_PROPERTIES.COORDINATE_POINT] ||
+					feature.properties?.[SELECT_PROPERTIES.SELECTION_POINT] ||
+					feature.properties?.[SELECT_PROPERTIES.MID_POINT]
+				) {
+					return;
+				}
+
+				coordinates = [feature.geometry.coordinates];
 			} else {
 				return;
 			}
 
 			coordinates.forEach((coord, coordIndex) => {
 				const dist = this.pixelDistance.measure(event, coord);
-				if (dist < closest.minDist && dist < this.pointerDistance) {
+				if (dist < closest.minDistance && dist < this.pointerDistance) {
 					closest.coordinate = coord;
-					closest.minDist = dist;
+					closest.minDistance = dist;
 					closest.featureId = feature.id;
 					closest.featureCoordinateIndex = coordIndex;
 				}

--- a/packages/terra-draw/src/modes/feature-snapping.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/feature-snapping.behavior.spec.ts
@@ -1,0 +1,190 @@
+import { Feature } from "geojson";
+import { Snappable, TerraDrawMouseEvent } from "../common";
+import { CoordinateSnappingBehavior } from "./coordinate-snapping.behavior";
+import { FeatureSnappingBehavior } from "./feature-snapping.behavior";
+import { LineSnappingBehavior } from "./line-snapping.behavior";
+
+const event: TerraDrawMouseEvent = {
+	lng: 0,
+	lat: 0,
+	containerX: 0,
+	containerY: 0,
+	button: "left",
+	heldKeys: [],
+	isContextMenu: false,
+};
+
+const emptySnappable: Snappable = {
+	coordinate: undefined,
+	featureId: undefined,
+	featureCoordinateIndex: undefined,
+	minDistance: Infinity,
+};
+
+describe("FeatureSnappingBehavior", () => {
+	describe("constructor", () => {
+		it("constructs", () => {
+			const coordinateGetSnappable = jest.fn<
+				Snappable,
+				[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+			>();
+			const lineGetSnappable = jest.fn<
+				Snappable,
+				[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+			>();
+
+			const behavior = new FeatureSnappingBehavior(
+				{
+					getSnappable: coordinateGetSnappable,
+				} as unknown as CoordinateSnappingBehavior,
+				{
+					getSnappable: lineGetSnappable,
+				} as unknown as LineSnappingBehavior,
+			);
+
+			expect(behavior).toBeInstanceOf(FeatureSnappingBehavior);
+		});
+	});
+
+	describe("api", () => {
+		let behavior: FeatureSnappingBehavior;
+		let coordinateGetSnappable: jest.Mock<
+			Snappable,
+			[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+		>;
+		let lineGetSnappable: jest.Mock<
+			Snappable,
+			[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+		>;
+
+		beforeEach(() => {
+			coordinateGetSnappable = jest.fn<
+				Snappable,
+				[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+			>();
+			lineGetSnappable = jest.fn<
+				Snappable,
+				[TerraDrawMouseEvent, ((feature: Feature) => boolean) | undefined]
+			>();
+
+			behavior = new FeatureSnappingBehavior(
+				{
+					getSnappable: coordinateGetSnappable,
+				} as unknown as CoordinateSnappingBehavior,
+				{
+					getSnappable: lineGetSnappable,
+				} as unknown as LineSnappingBehavior,
+			);
+		});
+
+		it("uses both coordinate and line snapping by default and returns the nearest", () => {
+			coordinateGetSnappable.mockReturnValue({
+				coordinate: [10, 10],
+				featureId: "coordinate-feature",
+				featureCoordinateIndex: 3,
+				minDistance: 10,
+			});
+			lineGetSnappable.mockReturnValue({
+				coordinate: [1, 1],
+				featureId: "line-feature",
+				featureCoordinateIndex: 0,
+				minDistance: 2,
+			});
+
+			const snapped = behavior.getSnappable(event);
+
+			expect(coordinateGetSnappable).toHaveBeenCalledTimes(1);
+			expect(lineGetSnappable).toHaveBeenCalledTimes(1);
+			expect(snapped).toEqual({
+				coordinate: [1, 1],
+				featureId: "line-feature",
+				featureCoordinateIndex: 0,
+				minDistance: 2,
+			});
+		});
+
+		it("respects toCoordinate=false and only evaluates line snapping", () => {
+			lineGetSnappable.mockReturnValue({
+				coordinate: [2, 2],
+				featureId: "line-feature",
+				featureCoordinateIndex: 1,
+				minDistance: 4,
+			});
+
+			const snapped = behavior.getSnappable(event, undefined, undefined, {
+				toCoordinate: false,
+				toLine: true,
+			});
+
+			expect(coordinateGetSnappable).not.toHaveBeenCalled();
+			expect(lineGetSnappable).toHaveBeenCalledTimes(1);
+			expect(snapped.coordinate).toEqual([2, 2]);
+		});
+
+		it("respects toLine=false and only evaluates coordinate snapping", () => {
+			coordinateGetSnappable.mockReturnValue({
+				coordinate: [3, 3],
+				featureId: "coordinate-feature",
+				featureCoordinateIndex: 4,
+				minDistance: 5,
+			});
+
+			const snapped = behavior.getSnappable(event, undefined, undefined, {
+				toCoordinate: true,
+				toLine: false,
+			});
+
+			expect(coordinateGetSnappable).toHaveBeenCalledTimes(1);
+			expect(lineGetSnappable).not.toHaveBeenCalled();
+			expect(snapped.coordinate).toEqual([3, 3]);
+		});
+
+		it("excludes current feature id before applying custom filter", () => {
+			const customFilter = jest.fn(
+				(feature: Feature) => feature.id === "keep-me",
+			);
+
+			coordinateGetSnappable.mockImplementation((_event, passedFilter) => {
+				expect(passedFilter).toBeDefined();
+				const filter = passedFilter!;
+
+				expect(
+					filter({
+						id: "current-id",
+						type: "Feature",
+						geometry: { type: "Point", coordinates: [0, 0] },
+						properties: {},
+					}),
+				).toBe(false);
+				expect(customFilter).not.toHaveBeenCalled();
+
+				expect(
+					filter({
+						id: "drop-me",
+						type: "Feature",
+						geometry: { type: "Point", coordinates: [0, 0] },
+						properties: {},
+					}),
+				).toBe(false);
+				expect(customFilter).toHaveBeenCalledWith(
+					expect.objectContaining({ id: "drop-me" }),
+				);
+
+				expect(
+					filter({
+						id: "keep-me",
+						type: "Feature",
+						geometry: { type: "Point", coordinates: [0, 0] },
+						properties: {},
+					}),
+				).toBe(true);
+
+				return emptySnappable;
+			});
+			lineGetSnappable.mockReturnValue(emptySnappable);
+
+			behavior.getSnappable(event, "current-id", customFilter);
+			expect(customFilter).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/terra-draw/src/modes/feature-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/feature-snapping.behavior.ts
@@ -4,11 +4,6 @@ import { FeatureId } from "../store/store";
 import { CoordinateSnappingBehavior } from "./coordinate-snapping.behavior";
 import { LineSnappingBehavior } from "./line-snapping.behavior";
 
-export type FeatureSnappingOptions = {
-	toLine?: boolean;
-	toCoordinate?: boolean;
-};
-
 export class FeatureSnappingBehavior {
 	constructor(
 		private readonly coordinateSnapping: CoordinateSnappingBehavior,
@@ -19,7 +14,10 @@ export class FeatureSnappingBehavior {
 		event: TerraDrawMouseEvent,
 		currentFeatureId?: FeatureId,
 		filter?: (feature: Feature) => boolean,
-		options?: FeatureSnappingOptions,
+		options?: {
+			toLine?: boolean;
+			toCoordinate?: boolean;
+		},
 	): Snappable {
 		const toCoordinate = options?.toCoordinate !== false;
 		const toLine = options?.toLine !== false;

--- a/packages/terra-draw/src/modes/feature-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/feature-snapping.behavior.ts
@@ -1,0 +1,74 @@
+import { Snappable, TerraDrawMouseEvent } from "../common";
+import { Feature } from "geojson";
+import { FeatureId } from "../store/store";
+import { CoordinateSnappingBehavior } from "./coordinate-snapping.behavior";
+import { LineSnappingBehavior } from "./line-snapping.behavior";
+
+export type FeatureSnappingOptions = {
+	toLine?: boolean;
+	toCoordinate?: boolean;
+};
+
+export class FeatureSnappingBehavior {
+	constructor(
+		private readonly coordinateSnapping: CoordinateSnappingBehavior,
+		private readonly lineSnapping: LineSnappingBehavior,
+	) {}
+
+	public getSnappable(
+		event: TerraDrawMouseEvent,
+		currentFeatureId?: FeatureId,
+		filter?: (feature: Feature) => boolean,
+		options?: FeatureSnappingOptions,
+	): Snappable {
+		const toCoordinate = options?.toCoordinate !== false;
+		const toLine = options?.toLine !== false;
+		const effectiveFilter = (feature: Feature) => {
+			if (currentFeatureId !== undefined && feature.id === currentFeatureId) {
+				return false;
+			}
+
+			if (filter) {
+				return filter(feature);
+			}
+
+			return true;
+		};
+
+		let closest: Snappable = {
+			coordinate: undefined,
+			featureId: undefined,
+			featureCoordinateIndex: undefined,
+			minDistance: Infinity,
+		};
+
+		if (toCoordinate) {
+			const coordinateCandidate = this.coordinateSnapping.getSnappable(
+				event,
+				effectiveFilter,
+			);
+
+			if (
+				coordinateCandidate.coordinate &&
+				coordinateCandidate.minDistance < closest.minDistance
+			) {
+				closest = coordinateCandidate;
+			}
+		}
+
+		if (toLine) {
+			const lineCandidate = this.lineSnapping.getSnappable(
+				event,
+				effectiveFilter,
+			);
+			if (
+				lineCandidate.coordinate &&
+				lineCandidate.minDistance < closest.minDistance
+			) {
+				closest = lineCandidate;
+			}
+		}
+
+		return closest;
+	}
+}

--- a/packages/terra-draw/src/modes/line-snapping.behavior.ts
+++ b/packages/terra-draw/src/modes/line-snapping.behavior.ts
@@ -1,5 +1,5 @@
 import { BehaviorConfig, TerraDrawModeBehavior } from "./base.behavior";
-import { TerraDrawMouseEvent } from "../common";
+import { Snappable, TerraDrawMouseEvent } from "../common";
 import { Feature, Position } from "geojson";
 import { ClickBoundingBoxBehavior } from "./click-bounding-box.behavior";
 import { BBoxPolygon, FeatureId } from "../store/store";
@@ -65,18 +65,13 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 			: undefined;
 	};
 
-	public getSnappable(
+	public getSnappable = (
 		event: TerraDrawMouseEvent,
 		filter?: (feature: Feature) => boolean,
-	) {
+	) => {
 		const boundingBox = this.clickBoundingBox.create(event) as BBoxPolygon;
 		const features = this.store.search(boundingBox, filter);
-		const closest: {
-			coordinate: undefined | Position;
-			minDistance: number;
-			featureId: undefined | FeatureId;
-			featureCoordinateIndex: undefined | number;
-		} = {
+		const closest: Snappable = {
 			featureId: undefined,
 			featureCoordinateIndex: undefined,
 			coordinate: undefined,
@@ -137,5 +132,5 @@ export class LineSnappingBehavior extends TerraDrawModeBehavior {
 		});
 
 		return closest;
-	}
+	};
 }

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -35,6 +35,7 @@ import { haversineDistanceKilometers } from "../../geometry/measure/haversine-di
 import { coordinatesIdentical } from "../../geometry/coordinates-identical";
 import { ValidateLineStringFeature } from "../../validations/linestring.validation";
 import { LineSnappingBehavior } from "../line-snapping.behavior";
+import { FeatureSnappingBehavior } from "../feature-snapping.behavior";
 import {
 	MutateFeatureBehavior,
 	Mutations,
@@ -138,6 +139,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	private coordinateSnapping!: CoordinateSnappingBehavior;
 	private insertPoint!: InsertCoordinatesBehavior;
 	private lineSnapping!: LineSnappingBehavior;
+	private featureSnapping!: FeatureSnappingBehavior;
 	private pixelDistance!: PixelDistanceBehavior;
 	private clickBoundingBox!: ClickBoundingBoxBehavior;
 	private mutateFeature!: MutateFeatureBehavior;
@@ -664,6 +666,10 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			config,
 			this.pixelDistance,
 			this.clickBoundingBox,
+		);
+		this.featureSnapping = new FeatureSnappingBehavior(
+			this.coordinateSnapping,
+			this.lineSnapping,
 		);
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
@@ -1354,6 +1360,22 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 			if (snapped) {
 				snappedCoordinate = snapped;
+			}
+		}
+
+		if (this.snapping?.toFeature) {
+			const snappable = this.featureSnapping.getSnappable(
+				event,
+				this.currentId,
+				this.snapping.toFeature.filter,
+				{
+					toLine: this.snapping.toFeature.toLine,
+					toCoordinate: this.snapping.toFeature.toCoordinate,
+				},
+			);
+
+			if (snappable.coordinate) {
+				snappedCoordinate = snappable.coordinate;
 			}
 		}
 

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -32,6 +32,7 @@ import {
 import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 import { LineSnappingBehavior } from "../line-snapping.behavior";
 import { CoordinateSnappingBehavior } from "../coordinate-snapping.behavior";
+import { FeatureSnappingBehavior } from "../feature-snapping.behavior";
 import { CoordinatePointBehavior } from "../select/behaviors/coordinate-point.behavior";
 import {
 	CoordinateMutation,
@@ -133,6 +134,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	private coordinatePoints!: CoordinatePointBehavior;
 	private lineSnapping!: LineSnappingBehavior;
 	private coordinateSnapping!: CoordinateSnappingBehavior;
+	private featureSnapping!: FeatureSnappingBehavior;
 	private pixelDistance!: PixelDistanceBehavior;
 	private closingPoints!: ClosingPointsBehavior;
 	private clickBoundingBox!: ClickBoundingBoxBehavior;
@@ -295,6 +297,10 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			config,
 			this.pixelDistance,
 			this.clickBoundingBox,
+		);
+		this.featureSnapping = new FeatureSnappingBehavior(
+			this.coordinateSnapping,
+			this.lineSnapping,
 		);
 		this.closingPoints = new ClosingPointsBehavior(
 			config,
@@ -652,6 +658,22 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 			if (snapped) {
 				snappedCoordinate = snapped;
+			}
+		}
+
+		if (this.snapping?.toFeature) {
+			const snappable = this.featureSnapping.getSnappable(
+				event,
+				this.currentId,
+				this.snapping?.toFeature.filter,
+				{
+					toLine: this.snapping.toFeature.toLine,
+					toCoordinate: this.snapping.toFeature.toCoordinate,
+				},
+			);
+
+			if (snappable.coordinate) {
+				snappedCoordinate = snappable.coordinate;
 			}
 		}
 

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -24,6 +24,7 @@ import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { LineSnappingBehavior } from "../line-snapping.behavior";
 import { CoordinateSnappingBehavior } from "../coordinate-snapping.behavior";
+import { FeatureSnappingBehavior } from "../feature-snapping.behavior";
 import { getDefaultStyling } from "../../util/styling";
 import {
 	FeatureId,
@@ -103,6 +104,7 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 	private clickBoundingBox!: ClickBoundingBoxBehavior;
 	private lineSnapping!: LineSnappingBehavior;
 	private coordinateSnapping!: CoordinateSnappingBehavior;
+	private featureSnapping!: FeatureSnappingBehavior;
 
 	constructor(options?: TerraDrawPolyLineModeOptions<PolyLineStyling>) {
 		super(options, true);
@@ -142,6 +144,10 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			config,
 			this.pixelDistance,
 			this.clickBoundingBox,
+		);
+		this.featureSnapping = new FeatureSnappingBehavior(
+			this.coordinateSnapping,
+			this.lineSnapping,
 		);
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
@@ -469,6 +475,22 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 
 			if (snapped) {
 				snappedCoordinate = snapped;
+			}
+		}
+
+		if (this.snapping?.toFeature) {
+			const snappable = this.featureSnapping.getSnappable(
+				event,
+				this.currentId,
+				this.snapping.toFeature.filter,
+				{
+					toLine: this.snapping.toFeature.toLine,
+					toCoordinate: this.snapping.toFeature.toCoordinate,
+				},
+			);
+
+			if (snappable.coordinate) {
+				snappedCoordinate = snappable.coordinate;
 			}
 		}
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -15,6 +15,7 @@ import { FeatureId, GeoJSONStoreFeatures } from "../../../store/store";
 import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { CoordinateSnappingBehavior } from "../../coordinate-snapping.behavior";
 import { LineSnappingBehavior } from "../../line-snapping.behavior";
+import { FeatureSnappingBehavior } from "../../feature-snapping.behavior";
 import { ReadFeatureBehavior } from "../../read-feature.behavior";
 import {
 	MutateFeatureBehavior,
@@ -22,6 +23,8 @@ import {
 } from "../../mutate-feature.behavior";
 
 export class DragCoordinateBehavior extends TerraDrawModeBehavior {
+	private readonly featureSnapping: FeatureSnappingBehavior;
+
 	constructor(
 		readonly config: BehaviorConfig,
 		private readonly pixelDistance: PixelDistanceBehavior,
@@ -34,6 +37,10 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 		private readonly mutateFeature: MutateFeatureBehavior,
 	) {
 		super(config);
+		this.featureSnapping = new FeatureSnappingBehavior(
+			this.coordinateSnapping,
+			this.lineSnapping,
+		);
 	}
 
 	private draggedCoordinate: { id: null | FeatureId; index: number } = {
@@ -143,6 +150,22 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 
 			if (snapped) {
 				snappedCoordinate = snapped;
+			}
+		}
+
+		if (snapping?.toFeature) {
+			const snappable = this.featureSnapping.getSnappable(
+				event,
+				draggedFeature.id as FeatureId,
+				snapping.toFeature.filter,
+				{
+					toLine: snapping.toFeature.toLine,
+					toCoordinate: snapping.toFeature.toCoordinate,
+				},
+			);
+
+			if (snappable.coordinate) {
+				snappedCoordinate = snappable.coordinate;
 			}
 		}
 

--- a/packages/terra-draw/src/terra-draw.ts
+++ b/packages/terra-draw/src/terra-draw.ts
@@ -20,6 +20,9 @@ import {
 	TerraDrawOnChangeContext,
 	Projection,
 	TerraDrawHandledEvents,
+	SnapToCustom,
+	SnappableContext,
+	Snappable,
 } from "./common";
 import {
 	ModeTypes,
@@ -44,7 +47,6 @@ import {
 	GeoJSONStoreGeometries,
 	IdStrategy,
 	JSON,
-	JSONObject,
 	StoreChangeHandler,
 	StoreValidation,
 } from "./store/store";
@@ -85,9 +87,7 @@ import {
 } from "./undo-redo/session-undo-redo";
 import { TerraDrawUndoRedoCoordinator } from "./undo-redo/undo-redo-coordinator";
 import type {
-	HistoryCause,
 	HistoryEvent,
-	StackType,
 	TerraDrawUndoRedoInterface,
 } from "./undo-redo/undo-redo-types";
 
@@ -1601,10 +1601,12 @@ export {
 	type GeoJSONStoreFeatures,
 	type GeoJSONStoreGeometries,
 	type HexColor,
+	type Snappable,
+	type SnappableContext,
+	type SnapToCustom,
 	type TerraDrawMouseEvent,
 	type TerraDrawAdapterStyling,
 	type TerraDrawKeyboardEvent,
-
 	// TerraDrawBaseAdapter
 	type TerraDrawHandledEvents,
 	type TerraDrawChanges,


### PR DESCRIPTION
## Description of Changes

Adds support for snapping to other features inside the Terra Draw store
 
## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/848

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 