### PR TITLE
fix(terra-draw): fix case where a feature has been removed as it is being dragged

### DIFF
--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate.behavior.ts
@@ -204,6 +204,11 @@ export class DragCoordinateBehavior extends TerraDrawModeBehavior {
 			return false;
 		}
 
+		if (this.readFeature.hasFeature(draggedFeatureId) === false) {
+			this.stopDragging();
+			return false;
+		}
+
 		const index = this.draggedCoordinate.index;
 		const geometry = this.readFeature.getGeometry(draggedFeatureId);
 		const properties = this.readFeature.getProperties(draggedFeatureId);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-feature.behavior.ts
@@ -66,6 +66,11 @@ export class DragFeatureBehavior extends TerraDrawModeBehavior {
 			return;
 		}
 
+		if (this.readFeature.hasFeature(this.draggedFeatureId) === false) {
+			this.stopDragging();
+			return false;
+		}
+
 		const geometry = this.readFeature.getGeometry(this.draggedFeatureId);
 		const cursorCoord = [event.lng, event.lat];
 


### PR DESCRIPTION
## Description of Changes

In theory a feature could be removed whilst it is dragged which could cause a state issue in TerraDrawSelectMode, or more specifically dragCoordinateResizeFeature and dragCoordinate behaviors.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 