### PR TITLE
chore(terra-draw): create a github release upon release of a new version

### DIFF
--- a/.github/workflows/terra-draw-arcgis-adapter-release.yml
+++ b/.github/workflows/terra-draw-arcgis-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-arcgis-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-arcgis-adapter
+          PACKAGE_DIR: packages/terra-draw-arcgis-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-google-maps-adapter-release.yml
+++ b/.github/workflows/terra-draw-google-maps-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-google-maps-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-google-maps-adapter
+          PACKAGE_DIR: packages/terra-draw-google-maps-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-leaflet-adapter-release.yml
+++ b/.github/workflows/terra-draw-leaflet-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-leaflet-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-leaflet-adapter
+          PACKAGE_DIR: packages/terra-draw-leaflet-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-mapbox-gl-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-mapbox-gl-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-mapbox-gl-adapter
+          PACKAGE_DIR: packages/terra-draw-mapbox-gl-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
+++ b/.github/workflows/terra-draw-maplibre-gl-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-maplibre-gl-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-maplibre-gl-adapter
+          PACKAGE_DIR: packages/terra-draw-maplibre-gl-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-openlayers-adapter-release.yml
+++ b/.github/workflows/terra-draw-openlayers-adapter-release.yml
@@ -50,5 +50,19 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw-openlayers-adapter
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw-openlayers-adapter
+          PACKAGE_DIR: packages/terra-draw-openlayers-adapter
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"

--- a/.github/workflows/terra-draw-release.yml
+++ b/.github/workflows/terra-draw-release.yml
@@ -46,6 +46,20 @@ jobs:
       - name: Push tags upstream
         run: git push origin main --tags
 
-      - run: npm publish
+      - name: Publish package
+        run: npm publish
         working-directory: ./packages/terra-draw
+
+      - name: Generate package release notes
+        id: package_release_notes
+        env:
+          PACKAGE_NAME: terra-draw
+          PACKAGE_DIR: packages/terra-draw
+        run: node ./github-release.mjs
+
+      - name: Create package GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.package_release_notes.outputs.tag }}" --verify-tag --title "${{ steps.package_release_notes.outputs.title }}" --notes-file "${{ steps.package_release_notes.outputs.notes_file }}"
  

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Terra Draw uses the concept of 'adapters' to allow it to work with a host of dif
 
 Please see the [the getting started guide](./guides/1.GETTING_STARTED.md) - this provides a host of information on how to get up and running with Terra Draw. You can see the auto generated [API docs on the Terra Draw website](https://terradraw.io/#/api).
 
-### Changelogs
+### Releases and Changelogs
 
-Automated changelogs are created for each package upon release, based off of the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format. You can find the generated CHANGELOG.md file in the [corresponding package folder](https://github.com/JamesLMilner/terra-draw/tree/main/packages).
+We create GitHub releases when we release new packages. We also keep automated changelogs that are created for each package upon release, based off of the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format. You can find the generated CHANGELOG.md file in the [corresponding package folder](https://github.com/JamesLMilner/terra-draw/tree/main/packages).
 
 
 ### Development & Contributing

--- a/github-release.mjs
+++ b/github-release.mjs
@@ -1,0 +1,75 @@
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function requiredEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+function extractVersionSection(changelog, version) {
+	const lines = changelog.split(/\r?\n/);
+	const startPattern = new RegExp(`^## \\[${escapeRegExp(version)}\\]`);
+	const headingPattern = /^## \[/;
+	const section = [];
+	let inSection = false;
+
+	for (const line of lines) {
+		if (!inSection && startPattern.test(line)) {
+			inSection = true;
+		}
+
+		if (inSection) {
+			if (section.length > 0 && headingPattern.test(line)) {
+				break;
+			}
+			section.push(line);
+		}
+	}
+
+	return section.join("\n").trim();
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function main() {
+	const packageName = requiredEnv("PACKAGE_NAME");
+	const packageDir = requiredEnv("PACKAGE_DIR");
+	const githubOutput = requiredEnv("GITHUB_OUTPUT");
+	const packageJsonPath = join(packageDir, "package.json");
+	const changelogPath = join(packageDir, "CHANGELOG.md");
+
+	const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+	const packageVersion = packageJson.version;
+	if (!packageVersion) {
+		throw new Error(`No version found in ${packageJsonPath}`);
+	}
+
+	const tag = `${packageName}@${packageVersion}`;
+	const changelog = readFileSync(changelogPath, "utf8");
+	const notes = extractVersionSection(changelog, packageVersion);
+
+	if (!notes) {
+		throw new Error(
+			`Could not find changelog notes for ${packageName} ${packageVersion} in ${changelogPath}`,
+		);
+	}
+
+	const title = `${packageName} ${packageVersion}`;
+	const releaseBody = `${"# " + title}\n\n${notes}\n`;
+	const safePackageName = packageName.replace(/[^a-zA-Z0-9_-]/g, "-");
+	const releaseBodyPath = `release-body-${safePackageName}.md`;
+	writeFileSync(releaseBodyPath, releaseBody, "utf8");
+
+	appendFileSync(githubOutput, `tag=${tag}\n`, "utf8");
+	appendFileSync(githubOutput, `title=${title}\n`, "utf8");
+	appendFileSync(githubOutput, `notes_file=${releaseBodyPath}\n`, "utf8");
+
+	console.log(`Generated release notes for ${tag} at ${releaseBodyPath}`);
+}
+
+main();


### PR DESCRIPTION
## Description of Changes

Creates GitHub releases when we release a new version of a package in Terra Draw

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/929

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 