### PR TITLE
fix(terra-draw): small freehand mode bugfixes

### DIFF
--- a/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.spec.ts
@@ -201,6 +201,22 @@ describe("TerraDrawFreehandMode", () => {
 
 			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
 		});
+
+		it("accepts minDistance set to 0", () => {
+			const freehandMode = new TerraDrawFreehandMode({ minDistance: 10 });
+
+			freehandMode.updateOptions({ minDistance: 0 });
+
+			expect((freehandMode as any).minDistance).toBe(0);
+		});
+
+		it("accepts autoCloseTimeout set to 0", () => {
+			const freehandMode = new TerraDrawFreehandMode({ autoCloseTimeout: 10 });
+
+			freehandMode.updateOptions({ autoCloseTimeout: 0 });
+
+			expect((freehandMode as any).autoCloseTimeout).toBe(0);
+		});
 	});
 
 	describe("onClick", () => {
@@ -302,6 +318,22 @@ describe("TerraDrawFreehandMode", () => {
 				expect(onFinish).toHaveBeenCalledTimes(1);
 			});
 
+			it("does not finish drawing polygon on second click without moving from the starting coordinate", () => {
+				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+				let features = store.copyAll();
+				expect(features.length).toBe(2);
+
+				freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+
+				features = store.copyAll();
+				expect(features.length).toBe(2);
+				expect(
+					features[0].properties[COMMON_PROPERTIES.CURRENTLY_DRAWING],
+				).toBe(true);
+				expect(onFinish).toHaveBeenCalledTimes(0);
+			});
+
 			describe("with leftClick pointer event set to false", () => {
 				beforeEach(() => {
 					freehandMode = new TerraDrawFreehandMode({
@@ -373,7 +405,9 @@ describe("TerraDrawFreehandMode", () => {
 				let features = store.copyAll();
 				expect(features.length).toBe(2);
 
-				freehandMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+				freehandMode.onMouseMove(MockCursorEvent({ lng: 45, lat: 45 }));
+
+				freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
 
 				// Closing coordinate should be removed
 				features = store.copyAll();

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -109,7 +109,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	): void {
 		super.updateOptions(options);
 
-		if (options?.minDistance !== undefined) {
+		if (options?.minDistance !== undefined && options.minDistance >= 0) {
 			this.minDistance = options.minDistance;
 		}
 
@@ -130,7 +130,10 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			this.autoClose = options.autoClose;
 		}
 
-		if (options?.autoCloseTimeout !== undefined) {
+		if (
+			options?.autoCloseTimeout !== undefined &&
+			options.autoCloseTimeout >= 0
+		) {
 			this.autoCloseTimeout = options.autoCloseTimeout;
 		}
 

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -109,7 +109,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	): void {
 		super.updateOptions(options);
 
-		if (options?.minDistance) {
+		if (options?.minDistance !== undefined) {
 			this.minDistance = options.minDistance;
 		}
 
@@ -130,7 +130,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			this.autoClose = options.autoClose;
 		}
 
-		if (options?.autoCloseTimeout) {
+		if (options?.autoCloseTimeout !== undefined) {
 			this.autoCloseTimeout = options.autoCloseTimeout;
 		}
 
@@ -229,6 +229,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 				}, this.autoCloseTimeout);
 
 				this.close();
+				return;
 			}
 
 			this.setCursor(this.cursors.close);
@@ -368,6 +369,10 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			if (this.canClose === false) {
 				this.beginDrawing(event);
 
+				return;
+			}
+
+			if (!this.hasLeftStartingPoint) {
 				return;
 			}
 


### PR DESCRIPTION
## Description of Changes

Small fixes to freehand mode; ensure numeric options can be set to 0, ensure clicking on the starting point doesn't produce a finished polygon, ensure we return after closing the polygon.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 