### PR TITLE
fix(terra-draw): validate mode options more thoroughly

### DIFF
--- a/packages/terra-draw/src/common/checks.spec.ts
+++ b/packages/terra-draw/src/common/checks.spec.ts
@@ -1,0 +1,101 @@
+import {
+	isBoolean,
+	isDrawInteraction,
+	isFiniteNonNegativeNumber,
+	isFunction,
+	isNonEmptyString,
+	isNonNullObject,
+	isNull,
+} from "./checks";
+
+describe("checks", () => {
+	describe("isFiniteNonNegativeNumber", () => {
+		it("returns true for finite non-negative numbers", () => {
+			expect(isFiniteNonNegativeNumber(0)).toBe(true);
+			expect(isFiniteNonNegativeNumber(1.5)).toBe(true);
+		});
+
+		it("returns false for invalid values", () => {
+			expect(isFiniteNonNegativeNumber(-1)).toBe(false);
+			expect(isFiniteNonNegativeNumber(Number.NaN)).toBe(false);
+			expect(isFiniteNonNegativeNumber(Number.POSITIVE_INFINITY)).toBe(false);
+			expect(isFiniteNonNegativeNumber("1")).toBe(false);
+		});
+	});
+
+	describe("isBoolean", () => {
+		it("returns true for boolean values", () => {
+			expect(isBoolean(true)).toBe(true);
+			expect(isBoolean(false)).toBe(true);
+		});
+
+		it("returns false for non-boolean values", () => {
+			expect(isBoolean("true")).toBe(false);
+			expect(isBoolean(0)).toBe(false);
+			expect(isBoolean(null)).toBe(false);
+		});
+	});
+
+	describe("isNull", () => {
+		it("returns true only for null", () => {
+			expect(isNull(null)).toBe(true);
+			expect(isNull(undefined)).toBe(false);
+			expect(isNull({})).toBe(false);
+		});
+	});
+
+	describe("isNonNullObject", () => {
+		it("returns true for non-null objects", () => {
+			expect(isNonNullObject({})).toBe(true);
+			expect(isNonNullObject([])).toBe(true);
+		});
+
+		it("returns false for null and non-objects", () => {
+			expect(isNonNullObject(null)).toBe(false);
+			expect(isNonNullObject("object")).toBe(false);
+			expect(isNonNullObject(1)).toBe(false);
+			expect(isNonNullObject(() => {})).toBe(false);
+		});
+	});
+
+	describe("isFunction", () => {
+		it("returns true for functions", () => {
+			expect(isFunction(() => {})).toBe(true);
+			expect(isFunction(function test() {})).toBe(true);
+		});
+
+		it("returns false for non-functions", () => {
+			expect(isFunction({})).toBe(false);
+			expect(isFunction("fn")).toBe(false);
+			expect(isFunction(null)).toBe(false);
+		});
+	});
+
+	describe("isNonEmptyString", () => {
+		it("returns true for non-empty strings", () => {
+			expect(isNonEmptyString("a")).toBe(true);
+			expect(isNonEmptyString("terra")).toBe(true);
+		});
+
+		it("returns false for empty and non-string values", () => {
+			expect(isNonEmptyString("")).toBe(false);
+			expect(isNonEmptyString(1)).toBe(false);
+			expect(isNonEmptyString(null)).toBe(false);
+		});
+	});
+
+	describe("isDrawInteraction", () => {
+		it("returns true for supported draw interaction values", () => {
+			expect(isDrawInteraction("click-move")).toBe(true);
+			expect(isDrawInteraction("click-drag")).toBe(true);
+			expect(isDrawInteraction("click-move-or-drag")).toBe(true);
+		});
+
+		it("returns false for unsupported values", () => {
+			expect(isDrawInteraction("click")).toBe(false);
+			expect(isDrawInteraction("drag")).toBe(false);
+			expect(isDrawInteraction(1)).toBe(false);
+			expect(isDrawInteraction(null)).toBe(false);
+		});
+	});
+});

--- a/packages/terra-draw/src/common/checks.ts
+++ b/packages/terra-draw/src/common/checks.ts
@@ -1,0 +1,83 @@
+import type { DrawInteractions } from "../common";
+
+export type Check<T> = (value: unknown) => value is T;
+
+/**
+ * Checks whether a value is a finite, non-negative number.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is a number >= 0 and finite.
+ */
+export const isFiniteNonNegativeNumber: Check<number> = (
+	value,
+): value is number => {
+	return typeof value === "number" && value >= 0 && Number.isFinite(value);
+};
+
+/**
+ * Checks whether a value is a boolean.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is either true or false.
+ */
+export const isBoolean: Check<boolean> = (value): value is boolean => {
+	return typeof value === "boolean";
+};
+
+/**
+ *  Checks whether a value is null.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is null.
+ */
+export const isNull: Check<null> = (value): value is null => {
+	return value === null;
+};
+
+/**
+ * Checks whether a value is a non-null object.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is an object and not null.
+ */
+export const isNonNullObject: Check<Record<string, unknown>> = (
+	value,
+): value is Record<string, unknown> => {
+	return typeof value === "object" && value !== null;
+};
+
+/**
+ * Checks whether a value is a function.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is a callable function.
+ */
+export const isFunction: Check<Function> = (value): value is Function => {
+	return typeof value === "function";
+};
+
+/**
+ * Checks whether a value is a string with at least one character.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is a non-empty string.
+ */
+export const isNonEmptyString: Check<string> = (value): value is string => {
+	return typeof value === "string" && value.length > 0;
+};
+
+/**
+ * Checks whether a value is a supported draw interaction string.
+ *
+ * @param value - The value to validate.
+ * @returns True when the value is one of the DrawInteractions literals.
+ */
+export const isDrawInteraction: Check<DrawInteractions> = (
+	value,
+): value is DrawInteractions => {
+	return (
+		value === "click-move" ||
+		value === "click-drag" ||
+		value === "click-move-or-drag"
+	);
+};

--- a/packages/terra-draw/src/common/checks.ts
+++ b/packages/terra-draw/src/common/checks.ts
@@ -1,6 +1,6 @@
 import type { DrawInteractions } from "../common";
 
-export type Check<T> = (value: unknown) => value is T;
+type Check<T> = (value: unknown) => value is T;
 
 /**
  * Checks whether a value is a finite, non-negative number.

--- a/packages/terra-draw/src/common/cursors.ts
+++ b/packages/terra-draw/src/common/cursors.ts
@@ -1,0 +1,8 @@
+export const CursorValues = {
+	Crosshair: "crosshair",
+	Pointer: "pointer",
+	Grab: "grab",
+	Grabbing: "grabbing",
+	Move: "move",
+	Unset: "unset",
+} as const;

--- a/packages/terra-draw/src/common/keys.ts
+++ b/packages/terra-draw/src/common/keys.ts
@@ -1,0 +1,8 @@
+const KeyboardEventKey = {
+	Enter: "Enter",
+	Escape: "Escape",
+	Backspace: "Backspace",
+	Delete: "Delete",
+} as const;
+
+export { KeyboardEventKey };

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -10,6 +10,8 @@ import {
 	COMMON_PROPERTIES,
 	FinishActions,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import {
 	TerraDrawBaseDrawMode,
 	BaseModeOptions,
@@ -43,13 +45,17 @@ import {
 } from "../mutate-feature.behavior";
 import { BehaviorConfig } from "../base.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
+import { isNonNullObject, isNull } from "../../common/checks";
 
 type TerraDrawPolygonModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
 	finish?: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type PolygonStyling = {
 	fillColor: HexColorStyling;
@@ -65,8 +71,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawAngledRectangleModeOptions<
@@ -102,13 +108,13 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 	}
@@ -156,7 +162,7 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/base.mode.ts
+++ b/packages/terra-draw/src/modes/base.mode.ts
@@ -24,6 +24,12 @@ import {
 } from "../store/store";
 import { isValidStoreFeature } from "../store/store-feature-validation";
 import { ValidationReasonModeMismatch } from "../validations/common-validations";
+import {
+	isFiniteNonNegativeNumber,
+	isFunction,
+	isNonNullObject,
+	isNonEmptyString,
+} from "../common/checks";
 
 export type CustomStyling = Record<
 	string,
@@ -135,27 +141,27 @@ export abstract class TerraDrawBaseDrawMode<Styling extends CustomStyling> {
 	}
 
 	updateOptions(options?: BaseModeOptions<Styling>) {
-		if (options?.styles) {
+		if (isNonNullObject(options?.styles)) {
 			// Note: we are updating this.styles and not this._styles - this is because
 			// once registered we want to trigger the onStyleChange
 			this.styles = { ...this._styles, ...options.styles };
 		}
 
-		if (options?.pointerDistance !== undefined) {
+		if (isFiniteNonNegativeNumber(options?.pointerDistance)) {
 			this.pointerDistance = options.pointerDistance;
 		}
-		if (options?.validation) {
-			this.validate = options && options.validation;
+		if (isFunction(options?.validation)) {
+			this.validate = options.validation;
 		}
-		if (options?.projection) {
+		if (isNonEmptyString(options?.projection)) {
 			this.projection = options.projection;
 		}
 
-		if (options?.pointerEvents !== undefined) {
+		if (isNonNullObject(options?.pointerEvents)) {
 			this.pointerEvents = options.pointerEvents;
 		}
 
-		if (options?.modeName && this.isInitialUpdate === true) {
+		if (isNonEmptyString(options?.modeName) && this.isInitialUpdate === true) {
 			this.mode = options.modeName;
 		}
 

--- a/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.spec.ts
@@ -378,6 +378,27 @@ describe("TerraDrawCircleMode", () => {
 						1000,
 					);
 				});
+
+				it("accepts a startingRadiusKilometers value of 0", () => {
+					circleMode = new TerraDrawCircleMode({
+						startingRadiusKilometers: 0,
+					});
+					const mockConfig = MockModeConfig(circleMode.mode);
+
+					store = mockConfig.store;
+					onChange = mockConfig.onChange;
+					onFinish = mockConfig.onFinish;
+
+					circleMode.register(mockConfig);
+					circleMode.start();
+
+					circleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+					expect(onChange).toHaveBeenCalledTimes(1);
+					expect(store.copyAll()[0].properties.radiusKilometers).toStrictEqual(
+						0,
+					);
+				});
 			});
 
 			describe("segments option", () => {

--- a/packages/terra-draw/src/modes/circle/circle.mode.ts
+++ b/packages/terra-draw/src/modes/circle/circle.mode.ts
@@ -14,6 +14,8 @@ import {
 	DrawInteractions,
 	DrawType,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { haversineDistanceKilometers } from "../../geometry/measure/haversine-distance";
 import { circle, circleWebMercator } from "../../geometry/shape/create-circle";
 import {
@@ -33,13 +35,22 @@ import { Polygon } from "geojson";
 import { calculateWebMercatorDistortion } from "../../geometry/shape/web-mercator-distortion";
 import { BehaviorConfig } from "../base.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
+import {
+	isFiniteNonNegativeNumber,
+	isDrawInteraction,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawCircleModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type CirclePolygonStyling = {
 	fillColor: HexColorStyling;
@@ -54,7 +65,7 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
+	start: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawCircleModeOptions<
@@ -109,25 +120,25 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.startingRadiusKilometers) {
+		if (isFiniteNonNegativeNumber(options?.startingRadiusKilometers)) {
 			this.startingRadiusKilometers = options.startingRadiusKilometers;
 		}
 
-		if (options?.drawInteraction) {
+		if (isDrawInteraction(options?.drawInteraction)) {
 			this.drawInteraction = options.drawInteraction;
 		}
 
-		if (options?.segments) {
+		if (isFiniteNonNegativeNumber(options?.segments)) {
 			this.segments = options.segments < 3 ? 3 : options.segments;
 		}
 	}
@@ -216,7 +227,7 @@ export class TerraDrawCircleMode extends TerraDrawBaseDrawMode<CirclePolygonStyl
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.spec.ts
@@ -179,6 +179,28 @@ describe("TerraDrawFreehandLineStringMode", () => {
 
 			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
 		});
+
+		it("accepts minDistance set to 0", () => {
+			const freehandMode = new TerraDrawFreehandLineStringMode({
+				minDistance: 0,
+			});
+			const mockConfig = MockModeConfig(freehandMode.mode);
+
+			freehandMode.register(mockConfig);
+			freehandMode.start();
+
+			freehandMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			freehandMode.onMouseMove(MockCursorEvent({ lng: 0.1, lat: 0.1 }));
+
+			const lineString = mockConfig.store
+				.copyAll()
+				.find((feature) => feature.geometry.type === "LineString");
+
+			expect(lineString).toBeDefined();
+			expect(
+				(lineString as GeoJSONStoreFeatures).geometry.coordinates,
+			).toHaveLength(3);
+		});
 	});
 
 	describe("onClick", () => {

--- a/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
+++ b/packages/terra-draw/src/modes/freehand-linestring/freehand-linestring.mode.ts
@@ -11,6 +11,8 @@ import {
 	FinishActions,
 	DashArrayStyling,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 
 import {
 	BaseModeOptions,
@@ -31,13 +33,21 @@ import { ReadFeatureBehavior } from "../read-feature.behavior";
 import { BehaviorConfig } from "../base.behavior";
 import { ClosingPointsBehavior } from "../closing-points.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
+import {
+	isFiniteNonNegativeNumber,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawFreehandLineStringModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type FreehandLineStringStyling = {
 	lineStringWidth: NumericStyling;
@@ -58,8 +68,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawFreehandLineStringModeOptions<
@@ -101,17 +111,17 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 	): void {
 		super.updateOptions(options);
 
-		if (options?.minDistance) {
+		if (isFiniteNonNegativeNumber(options?.minDistance)) {
 			this.minDistance = options.minDistance;
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 	}
@@ -161,7 +171,7 @@ export class TerraDrawFreehandLineStringMode extends TerraDrawBaseDrawMode<Freeh
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/freehand/freehand.mode.ts
+++ b/packages/terra-draw/src/modes/freehand/freehand.mode.ts
@@ -12,6 +12,8 @@ import {
 	DrawInteractions,
 	DrawType,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 
 import {
 	BaseModeOptions,
@@ -30,13 +32,23 @@ import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import { BehaviorConfig } from "../base.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
+import {
+	isBoolean,
+	isDrawInteraction,
+	isFiniteNonNegativeNumber,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawFreehandModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type FreehandPolygonStyling = {
 	fillColor: HexColorStyling;
@@ -58,8 +70,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawFreehandModeOptions<
@@ -109,11 +121,11 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	): void {
 		super.updateOptions(options);
 
-		if (options?.minDistance) {
+		if (isFiniteNonNegativeNumber(options?.minDistance)) {
 			this.minDistance = options.minDistance;
 		}
 
-		if (options?.smoothing !== undefined) {
+		if (isFiniteNonNegativeNumber(options?.smoothing)) {
 			const minimumSmoothing = 0;
 			const maximumSmoothing = 0.999;
 			this.smoothing = Math.min(
@@ -122,29 +134,29 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 			);
 		}
 
-		if (options?.preventPointsNearClose !== undefined) {
+		if (isBoolean(options?.preventPointsNearClose)) {
 			this.preventPointsNearClose = options.preventPointsNearClose;
 		}
 
-		if (options?.autoClose !== undefined) {
+		if (isBoolean(options?.autoClose)) {
 			this.autoClose = options.autoClose;
 		}
 
-		if (options?.autoCloseTimeout) {
+		if (isFiniteNonNegativeNumber(options?.autoCloseTimeout)) {
 			this.autoCloseTimeout = options.autoCloseTimeout;
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.drawInteraction) {
+		if (isDrawInteraction(options?.drawInteraction)) {
 			this.drawInteraction = options.drawInteraction;
 		}
 	}
@@ -338,7 +350,7 @@ export class TerraDrawFreehandMode extends TerraDrawBaseDrawMode<FreehandPolygon
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.spec.ts
@@ -890,6 +890,42 @@ describe("TerraDrawLineStringMode", () => {
 			]);
 		});
 
+		it("does not delete a point when editable is disabled via updateOptions", () => {
+			lineStringMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			lineStringMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 2 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+			lineStringMode.onClick(MockCursorEvent({ lng: 2, lat: 2 }));
+
+			const [lineStringBefore] = store.copyAll();
+			expect(lineStringBefore.geometry.coordinates).toStrictEqual([
+				[0, 0],
+				[1, 1],
+				[2, 2],
+			]);
+
+			lineStringMode.updateOptions({ editable: false });
+			onChange.mockClear();
+
+			lineStringMode.onClick(
+				MockCursorEvent({ lng: 1, lat: 1, button: "right" }),
+			);
+
+			expect(onChange).not.toHaveBeenCalledWith(
+				[expect.any(String)],
+				"update",
+				expect.objectContaining({ target: "geometry" }),
+			);
+
+			const [lineStringAfter] = store.copyAll();
+			expect(lineStringAfter.geometry.coordinates).toStrictEqual([
+				[0, 0],
+				[1, 1],
+				[2, 2],
+			]);
+		});
+
 		describe("with leftClick pointer event set to false", () => {
 			beforeEach(() => {
 				lineStringMode = new TerraDrawLineStringMode({

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -12,6 +12,8 @@ import {
 	FinishActions,
 	DashArrayStyling,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { Feature, LineString, Position } from "geojson";
 import {
 	BaseModeOptions,
@@ -45,13 +47,17 @@ import { ReadFeatureBehavior } from "../read-feature.behavior";
 import { ClosingPointsBehavior } from "../closing-points.behavior";
 import { CoordinatePointBehavior } from "../select/behaviors/coordinate-point.behavior";
 import { UndoRedoBehavior } from "../undo-redo.behavior";
+import { isBoolean, isNonNullObject, isNull } from "../../common/checks";
 
 type TerraDrawLineStringModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" } as const;
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+} as const;
 
 type LineStringStyling = {
 	lineStringWidth: NumericStyling;
@@ -86,10 +92,10 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
-	dragStart: "grabbing",
-	dragEnd: "crosshair",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
+	dragStart: CursorValues.Grabbing,
+	dragEnd: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface InertCoordinates {
@@ -167,25 +173,25 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 			this.finishOnNthCoordinate = Math.floor(options.finishOnNthCoordinate);
 		}
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.snapping) {
+		if (isNonNullObject(options?.snapping)) {
 			this.snapping = options.snapping;
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.insertCoordinates) {
+		if (isNonNullObject(options?.insertCoordinates)) {
 			this.insertCoordinates = options.insertCoordinates;
 		}
 
-		if (options && options.editable) {
+		if (isBoolean(options?.editable)) {
 			this.editable = options.editable;
 		}
 
@@ -701,7 +707,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.spec.ts
@@ -147,6 +147,25 @@ describe("TerraDrawMarkerMode", () => {
 			]);
 		});
 
+		it("can disable editable", () => {
+			const markerMode = new TerraDrawMarkerMode({ editable: true });
+			const mockConfig = MockModeConfig(markerMode.mode);
+
+			markerMode.register(mockConfig);
+			markerMode.start();
+
+			markerMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			markerMode.updateOptions({ editable: false });
+
+			markerMode.onDragStart(MockCursorEvent({ lng: 0, lat: 0 }), jest.fn());
+			markerMode.onDrag(MockCursorEvent({ lng: 0, lat: 1 }), jest.fn());
+			markerMode.onDragEnd(MockCursorEvent({ lng: 0, lat: 1 }), jest.fn());
+
+			expect(mockConfig.store.copyAll()[0].geometry.coordinates).toEqual([
+				0, 0,
+			]);
+		});
+
 		it("does not update mode name if passed", () => {
 			const markerMode = new TerraDrawMarkerMode();
 			markerMode.updateOptions({ modeName: "custom-marker" } as any);

--- a/packages/terra-draw/src/modes/marker/marker.mode.ts
+++ b/packages/terra-draw/src/modes/marker/marker.mode.ts
@@ -10,6 +10,7 @@ import {
 	MARKER_URL_DEFAULT,
 	FinishActions,
 } from "../../common";
+import { CursorValues } from "../../common/cursors";
 import {
 	FeatureId,
 	GeoJSONStoreFeatures,
@@ -28,6 +29,7 @@ import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import { PointSearchBehavior } from "../point-search.behavior";
+import { isBoolean, isNonNullObject } from "../../common/checks";
 
 type MarkerModeStyling = {
 	/** Marker must be a PNG or JPG  */
@@ -43,9 +45,9 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	create: "crosshair",
-	dragStart: "grabbing",
-	dragEnd: "crosshair",
+	create: CursorValues.Crosshair,
+	dragStart: CursorValues.Grabbing,
+	dragEnd: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawMarkerModeOptions<
@@ -81,11 +83,11 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 	): void {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.editable) {
+		if (isBoolean(options?.editable)) {
 			this.editable = options.editable;
 		}
 	}
@@ -100,7 +102,7 @@ export class TerraDrawMarkerMode extends TerraDrawBaseDrawMode<MarkerModeStyling
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/point/point.mode.spec.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.spec.ts
@@ -138,6 +138,25 @@ describe("TerraDrawPointMode", () => {
 				0, 1,
 			]);
 		});
+
+		it("can disable editable", () => {
+			const pointMode = new TerraDrawPointMode({ editable: true });
+			const mockConfig = MockModeConfig(pointMode.mode);
+
+			pointMode.register(mockConfig);
+			pointMode.start();
+
+			pointMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			pointMode.updateOptions({ editable: false });
+
+			pointMode.onDragStart(MockCursorEvent({ lng: 0, lat: 0 }), jest.fn());
+			pointMode.onDrag(MockCursorEvent({ lng: 0, lat: 1 }), jest.fn());
+			pointMode.onDragEnd(MockCursorEvent({ lng: 0, lat: 1 }), jest.fn());
+
+			expect(mockConfig.store.copyAll()[0].geometry.coordinates).toEqual([
+				0, 0,
+			]);
+		});
 	});
 
 	describe("onClick", () => {

--- a/packages/terra-draw/src/modes/point/point.mode.ts
+++ b/packages/terra-draw/src/modes/point/point.mode.ts
@@ -9,6 +9,7 @@ import {
 	Z_INDEX,
 	FinishActions,
 } from "../../common";
+import { CursorValues } from "../../common/cursors";
 import {
 	FeatureId,
 	GeoJSONStoreFeatures,
@@ -27,6 +28,7 @@ import { ClickBoundingBoxBehavior } from "../click-bounding-box.behavior";
 import { PixelDistanceBehavior } from "../pixel-distance.behavior";
 import { PointSearchBehavior } from "../point-search.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
+import { isBoolean, isNonNullObject } from "../../common/checks";
 
 type PointModeStyling = {
 	pointWidth: NumericStyling;
@@ -48,9 +50,9 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	create: "crosshair",
-	dragStart: "grabbing",
-	dragEnd: "crosshair",
+	create: CursorValues.Crosshair,
+	dragStart: CursorValues.Grabbing,
+	dragEnd: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawPointModeOptions<
@@ -86,11 +88,11 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 	): void {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.editable) {
+		if (isBoolean(options?.editable)) {
 			this.editable = options.editable;
 		}
 	}
@@ -105,7 +107,7 @@ export class TerraDrawPointMode extends TerraDrawBaseDrawMode<PointModeStyling> 
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.spec.ts
@@ -190,6 +190,36 @@ describe("TerraDrawPolygonMode", () => {
 			]);
 		});
 
+		it("can disable editable", () => {
+			const polygonMode = new TerraDrawPolygonMode({ editable: true });
+			const mockConfig = MockModeConfig(polygonMode.mode);
+
+			const mockPolygon = MockPolygonSquare();
+			mockConfig.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: mockPolygon.properties as JSONObject,
+				},
+			]);
+
+			polygonMode.register(mockConfig);
+			polygonMode.start();
+			polygonMode.updateOptions({ editable: false });
+
+			polygonMode.onDragStart(MockCursorEvent({ lng: 0, lat: 0 }), jest.fn());
+			polygonMode.onDrag(MockCursorEvent({ lng: -1, lat: -1 }), jest.fn());
+			polygonMode.onDragEnd(MockCursorEvent({ lng: -1, lat: -1 }), jest.fn());
+
+			const [feature] = mockConfig.store.copyAll();
+			expect(feature.geometry.coordinates[0]).toStrictEqual([
+				[0, 0],
+				[0, 1],
+				[1, 1],
+				[1, 0],
+				[0, 0],
+			]);
+		});
+
 		it("can set editable which ignores non polygon mode features", () => {
 			const polygonMode = new TerraDrawPolygonMode();
 			polygonMode.updateOptions({

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -11,6 +11,8 @@ import {
 	Snapping,
 	FinishActions,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { Feature, Polygon, Position } from "geojson";
 import {
 	TerraDrawBaseDrawMode,
@@ -41,13 +43,17 @@ import {
 } from "../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
 import { UndoRedoBehavior } from "../undo-redo.behavior";
+import { isBoolean, isNonNullObject, isNull } from "../../common/checks";
 
 type TerraDrawPolygonModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
 	finish?: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type PolygonStyling = {
 	fillColor: HexColorStyling;
@@ -89,10 +95,10 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
-	dragStart: "grabbing",
-	dragEnd: "crosshair",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
+	dragStart: CursorValues.Grabbing,
+	dragEnd: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawPolygonModeOptions<
@@ -152,30 +158,30 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
 		// null is the case where we want to explicitly turn key bindings off
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.snapping) {
+		if (isNonNullObject(options?.snapping)) {
 			this.snapping = options.snapping;
 		}
 
-		if (options?.editable !== undefined) {
+		if (isBoolean(options?.editable)) {
 			this.editable = options.editable;
 		}
 
-		if (options?.pointerEvents !== undefined) {
+		if (isNonNullObject(options?.pointerEvents)) {
 			this.pointerEvents = options.pointerEvents;
 		}
 
-		if (options?.showCoordinatePoints !== undefined) {
+		if (isBoolean(options?.showCoordinatePoints)) {
 			this.showCoordinatePoints = options.showCoordinatePoints;
 
 			// If we are not showing coordinate points, we need to add them all
@@ -330,7 +336,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	private updateSnappedCoordinate(event: TerraDrawMouseEvent) {

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
@@ -172,6 +172,19 @@ describe("TerraDrawPolyLineMode", () => {
 				[20, 20],
 			]);
 		});
+
+		it("ignores non-object cursors", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			polyLineMode.updateOptions({
+				cursors: "pointer" as unknown as { start?: "pointer" },
+			});
+
+			const mockConfig = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(mockConfig);
+			polyLineMode.start();
+
+			expect(mockConfig.setCursor).toHaveBeenCalledWith("crosshair");
+		});
 	});
 
 	describe("onMouseMove", () => {

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -12,6 +12,8 @@ import {
 	Snapping,
 	DashArrayStyling,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { LineString, Position } from "geojson";
 import {
 	BaseModeOptions,
@@ -36,13 +38,17 @@ import { ValidatePolygonFeature } from "../../validations/polygon.validation";
 import { ClosingPointsBehavior } from "../closing-points.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
+import { isNonNullObject, isNull } from "../../common/checks";
 
 type TerraDrawPolyLineModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" } as const;
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+} as const;
 
 type PolyLineStyling = {
 	lineStringWidth: NumericStyling;
@@ -74,8 +80,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawPolyLineModeOptions<
@@ -116,17 +122,17 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.snapping) {
+		if (isNonNullObject(options?.snapping)) {
 			this.snapping = options.snapping;
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 	}
@@ -171,7 +177,7 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	private finishLine() {

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -13,6 +13,8 @@ import {
 	DrawInteractions,
 	DrawType,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import {
 	FeatureId,
 	GeoJSONStoreFeatures,
@@ -28,14 +30,21 @@ import {
 import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon.validation";
 import { BehaviorConfig } from "../base.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
-import { ReadFeatureBehavior } from "../read-feature.behavior";
+import {
+	isDrawInteraction,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawRectangleModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
 	finish: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type RectanglePolygonStyling = {
 	fillColor: HexColorStyling;
@@ -50,7 +59,7 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
+	start: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawRectangleModeOptions<
@@ -73,7 +82,6 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 	// Behaviors
 	private mutateFeature!: MutateFeatureBehavior;
-	private readFeature!: ReadFeatureBehavior;
 
 	constructor(
 		options?: TerraDrawRectangleModeOptions<RectanglePolygonStyling>,
@@ -89,17 +97,17 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.drawInteraction) {
+		if (isDrawInteraction(options?.drawInteraction)) {
 			this.drawInteraction = options.drawInteraction;
 		}
 	}
@@ -225,7 +233,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */
@@ -403,7 +411,6 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	}
 
 	registerBehaviors(config: BehaviorConfig) {
-		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
 		});

--- a/packages/terra-draw/src/modes/sector/sector.mode.ts
+++ b/packages/terra-draw/src/modes/sector/sector.mode.ts
@@ -10,6 +10,8 @@ import {
 	COMMON_PROPERTIES,
 	FinishActions,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { Polygon, Position } from "geojson";
 import {
 	TerraDrawBaseDrawMode,
@@ -44,13 +46,21 @@ import {
 	Mutations,
 	ReplaceMutation,
 } from "../mutate-feature.behavior";
+import {
+	isFiniteNonNegativeNumber,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawSectorModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
 	finish?: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+} as const;
 
 type SectorPolygonStyling = {
 	fillColor: HexColorStyling;
@@ -66,8 +76,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawSectorModeOptions<
@@ -106,17 +116,20 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 	) {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.arcPoints) {
+		if (
+			isFiniteNonNegativeNumber(options?.arcPoints) &&
+			options.arcPoints > 0
+		) {
 			this.arcPoints = options.arcPoints;
 		}
 	}
@@ -275,7 +288,7 @@ export class TerraDrawSectorMode extends TerraDrawBaseDrawMode<SectorPolygonStyl
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -47,6 +47,14 @@ import { CoordinateSnappingBehavior } from "../coordinate-snapping.behavior";
 import { LineSnappingBehavior } from "../line-snapping.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
+import {
+	isBoolean,
+	isFiniteNonNegativeNumber,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 
 type TerraDrawSelectModeKeyEvents = {
 	deselect: KeyboardEvent["key"] | null;
@@ -56,11 +64,11 @@ type TerraDrawSelectModeKeyEvents = {
 };
 
 const defaultKeyEvents = {
-	deselect: "Escape",
-	delete: "Delete",
+	deselect: KeyboardEventKey.Escape,
+	delete: KeyboardEventKey.Delete,
 	rotate: ["Control", "r"],
 	scale: ["Control", "s"],
-};
+} as Required<TerraDrawSelectModeKeyEvents>;
 
 type ModeFlags = {
 	feature?: {
@@ -138,10 +146,10 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	pointerOver: "move",
-	dragStart: "move",
-	dragEnd: "move",
-	insertMidpoint: "crosshair",
+	pointerOver: CursorValues.Move,
+	dragStart: CursorValues.Move,
+	dragEnd: CursorValues.Move,
+	insertMidpoint: CursorValues.Crosshair,
 } as Required<Cursors>;
 
 interface TerraDrawSelectModeOptions<
@@ -218,7 +226,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 	) {
 		super.updateOptions(options);
 
-		if (options && options.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		} else {
 			this.cursors = defaultCursors;
@@ -226,31 +234,31 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 		// We want to have some defaults, but also allow key bindings
 		// to be explicitly turned off
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = {
 				deselect: null,
 				delete: null,
 				rotate: null,
 				scale: null,
 			};
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.dragEventThrottle !== undefined) {
+		if (isFiniteNonNegativeNumber(options?.dragEventThrottle)) {
 			this.dragEventThrottle = options.dragEventThrottle;
 		}
 
-		if (options?.allowManualDeselection !== undefined) {
+		if (isBoolean(options?.allowManualDeselection)) {
 			this.allowManualDeselection = options.allowManualDeselection;
 		}
 
-		if (options?.allowManualSelection !== undefined) {
+		if (isBoolean(options?.allowManualSelection)) {
 			this.allowManualSelection = options.allowManualSelection;
 		}
 
 		// Flags and Validations
-		if (options?.flags) {
+		if (isNonNullObject(options?.flags)) {
 			this.flags = { ...this.flags, ...options.flags };
 			this.validations = {};
 
@@ -403,7 +411,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 
 	private clearDragTargetAndCursor() {
 		this.dragTarget = { type: "none" };
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	private getSelectedFlags(featureId: FeatureId) {
@@ -918,7 +926,7 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 			return;
 		}
 
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */

--- a/packages/terra-draw/src/modes/sensor/sensor.mode.ts
+++ b/packages/terra-draw/src/modes/sensor/sensor.mode.ts
@@ -10,6 +10,8 @@ import {
 	COMMON_PROPERTIES,
 	FinishActions,
 } from "../../common";
+import { KeyboardEventKey } from "../../common/keys";
+import { CursorValues } from "../../common/cursors";
 import { LineString, Point, Polygon, Position } from "geojson";
 import {
 	TerraDrawBaseDrawMode,
@@ -39,13 +41,21 @@ import { limitPrecision } from "../../geometry/limit-decimal-precision";
 import { BehaviorConfig } from "../base.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
+import {
+	isFiniteNonNegativeNumber,
+	isNonNullObject,
+	isNull,
+} from "../../common/checks";
 
 type TerraDrawSensorModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
 	finish?: KeyboardEvent["key"] | null;
 };
 
-const defaultKeyEvents = { cancel: "Escape", finish: "Enter" };
+const defaultKeyEvents = {
+	cancel: KeyboardEventKey.Escape,
+	finish: KeyboardEventKey.Enter,
+};
 
 type SensorPolygonStyling = {
 	centerPointColor: HexColorStyling;
@@ -67,8 +77,8 @@ interface Cursors {
 }
 
 const defaultCursors = {
-	start: "crosshair",
-	close: "pointer",
+	start: CursorValues.Crosshair,
+	close: CursorValues.Pointer,
 } as Required<Cursors>;
 
 interface TerraDrawSensorModeOptions<
@@ -109,17 +119,20 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 	): void {
 		super.updateOptions(options);
 
-		if (options?.cursors) {
+		if (isNonNullObject(options?.cursors)) {
 			this.cursors = { ...this.cursors, ...options.cursors };
 		}
 
-		if (options?.keyEvents === null) {
+		if (isNull(options?.keyEvents)) {
 			this.keyEvents = { cancel: null, finish: null };
-		} else if (options?.keyEvents) {
+		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
 
-		if (options?.arcPoints) {
+		if (
+			isFiniteNonNegativeNumber(options?.arcPoints) &&
+			options.arcPoints > 0
+		) {
 			this.arcPoints = options.arcPoints;
 		}
 	}
@@ -134,7 +147,7 @@ export class TerraDrawSensorMode extends TerraDrawBaseDrawMode<SensorPolygonStyl
 	stop() {
 		this.cleanUp();
 		this.setStopped();
-		this.setCursor("unset");
+		this.setCursor(CursorValues.Unset);
 	}
 
 	/** @internal */


### PR DESCRIPTION
## Description of Changes

- Ensures that mode options follow basic correct typings. The checks are not exhaustive but should catch the majority of badly formed options.
- Use constant for keyboard keys
- Use constant for cursors

## Link to Issue

https://github.com/JamesLMilner/terra-draw/issues/938

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 