### PR TITLE
chore(terra-draw): remove benchmark from coverage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,7 +23,7 @@ export default {
 	],
 	coveragePathIgnorePatterns: [
 		"<rootDir>/packages/terra-draw/src/benchmark/",
-		"<rootDir>/packages/terra-draw/src/benchmark.ts",
+		"<rootDir>/packages/terra-draw/src/terra-draw.benchmark.ts",
 		"<rootDir>/packages/.*/dist/",
 		"<rootDir>/packages/.*/src/test",
 		"<rootDir>/packages/e2e/",


### PR DESCRIPTION
## Description of Changes

Fixes the path to ignore the benchmark file for coverage

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 