### PR TITLE
fix(terra-draw-google-maps-adapter): cache the map event element for listener removal

### DIFF
--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.spec.ts
@@ -713,6 +713,67 @@ describe("TerraDrawGoogleMapsAdapter", () => {
 			expect(div.removeEventListener).toHaveBeenCalledTimes(9);
 			expect(keyboardDiv.removeEventListener).toHaveBeenCalledTimes(2);
 		});
+
+		it("removes listeners from the element they were registered on", () => {
+			// Google Maps can rebuild its panes, so the lookup can resolve to a different element after registration
+			const registeredOn = {
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+
+			const replacement = {
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+
+			const mapDiv = {
+				id: "map",
+				querySelector: jest
+					.fn()
+					.mockReturnValueOnce(registeredOn)
+					.mockReturnValue(replacement),
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} as unknown as HTMLDivElement;
+
+			const mockMap = createMockGoogleMap({
+				getDiv: jest.fn(() => mapDiv) as any,
+				data: {
+					addListener: jest.fn(() => ({ remove: jest.fn() })),
+					setStyle: jest.fn(),
+				} as any,
+			});
+
+			const adapter = new TerraDrawGoogleMapsAdapter({
+				lib: {
+					OverlayView: jest.fn(() => ({
+						setMap: jest.fn(),
+						getMap: jest.fn(() => ({})),
+					})),
+				} as any,
+				map: mockMap,
+				forwardMapElementEvents: true,
+			});
+
+			adapter.register(MockCallbacks());
+			adapter.unregister();
+
+			const registered = (
+				registeredOn.addEventListener as jest.Mock
+			).mock.calls.map(([event, fn]) => ({ event, fn }));
+			const removed = (
+				registeredOn.removeEventListener as jest.Mock
+			).mock.calls.map(([event, fn]) => ({ event, fn }));
+
+			expect(registered.length).toBeGreaterThan(0);
+			for (const listener of registered) {
+				expect(removed).toContainEqual(listener);
+			}
+			expect(replacement.addEventListener).not.toHaveBeenCalled();
+
+			// The element is released, so the next registration resolves it again
+			expect(adapter.getMapEventElement()).toBe(replacement);
+		});
 	});
 
 	describe("getLngLatFromEvent", () => {

--- a/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
+++ b/packages/terra-draw-google-maps-adapter/src/terra-draw-google-maps-adapter.ts
@@ -45,6 +45,8 @@ export class TerraDrawGoogleMapsAdapter
 	private _lib: typeof google.maps;
 	private _map: google.maps.Map;
 	private _overlay: google.maps.OverlayView | undefined;
+	// Cached so listeners are always removed from the element they were added to
+	private _mapEventElement: HTMLElement | undefined;
 	private _markerClickListener: any | undefined;
 	private _markerMouseMoveListener: ((event: MouseEvent) => void) | undefined;
 	private _pointerCaptureDownListener:
@@ -459,6 +461,7 @@ export class TerraDrawGoogleMapsAdapter
 		}
 		this._overlay = undefined;
 		this._readyCalled = false;
+		this._mapEventElement = undefined;
 
 		if (this._isolatedData && this._data) {
 			this._data.setMap(null);
@@ -524,9 +527,15 @@ export class TerraDrawGoogleMapsAdapter
 			return this._map.getDiv();
 		}
 
-		// TODO: This is a bit hacky, maybe there is a better solution here
-		const selector = 'div[style*="z-index: 3;"]';
-		return this._map.getDiv().querySelector(selector) as HTMLDivElement;
+		if (!this._mapEventElement) {
+			// TODO: This is a bit hacky, maybe there is a better solution here
+			const selector = 'div[style*="z-index: 3;"]';
+			this._mapEventElement = this._map
+				.getDiv()
+				.querySelector(selector) as HTMLElement;
+		}
+
+		return this._mapEventElement;
 	}
 
 	/**


### PR DESCRIPTION
## Description of Changes

`TerraDrawGoogleMapsAdapter.getMapEventElement()` re-ran the `div[style*="z-index: 3;"]` lookup on every call, so the element resolved during `register()` was not guaranteed to be the same object as the one resolved during `unregister()`. When they differ, `removeEventListener()` is a silent no-op and the listeners stay attached to the original element.

This caches the resolved element on the adapter and releases it in `unregister()`:

- `register()` and `unregister()` now operate on the same `EventTarget`, both for the `BaseAdapter` listeners and for the adapter's own `forwardMapElementEvents` listeners.
- The `pointerup` guard in `BaseAdapter` (`if (event.target !== this.getMapEventElement("pointerup")) return;`) becomes stable for the lifetime of a `start()` / `stop()` cycle.
- The cache is cleared at the end of `unregister()`, after `super.unregister()` and the adapter's own `removeEventListener()` calls, so the next `register()` resolves the element again.

`keyup` / `keydown` continue to return `this._map.getDiv()` and are unaffected.

A unit test registers the adapter against one element, makes the lookup resolve to a different element afterwards, and asserts that every listener added to the first element is removed from that same element, and that the cache is released on `unregister()`.

## Link to Issue

Fixes #941

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] There is a associated GitHub issue
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented
