### PR TITLE
fix(terra-draw): fix issues with select mode resizeable 

### DIFF
--- a/packages/terra-draw/src/modes/mutate-feature.behavior.ts
+++ b/packages/terra-draw/src/modes/mutate-feature.behavior.ts
@@ -398,7 +398,7 @@ export class MutateFeatureBehavior extends TerraDrawModeBehavior {
 		propertyMutations?: ValidProperties;
 		context: MutateContext & { correctRightHandRule?: boolean };
 	}): boolean {
-		if (!featureId) {
+		if (featureId === null || featureId === undefined) {
 			return false;
 		}
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -341,6 +341,53 @@ describe("DragCoordinateResizeBehavior", () => {
 				});
 
 				describe("opposite", () => {
+					it("keeps the initial handle axes across drag events", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0, 0],
+								[0, 1],
+								[2, 1],
+								[2, 0],
+								[0, 0],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						const getIndexes = jest.spyOn(
+							dragMaintainedShapeBehavior as unknown as {
+								getIndexesWebMercator: () => unknown;
+							},
+							"getIndexesWebMercator",
+						);
+						getIndexes
+							.mockReturnValueOnce({
+								oppositeBboxIndex: 2,
+								closestBBoxIndex: 6,
+							})
+							.mockReturnValueOnce({
+								oppositeBboxIndex: 5,
+								closestBBoxIndex: 1,
+							});
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"opposite",
+						);
+						const coordinateAfterFirstDrag =
+							readFeatureBehavior.getGeometry<Polygon>(id).coordinates[0][0];
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -2, lat: -2 }),
+							"opposite",
+						);
+						const coordinateAfterSecondDrag =
+							readFeatureBehavior.getGeometry<Polygon>(id).coordinates[0][0];
+
+						expect(coordinateAfterSecondDrag[0]).not.toBe(
+							coordinateAfterFirstDrag[0],
+						);
+					});
+
 					it("keeps the opposite reference point fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
@@ -487,6 +534,22 @@ describe("DragCoordinateResizeBehavior", () => {
 				});
 
 				describe("center-fixed", () => {
+					it("does not update the Polygon for an invalid drag direction", () => {
+						const id = createStorePolygon(config);
+
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						jest.spyOn(config.store, "updateGeometry");
+
+						const didResize = dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: 1, lat: 1 }),
+							"center-fixed",
+						);
+
+						expect(didResize).toBe(false);
+						expect(config.store.updateGeometry).not.toHaveBeenCalled();
+					});
+
 					it("keeps the Polygon center fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
@@ -551,7 +614,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.startDragging(id, 0);
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: 1, lat: 0 }),
 							"center-fixed",
 						);
 
@@ -612,7 +675,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						dragMaintainedShapeBehavior.startDragging(id, 0);
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: 1, lat: 0 }),
 							"opposite-fixed",
 						);
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -1,4 +1,4 @@
-import { Position } from "geojson";
+import { Feature, Polygon, Position } from "geojson";
 import {
 	createStorePoint,
 	createStorePolygon,
@@ -13,6 +13,7 @@ import { MockCursorEvent } from "../../../test/mock-cursor-event";
 import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MutateFeatureBehavior } from "../../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../../read-feature.behavior";
+import { webMercatorCentroid } from "../../../geometry/web-mercator-centroid";
 
 describe("DragCoordinateResizeBehavior", () => {
 	const createLineString = (
@@ -203,7 +204,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: -1, lat: -1 }),
 							"center",
 						);
 
@@ -220,15 +221,79 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
-							"center",
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"center-fixed",
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 					});
+
+					it("should not update if the Polygon centroid is not finite", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0, 0],
+								[1, 0],
+								[2, 0],
+								[0, 0],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						jest.spyOn(config.store, "updateGeometry");
+
+						const didResize = dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: 0, lat: 0 }),
+							"center",
+						);
+
+						expect(didResize).toBe(false);
+						expect(config.store.updateGeometry).not.toHaveBeenCalled();
+					});
 				});
 
 				describe("center", () => {
+					it("keeps the Polygon center fixed across drag events", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0.1234567891, 0.1234567891],
+								[0.1234567891, 1.2345678912],
+								[2.3456789123, 1.2345678912],
+								[2.3456789123, 0.1234567891],
+								[0.1234567891, 0.1234567891],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						const getPolygonCenter = () =>
+							webMercatorCentroid({
+								type: "Feature",
+								id,
+								geometry: readFeatureBehavior.getGeometry<Polygon>(id),
+								properties: {},
+							} as Feature<Polygon>);
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"center",
+						);
+						const centerAfterFirstDrag = getPolygonCenter();
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -2, lat: -2 }),
+							"center",
+						);
+						const centerAfterSecondDrag = getPolygonCenter();
+
+						expect(centerAfterSecondDrag.x).toBeCloseTo(
+							centerAfterFirstDrag.x,
+							3,
+						);
+						expect(centerAfterSecondDrag.y).toBeCloseTo(
+							centerAfterFirstDrag.y,
+							3,
+						);
+					});
+
 					it("updates the Polygon coordinate if within pointer distance", () => {
 						const id = createStorePolygon(config);
 
@@ -237,21 +302,37 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: -1, lat: -1 }),
 							"center",
 						);
 
 						expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
 					});
 
+					it("does not update the Polygon for an invalid drag direction", () => {
+						const id = createStorePolygon(config);
+
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						jest.spyOn(config.store, "updateGeometry");
+
+						const didResize = dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: 1, lat: 1 }),
+							"center",
+						);
+
+						expect(didResize).toBe(false);
+						expect(config.store.updateGeometry).not.toHaveBeenCalled();
+					});
+
 					it("updates the LineString coordinate if within pointer distance", () => {
 						const id = createLineString(config);
 						jest.spyOn(config.store, "updateGeometry");
 
-						dragMaintainedShapeBehavior.startDragging(id, 0);
+						dragMaintainedShapeBehavior.startDragging(id, 1);
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: -1, lat: 2 }),
 							"center",
 						);
 
@@ -260,6 +341,36 @@ describe("DragCoordinateResizeBehavior", () => {
 				});
 
 				describe("opposite", () => {
+					it("keeps the opposite reference point fixed across drag events", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0.1234567891, 0.1234567891],
+								[0.1234567891, 1.2345678912],
+								[2.3456789123, 1.2345678912],
+								[2.3456789123, 0.1234567891],
+								[0.1234567891, 0.1234567891],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						const getReferencePoint = () =>
+							readFeatureBehavior.getGeometry<Polygon>(id).coordinates[0][2];
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"opposite",
+						);
+						const referenceAfterFirstDrag = getReferencePoint();
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -2, lat: -2 }),
+							"opposite",
+						);
+						const referenceAfterSecondDrag = getReferencePoint();
+
+						expect(referenceAfterSecondDrag).toEqual(referenceAfterFirstDrag);
+					});
+
 					it("updates the Polygon coordinate if within pointer distance", () => {
 						const id = createStorePolygon(config);
 
@@ -268,7 +379,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: -1, lat: -1 }),
 							"opposite",
 						);
 
@@ -364,10 +475,10 @@ describe("DragCoordinateResizeBehavior", () => {
 						const id = createLineString(config);
 						jest.spyOn(config.store, "updateGeometry");
 
-						dragMaintainedShapeBehavior.startDragging(id, 0);
+						dragMaintainedShapeBehavior.startDragging(id, 1);
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: 0, lat: 0 }),
+							MockCursorEvent({ lng: -1, lat: 2 }),
 							"opposite",
 						);
 
@@ -376,6 +487,48 @@ describe("DragCoordinateResizeBehavior", () => {
 				});
 
 				describe("center-fixed", () => {
+					it("keeps the Polygon center fixed across drag events", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0.1234567891, 0.1234567891],
+								[0.1234567891, 1.2345678912],
+								[2.3456789123, 1.2345678912],
+								[2.3456789123, 0.1234567891],
+								[0.1234567891, 0.1234567891],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						const getPolygonCenter = () =>
+							webMercatorCentroid({
+								type: "Feature",
+								id,
+								geometry: readFeatureBehavior.getGeometry<Polygon>(id),
+								properties: {},
+							} as Feature<Polygon>);
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"center-fixed",
+						);
+						const centerAfterFirstDrag = getPolygonCenter();
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -2, lat: -2 }),
+							"center-fixed",
+						);
+						const centerAfterSecondDrag = getPolygonCenter();
+
+						expect(centerAfterSecondDrag.x).toBeCloseTo(
+							centerAfterFirstDrag.x,
+							3,
+						);
+						expect(centerAfterSecondDrag.y).toBeCloseTo(
+							centerAfterFirstDrag.y,
+							3,
+						);
+					});
+
 					it("updates the Polygon coordinate if within pointer distance", () => {
 						const id = createStorePolygon(config);
 
@@ -407,6 +560,36 @@ describe("DragCoordinateResizeBehavior", () => {
 				});
 
 				describe("opposite-fixed", () => {
+					it("keeps the opposite reference point fixed across drag events", () => {
+						const id = createStorePolygon(config, [
+							[
+								[0.1234567891, 0.1234567891],
+								[0.1234567891, 1.2345678912],
+								[2.3456789123, 1.2345678912],
+								[2.3456789123, 0.1234567891],
+								[0.1234567891, 0.1234567891],
+							],
+						]);
+						dragMaintainedShapeBehavior.startDragging(id, 0);
+
+						const getReferencePoint = () =>
+							readFeatureBehavior.getGeometry<Polygon>(id).coordinates[0][2];
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -1, lat: -1 }),
+							"opposite-fixed",
+						);
+						const referenceAfterFirstDrag = getReferencePoint();
+
+						dragMaintainedShapeBehavior.drag(
+							MockCursorEvent({ lng: -2, lat: -2 }),
+							"opposite-fixed",
+						);
+						const referenceAfterSecondDrag = getReferencePoint();
+
+						expect(referenceAfterSecondDrag).toEqual(referenceAfterFirstDrag);
+					});
+
 					it("updates the Polygon coordinate if within pointer distance", () => {
 						const id = createStorePolygon(config);
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -204,7 +204,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: -1, lat: -1 }),
+							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center",
 						);
 
@@ -221,7 +221,7 @@ describe("DragCoordinateResizeBehavior", () => {
 						jest.spyOn(config.store, "updateGeometry");
 
 						dragMaintainedShapeBehavior.drag(
-							MockCursorEvent({ lng: -1, lat: -1 }),
+							MockCursorEvent({ lng: 0, lat: 0 }),
 							"center-fixed",
 						);
 
@@ -255,11 +255,11 @@ describe("DragCoordinateResizeBehavior", () => {
 					it("keeps the Polygon center fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
-								[0.1234567891, 0.1234567891],
-								[0.1234567891, 1.2345678912],
-								[2.3456789123, 1.2345678912],
-								[2.3456789123, 0.1234567891],
-								[0.1234567891, 0.1234567891],
+								[0, 0],
+								[0, 1],
+								[2, 1],
+								[2, 0],
+								[0, 0],
 							],
 						]);
 						dragMaintainedShapeBehavior.startDragging(id, 0);
@@ -344,11 +344,11 @@ describe("DragCoordinateResizeBehavior", () => {
 					it("keeps the opposite reference point fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
-								[0.1234567891, 0.1234567891],
-								[0.1234567891, 1.2345678912],
-								[2.3456789123, 1.2345678912],
-								[2.3456789123, 0.1234567891],
-								[0.1234567891, 0.1234567891],
+								[0, 0],
+								[0, 1],
+								[2, 1],
+								[2, 0],
+								[0, 0],
 							],
 						]);
 						dragMaintainedShapeBehavior.startDragging(id, 0);
@@ -490,11 +490,11 @@ describe("DragCoordinateResizeBehavior", () => {
 					it("keeps the Polygon center fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
-								[0.1234567891, 0.1234567891],
-								[0.1234567891, 1.2345678912],
-								[2.3456789123, 1.2345678912],
-								[2.3456789123, 0.1234567891],
-								[0.1234567891, 0.1234567891],
+								[0, 0],
+								[0, 1],
+								[2, 1],
+								[2, 0],
+								[0, 0],
 							],
 						]);
 						dragMaintainedShapeBehavior.startDragging(id, 0);
@@ -563,11 +563,11 @@ describe("DragCoordinateResizeBehavior", () => {
 					it("keeps the opposite reference point fixed across drag events", () => {
 						const id = createStorePolygon(config, [
 							[
-								[0.1234567891, 0.1234567891],
-								[0.1234567891, 1.2345678912],
-								[2.3456789123, 1.2345678912],
-								[2.3456789123, 0.1234567891],
-								[0.1234567891, 0.1234567891],
+								[0, 0],
+								[0, 1],
+								[2, 1],
+								[2, 0],
+								[0, 0],
 							],
 						]);
 						dragMaintainedShapeBehavior.startDragging(id, 0);

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.spec.ts
@@ -170,6 +170,39 @@ describe("DragCoordinateResizeBehavior", () => {
 			});
 
 			describe("drag", () => {
+				it("resizes a feature with numeric id zero", () => {
+					config.store.load([
+						{
+							type: "Feature",
+							id: 0,
+							geometry: {
+								type: "Polygon",
+								coordinates: [
+									[
+										[0, 0],
+										[0, 1],
+										[1, 1],
+										[1, 0],
+										[0, 0],
+									],
+								],
+							},
+							properties: {},
+						},
+					]);
+					dragMaintainedShapeBehavior.startDragging(0, 0);
+
+					jest.spyOn(config.store, "updateGeometry");
+
+					const didResize = dragMaintainedShapeBehavior.drag(
+						MockCursorEvent({ lng: -1, lat: -1 }),
+						"center",
+					);
+
+					expect(didResize).toBe(true);
+					expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
+				});
+
 				it("returns early if nothing is being dragged", () => {
 					jest.spyOn(config.store, "updateGeometry");
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -64,6 +64,9 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		index: -1,
 	};
 
+	private centerOrigin: CartesianPoint | null = null;
+	private oppositeOrigin: CartesianPoint | null = null;
+
 	// This map provides the oppsite corner of the bbox
 	// to the index of the coordinate provided
 	//   0    1    2
@@ -217,11 +220,17 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const { feature, boundingBox, updatedCoords, selectedCoordinate } =
 			featureData;
 
-		const webMercatorOrigin = webMercatorCentroid(feature);
+		const webMercatorOrigin = this.centerOrigin ?? webMercatorCentroid(feature);
 
-		if (!webMercatorOrigin) {
+		if (
+			!webMercatorOrigin ||
+			!Number.isFinite(webMercatorOrigin.x) ||
+			!Number.isFinite(webMercatorOrigin.y)
+		) {
 			return null;
 		}
+
+		this.centerOrigin = webMercatorOrigin;
 
 		const webMercatorSelected = lngLatToWebMercatorXY(
 			selectedCoordinate[0],
@@ -235,15 +244,13 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
-		this.scaleWebMercator({
+		return this.scaleWebMercator({
 			closestBBoxIndex,
 			updatedCoords,
 			webMercatorCursor,
 			webMercatorSelected,
 			webMercatorOrigin,
 		});
-
-		return updatedCoords;
 	}
 
 	private centerFixedWebMercatorDrag(event: TerraDrawMouseEvent) {
@@ -254,11 +261,17 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		const { feature, boundingBox, updatedCoords, selectedCoordinate } =
 			featureData;
 
-		const webMercatorOrigin = webMercatorCentroid(feature);
+		const webMercatorOrigin = this.centerOrigin ?? webMercatorCentroid(feature);
 
-		if (!webMercatorOrigin) {
+		if (
+			!webMercatorOrigin ||
+			!Number.isFinite(webMercatorOrigin.x) ||
+			!Number.isFinite(webMercatorOrigin.y)
+		) {
 			return null;
 		}
+
+		this.centerOrigin = webMercatorOrigin;
 
 		const webMercatorSelected = lngLatToWebMercatorXY(
 			selectedCoordinate[0],
@@ -272,7 +285,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
-		this.scaleFixedWebMercator({
+		const scaledCoords = this.scaleFixedWebMercator({
 			closestBBoxIndex,
 			updatedCoords,
 			webMercatorCursor,
@@ -280,7 +293,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorOrigin,
 		});
 
-		return updatedCoords;
+		return scaledCoords;
 	}
 
 	private scaleFixedWebMercator({
@@ -306,14 +319,18 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		);
 
 		if (!valid) {
-			return null;
+			return updatedCoords;
 		}
 
 		let scale =
 			cartesianDistance(webMercatorOrigin, webMercatorCursor) /
 			cartesianDistance(webMercatorOrigin, webMercatorSelected);
 
-		if (scale < 0) {
+		if (!Number.isFinite(scale)) {
+			return null;
+		}
+
+		if (scale < this.minimumScale) {
 			scale = this.minimumScale;
 		}
 
@@ -324,14 +341,6 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			xScale: scale,
 			yScale: scale,
 		});
-
-		// this.performWebMercatorScale(
-		// 	updatedCoords,
-		// 	webMercatorOrigin.x,
-		// 	webMercatorOrigin.y,
-		// 	scale,
-		// 	scale,
-		// );
 
 		return updatedCoords;
 	}
@@ -354,13 +363,22 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorSelected,
 		);
 
-		const webMercatorOrigin = {
+		const webMercatorOrigin = this.oppositeOrigin ?? {
 			x: boundingBox[oppositeBboxIndex][0],
 			y: boundingBox[oppositeBboxIndex][1],
 		};
+
+		if (
+			!Number.isFinite(webMercatorOrigin.x) ||
+			!Number.isFinite(webMercatorOrigin.y)
+		) {
+			return null;
+		}
+
+		this.oppositeOrigin = webMercatorOrigin;
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
-		this.scaleFixedWebMercator({
+		const scaledCoords = this.scaleFixedWebMercator({
 			closestBBoxIndex,
 			updatedCoords,
 			webMercatorCursor,
@@ -368,7 +386,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorOrigin,
 		});
 
-		return updatedCoords;
+		return scaledCoords;
 	}
 
 	private oppositeWebMercatorDrag(event: TerraDrawMouseEvent) {
@@ -389,21 +407,28 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			webMercatorSelected,
 		);
 
-		const webMercatorOrigin = {
+		const webMercatorOrigin = this.oppositeOrigin ?? {
 			x: boundingBox[oppositeBboxIndex][0],
 			y: boundingBox[oppositeBboxIndex][1],
 		};
+
+		if (
+			!Number.isFinite(webMercatorOrigin.x) ||
+			!Number.isFinite(webMercatorOrigin.y)
+		) {
+			return null;
+		}
+
+		this.oppositeOrigin = webMercatorOrigin;
 		const webMercatorCursor = lngLatToWebMercatorXY(event.lng, event.lat);
 
-		this.scaleWebMercator({
+		return this.scaleWebMercator({
 			closestBBoxIndex,
 			updatedCoords,
 			webMercatorCursor,
 			webMercatorSelected,
 			webMercatorOrigin,
 		});
-
-		return updatedCoords;
 	}
 
 	private scaleWebMercator({
@@ -505,8 +530,8 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	}
 
 	private validateScale(xScale: number, yScale: number) {
-		const validX = !isNaN(xScale) && yScale < Number.MAX_SAFE_INTEGER;
-		const validY = !isNaN(yScale) && yScale < Number.MAX_SAFE_INTEGER;
+		const validX = Number.isFinite(xScale) && xScale < Number.MAX_SAFE_INTEGER;
+		const validY = Number.isFinite(yScale) && yScale < Number.MAX_SAFE_INTEGER;
 
 		return validX && validY;
 	}
@@ -650,6 +675,8 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			id,
 			index,
 		};
+		this.centerOrigin = null;
+		this.oppositeOrigin = null;
 	}
 
 	/**
@@ -661,6 +688,8 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			id: null,
 			index: -1,
 		};
+		this.centerOrigin = null;
+		this.oppositeOrigin = null;
 	}
 
 	/**

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -193,7 +193,10 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 	}
 
 	private getSelectedFeatureDataWebMercator() {
-		if (!this.draggedCoordinate.id || this.draggedCoordinate.index === -1) {
+		if (
+			this.draggedCoordinate.id === null ||
+			this.draggedCoordinate.index === -1
+		) {
 			return null;
 		}
 
@@ -731,7 +734,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		event: TerraDrawMouseEvent,
 		resizeOption: ResizeOptions,
 	): boolean {
-		if (!this.draggedCoordinate.id) {
+		if (this.draggedCoordinate.id === null) {
 			return false;
 		}
 

--- a/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/drag-coordinate-resize.behavior.ts
@@ -66,6 +66,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 
 	private centerOrigin: CartesianPoint | null = null;
 	private oppositeOrigin: CartesianPoint | null = null;
+	private oppositeClosestBBoxIndex: BoundingBoxIndex | null = null;
 
 	// This map provides the oppsite corner of the bbox
 	// to the index of the coordinate provided
@@ -319,7 +320,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		);
 
 		if (!valid) {
-			return updatedCoords;
+			return null;
 		}
 
 		let scale =
@@ -358,14 +359,17 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			selectedCoordinate[1],
 		);
 
-		const { oppositeBboxIndex, closestBBoxIndex } = this.getIndexesWebMercator(
+		const indexes = this.getIndexesWebMercator(
 			boundingBox,
 			webMercatorSelected,
 		);
+		const closestBBoxIndex =
+			this.oppositeClosestBBoxIndex ?? indexes.closestBBoxIndex;
+		this.oppositeClosestBBoxIndex = closestBBoxIndex;
 
 		const webMercatorOrigin = this.oppositeOrigin ?? {
-			x: boundingBox[oppositeBboxIndex][0],
-			y: boundingBox[oppositeBboxIndex][1],
+			x: boundingBox[indexes.oppositeBboxIndex][0],
+			y: boundingBox[indexes.oppositeBboxIndex][1],
 		};
 
 		if (
@@ -402,14 +406,17 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 			selectedCoordinate[1],
 		);
 
-		const { oppositeBboxIndex, closestBBoxIndex } = this.getIndexesWebMercator(
+		const indexes = this.getIndexesWebMercator(
 			boundingBox,
 			webMercatorSelected,
 		);
+		const closestBBoxIndex =
+			this.oppositeClosestBBoxIndex ?? indexes.closestBBoxIndex;
+		this.oppositeClosestBBoxIndex = closestBBoxIndex;
 
 		const webMercatorOrigin = this.oppositeOrigin ?? {
-			x: boundingBox[oppositeBboxIndex][0],
-			y: boundingBox[oppositeBboxIndex][1],
+			x: boundingBox[indexes.oppositeBboxIndex][0],
+			y: boundingBox[indexes.oppositeBboxIndex][1],
 		};
 
 		if (
@@ -677,6 +684,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		};
 		this.centerOrigin = null;
 		this.oppositeOrigin = null;
+		this.oppositeClosestBBoxIndex = null;
 	}
 
 	/**
@@ -690,6 +698,7 @@ export class DragCoordinateResizeBehavior extends TerraDrawModeBehavior {
 		};
 		this.centerOrigin = null;
 		this.oppositeOrigin = null;
+		this.oppositeClosestBBoxIndex = null;
 	}
 
 	/**

--- a/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/scale-feature.behavior.spec.ts
@@ -110,10 +110,23 @@ describe("ScaleFeatureBehavior", () => {
 			});
 
 			it("scales the LineString", () => {
-				const id = createStoreLineString(config);
+				const originalCoordinates = [
+					[0, 0],
+					[1, 1],
+				];
+				const id = createStoreLineString(config, [...originalCoordinates]);
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 1.001, lat: 1.001 }),
+					id,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
+
+				const [updatedFeature] = (config.store.updateGeometry as jest.Mock).mock
+					.calls[0][0];
+				expect(updatedFeature.geometry.coordinates).not.toEqual(
+					originalCoordinates,
+				);
 			});
 
 			it("scales the Polygon", () => {
@@ -126,49 +139,37 @@ describe("ScaleFeatureBehavior", () => {
 
 		describe("reset", () => {
 			it("can be called to reset the behaviors state", () => {
-				const id = createStoreLineString(config);
+				const id = createStoreLineString(config, [
+					[0, 0],
+					[1, 1],
+				]);
 				const id2 = createStoreLineString(
 					config,
 					[
 						[10, 10],
-						[10, 11],
+						[11, 11],
 					],
 					true,
 				);
 
 				jest.spyOn(config.store, "updateGeometry");
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 0, lat: 0 }), id);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 1.001, lat: 1.001 }),
+					id,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(1);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[0, 0],
-								[0, 1],
-							],
-							type: "LineString",
-						},
-						id: id,
-					},
-				]);
 
 				scaleFeatureBehavior.reset();
 
-				scaleFeatureBehavior.scale(MockCursorEvent({ lng: 10, lat: 10 }), id2);
+				scaleFeatureBehavior.scale(
+					MockCursorEvent({ lng: 11.001, lat: 11.001 }),
+					id2,
+				);
 				expect(config.store.updateGeometry).toHaveBeenCalledTimes(2);
-				expect(config.store.updateGeometry).toHaveBeenCalledWith([
-					{
-						geometry: {
-							coordinates: [
-								[10, 10],
-								[10, 11],
-							],
-							type: "LineString",
-						},
-						id: id2,
-					},
-				]);
+				expect(config.store.updateGeometry).toHaveBeenLastCalledWith(
+					expect.arrayContaining([expect.objectContaining({ id: id2 })]),
+				);
 			});
 		});
 	});


### PR DESCRIPTION
## Description of Changes

Resizeable behaviour was buggy in various ways, partially due to recalculating the reference points across drag events which caused the feature to be unstable. There was also various opportunities for unsafe values to propagate which caused unpredictable behavours.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 