### PR TITLE
chore(terra-draw): fix type error when running tests

### DIFF
--- a/packages/terra-draw/src/test/test-adapter.ts
+++ b/packages/terra-draw/src/test/test-adapter.ts
@@ -53,16 +53,7 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 	public unproject(x: number, y: number): ReturnType<Unproject> {
 		return { lng: x, lat: y };
 	}
-	public setCursor(
-		_:
-			| "move"
-			| "unset"
-			| "grab"
-			| "grabbing"
-			| "crosshair"
-			| "pointer"
-			| "wait",
-	): ReturnType<SetCursor> {
+	public setCursor(_: TerraDrawExtend.Cursor): ReturnType<SetCursor> {
 		// pass
 	}
 	public getLngLatFromEvent(


### PR DESCRIPTION
## Description of Changes

Fixes the following error:

(node:62004) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/jamesmilner/Code/terra-draw/jest.config.ts is not specified and it doesn't parse as CommonJS. Reparsing as ES module because module syntax was detected. This incurs a performance overhead. To eliminate this warning, add "type": "module" to /Users/user/Code/terra-draw/package.json.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 