### PR TITLE
fix(terra-draw): use the correct projection on initial ellipse creation

### DIFF
--- a/packages/terra-draw/src/modes/ellipse/ellipse.mode.spec.ts
+++ b/packages/terra-draw/src/modes/ellipse/ellipse.mode.spec.ts
@@ -487,9 +487,9 @@ describe("TerraDrawEllipseMode", () => {
 					const features = store.copyAll();
 					expect(features.length).toBe(1);
 
-					// beginDrawing creates the initial ellipse with the helper default of 64 steps.
+					// The starting geometry is created with the segments option
 					expect((features[0].geometry as Polygon).coordinates[0].length).toBe(
-						65,
+						8,
 					);
 
 					expect(onFinish).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/ellipse/ellipse.mode.spec.ts
+++ b/packages/terra-draw/src/modes/ellipse/ellipse.mode.spec.ts
@@ -489,7 +489,7 @@ describe("TerraDrawEllipseMode", () => {
 
 					// The starting geometry is created with the segments option
 					expect((features[0].geometry as Polygon).coordinates[0].length).toBe(
-						8,
+						9,
 					);
 
 					expect(onFinish).toHaveBeenCalledTimes(1);

--- a/packages/terra-draw/src/modes/ellipse/ellipse.mode.ts
+++ b/packages/terra-draw/src/modes/ellipse/ellipse.mode.ts
@@ -161,12 +161,26 @@ export class TerraDrawEllipseMode extends TerraDrawBaseDrawMode<EllipsePolygonSt
 		this.center = [event.lng, event.lat];
 		this.endPosition = [event.lng, event.lat];
 
-		const startingEllipse = ellipse({
-			center: this.center,
-			xRadiusKilometers: this.startingRadiusKilometers,
-			yRadiusKilometers: this.startingRadiusKilometers,
-			coordinatePrecision: this.coordinatePrecision,
-		});
+		let startingEllipse: Feature<Polygon> | undefined;
+		if (this.projection === "globe") {
+			startingEllipse = ellipse({
+				steps: this.segments,
+				center: this.center,
+				xRadiusKilometers: this.startingRadiusKilometers,
+				yRadiusKilometers: this.startingRadiusKilometers,
+				coordinatePrecision: this.coordinatePrecision,
+			});
+		} else if (this.projection === "web-mercator") {
+			startingEllipse = ellipseWebMercator({
+				steps: this.segments,
+				center: this.center,
+				xRadiusKilometers: this.startingRadiusKilometers,
+				yRadiusKilometers: this.startingRadiusKilometers,
+				coordinatePrecision: this.coordinatePrecision,
+			});
+		} else {
+			throw new Error(`Unsupported projection: ${this.projection}`);
+		}
 
 		const created = this.mutateFeature.createPolygon({
 			coordinates: startingEllipse.geometry.coordinates[0],

--- a/packages/terra-draw/src/test/mock-behavior-config.ts
+++ b/packages/terra-draw/src/test/mock-behavior-config.ts
@@ -1,9 +1,10 @@
+import { Projection } from "../common";
 import { BehaviorConfig } from "../modes/base.behavior";
 import { GeoJSONStore } from "../store/store";
 
 export const MockBehaviorConfig = (
 	mode: string,
-	projection?: "web-mercator" | "globe",
+	projection?: Projection,
 	coordinatePrecision: number = 9,
 ) =>
 	({


### PR DESCRIPTION
## Description of Changes

Ensure the correct projection is used on the starting point

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 