### PR TITLE
feat(terra-draw): add more mode support for showCoordinatePoints

### DIFF
--- a/guides/4.MODES.md
+++ b/guides/4.MODES.md
@@ -801,7 +801,7 @@ styleFeature(feature: GeoJSONStoreFeatures): TerraDrawAdapterStyling {
 
 ## Rendering Coordinate Points
 
-Both `TerraDrawLineStringMode` and `TerraDrawPolygonMode` support rendering *coordinate points* (small point features rendered at each vertex of the geometry).
+`TerraDrawLineStringMode`, `TerraDrawPolyLineMode`, `TerraDrawPolygonMode`, `TerraDrawRectangleMode`, and `TerraDrawAngledRectangleMode` support rendering *coordinate points* (small point features rendered at each vertex of the geometry).
 
 This is controlled by the `showCoordinatePoints` option.
 
@@ -834,6 +834,26 @@ draw.start();
 draw.setMode("linestring");
 ```
 
+### PolyLine mode
+
+Enable coordinate points:
+
+```typescript
+import { TerraDraw, TerraDrawPolyLineMode } from "terra-draw";
+
+const draw = new TerraDraw({
+  adapter,
+  modes: [
+    new TerraDrawPolyLineMode({
+      showCoordinatePoints: true,
+    }),
+  ],
+});
+
+draw.start();
+draw.setMode("polyline");
+```
+
 ### Polygon mode
 
 Enable coordinate points:
@@ -852,6 +872,46 @@ const draw = new TerraDraw({
 
 draw.start();
 draw.setMode("polygon");
+```
+
+### Rectangle mode
+
+Enable coordinate points:
+
+```typescript
+import { TerraDraw, TerraDrawRectangleMode } from "terra-draw";
+
+const draw = new TerraDraw({
+  adapter,
+  modes: [
+    new TerraDrawRectangleMode({
+      showCoordinatePoints: true,
+    }),
+  ],
+});
+
+draw.start();
+draw.setMode("rectangle");
+```
+
+### Angled Rectangle mode
+
+Enable coordinate points:
+
+```typescript
+import { TerraDraw, TerraDrawAngledRectangleMode } from "terra-draw";
+
+const draw = new TerraDraw({
+  adapter,
+  modes: [
+    new TerraDrawAngledRectangleMode({
+      showCoordinatePoints: true,
+    }),
+  ],
+});
+
+draw.start();
+draw.setMode("angled-rectangle");
 ```
 
 ### Toggling at runtime

--- a/guides/5.STYLING.md
+++ b/guides/5.STYLING.md
@@ -144,6 +144,12 @@ The `TerraDrawRectangleMode` is styled using the following properties:
 | `outlineOpacity` | Number (0-1) | `0.7`       | The outline opacity of the rectangle |
 | `outlineWidth` | Integer      | `2`           | The outline width of the rectangle   |
 | `fillOpacity`  | Number (0-1) | `0.9`         | The fill opacity of the rectangle    |
+| `coordinatePointWidth` | Integer | `5` | The width of coordinate points |
+| `coordinatePointColor` | Hex Color | `#00FFFF` | The color of coordinate points |
+| `coordinatePointOpacity` | Number (0-1) | `1` | The opacity of coordinate points |
+| `coordinatePointOutlineWidth` | Integer | `2` | The outline width of coordinate points |
+| `coordinatePointOutlineColor` | Hex Color | `#FFFFFF` | The outline color of coordinate points |
+| `coordinatePointOutlineOpacity` | Number (0-1) | `1` | The outline opacity of coordinate points |
 
 
 ### Angled Rectangle
@@ -157,6 +163,12 @@ The `TerraDrawAngledRectangleMode` is styled using the following properties:
 | `outlineOpacity` | Number (0-1) | `0.7`       | The outline opacity of the rectangle |
 | `outlineWidth` | Integer      | `2`           | The outline width of the rectangle   |
 | `fillOpacity`  | Number (0-1) | `0.9`         | The fill opacity of the rectangle    |
+| `coordinatePointWidth` | Integer | `5` | The width of coordinate points |
+| `coordinatePointColor` | Hex Color | `#00FFFF` | The color of coordinate points |
+| `coordinatePointOpacity` | Number (0-1) | `1` | The opacity of coordinate points |
+| `coordinatePointOutlineWidth` | Integer | `2` | The outline width of coordinate points |
+| `coordinatePointOutlineColor` | Hex Color | `#FFFFFF` | The outline color of coordinate points |
+| `coordinatePointOutlineOpacity` | Number (0-1) | `1` | The outline opacity of coordinate points |
 
 ### Sector
 
@@ -214,6 +226,12 @@ The `TerraDrawPolyLineMode` is styled using the following properties:
 | `snappingPointOutlineColor`   | Hex Color    | `#FFFFFF`     | The outline color of the snapping guidance point.           |
 | `snappingPointOutlineOpacity` | Number (0-1) | `1`           | The outline opacity of the snapping guidance point.         |
 | `snappingPointOutlineWidth`   | Integer      | `1`           | The outline width of the snapping guidance point.           |
+| `coordinatePointColor`        | Hex Color    | `#00FFFF`     | The fill color of coordinate points.                        |
+| `coordinatePointOpacity`      | Number (0-1) | `1`           | The fill opacity of coordinate points.                      |
+| `coordinatePointWidth`        | Integer      | `5`           | The width of coordinate points.                             |
+| `coordinatePointOutlineColor` | Hex Color    | `#FFFFFF`     | The outline color of coordinate points.                     |
+| `coordinatePointOutlineOpacity` | Number (0-1) | `1`         | The outline opacity of coordinate points.                   |
+| `coordinatePointOutlineWidth` | Integer      | `2`           | The outline width of coordinate points.                     |
 
 ## Dynamically Changing Styling
 

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.spec.ts
@@ -51,6 +51,20 @@ describe("TerraDrawAngledRectangleMode", () => {
 			});
 			expect(angledRectangleMode.mode).toBe("custom");
 		});
+
+		it("constructs with coordinate point options", () => {
+			new TerraDrawAngledRectangleMode({
+				showCoordinatePoints: true,
+				styles: {
+					coordinatePointWidth: 6,
+					coordinatePointColor: "#ffffff",
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineColor: "#000000",
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+		});
 	});
 
 	describe("lifecycle", () => {
@@ -179,6 +193,35 @@ describe("TerraDrawAngledRectangleMode", () => {
 
 			expect(mockConfig.onChange).toHaveBeenCalledTimes(1);
 		});
+
+		it("can enable and disable coordinate points for existing rectangles", () => {
+			const angledRectangleMode = new TerraDrawAngledRectangleMode();
+			const mockConfig = MockModeConfig(angledRectangleMode.mode);
+			angledRectangleMode.register(mockConfig);
+			angledRectangleMode.start();
+
+			angledRectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			angledRectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			angledRectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			angledRectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			angledRectangleMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+
+			angledRectangleMode.updateOptions({ showCoordinatePoints: true });
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
+
+			angledRectangleMode.updateOptions({ showCoordinatePoints: false });
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(0);
+		});
 	});
 
 	describe("onMouseMove", () => {
@@ -288,6 +331,41 @@ describe("TerraDrawAngledRectangleMode", () => {
 					[0, 0],
 				],
 			]);
+		});
+
+		it("updates coordinate points while drawing", () => {
+			angledRectangleMode.updateOptions({ showCoordinatePoints: true });
+			angledRectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			angledRectangleMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+
+			const coordinates = store
+				.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				)
+				.map((feature) => feature.geometry.coordinates);
+
+			expect(coordinates).toStrictEqual([
+				[0, 0],
+				[1, 1],
+				[1, 1],
+			]);
+		});
+	});
+
+	describe("cleanUp", () => {
+		it("removes coordinate points for the rectangle being drawn", () => {
+			const angledRectangleMode = new TerraDrawAngledRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(angledRectangleMode.mode);
+			angledRectangleMode.register(mockConfig);
+			angledRectangleMode.start();
+			angledRectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			angledRectangleMode.cleanUp();
+
+			expect(mockConfig.store.copyAll()).toHaveLength(0);
 		});
 	});
 
@@ -669,9 +747,75 @@ describe("TerraDrawAngledRectangleMode", () => {
 				polygonFillOpacity: 0.5,
 			});
 		});
+
+		it("returns the correct styles for a coordinate point", () => {
+			const rectangleMode = new TerraDrawAngledRectangleMode({
+				styles: {
+					coordinatePointWidth: 6,
+					coordinatePointColor: "#ffffff",
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineColor: "#111111",
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+
+			expect(
+				rectangleMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: "angled-rectangle",
+						[COMMON_PROPERTIES.COORDINATE_POINT]: true,
+					},
+				}),
+			).toMatchObject({
+				pointWidth: 6,
+				pointColor: "#ffffff",
+				pointOpacity: 0.8,
+				pointOutlineWidth: 2,
+				pointOutlineColor: "#111111",
+				pointOutlineOpacity: 0.5,
+				zIndex: 20,
+			});
+		});
 	});
 
 	describe("afterFeatureUpdated", () => {
+		it("adds coordinate points when enabled", () => {
+			const angledRectangleMode = new TerraDrawAngledRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(angledRectangleMode.mode);
+			angledRectangleMode.register(mockConfig);
+			const [featureId] = mockConfig.store.create([
+				{
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[1, 1],
+								[1.5, 0.5],
+								[0.5, -0.5],
+								[0, 0],
+							],
+						],
+					},
+					properties: { mode: angledRectangleMode.mode },
+				},
+			]);
+
+			angledRectangleMode.afterFeatureUpdated(mockConfig.store.copy(featureId));
+
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
+		});
+
 		it("does nothing when update is not for the currently drawn polygon", () => {
 			const angledRectangleMode = new TerraDrawAngledRectangleMode();
 			const mockConfig = MockModeConfig(angledRectangleMode.mode);
@@ -721,6 +865,42 @@ describe("TerraDrawAngledRectangleMode", () => {
 			});
 
 			expect(mockConfig.setDoubleClickToZoom).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("afterFeatureAdded", () => {
+		it("adds coordinate points when enabled", () => {
+			const angledRectangleMode = new TerraDrawAngledRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(angledRectangleMode.mode);
+			angledRectangleMode.register(mockConfig);
+			const [featureId] = mockConfig.store.create([
+				{
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[1, 1],
+								[1.5, 0.5],
+								[0.5, -0.5],
+								[0, 0],
+							],
+						],
+					},
+					properties: { mode: angledRectangleMode.mode },
+				},
+			]);
+
+			angledRectangleMode.afterFeatureAdded(mockConfig.store.copy(featureId));
+
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
 		});
 	});
 });

--- a/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/angled-rectangle/angled-rectangle.mode.ts
@@ -45,7 +45,8 @@ import {
 } from "../mutate-feature.behavior";
 import { BehaviorConfig } from "../base.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
-import { isNonNullObject, isNull } from "../../common/checks";
+import { isBoolean, isNonNullObject, isNull } from "../../common/checks";
+import { CoordinatePointBehavior } from "../select/behaviors/coordinate-point.behavior";
 
 type TerraDrawPolygonModeKeyEvents = {
 	cancel?: KeyboardEvent["key"] | null;
@@ -63,6 +64,12 @@ type PolygonStyling = {
 	outlineColor: HexColorStyling;
 	outlineOpacity: NumericStyling;
 	outlineWidth: NumericStyling;
+	coordinatePointWidth: NumericStyling;
+	coordinatePointColor: HexColorStyling;
+	coordinatePointOpacity: NumericStyling;
+	coordinatePointOutlineWidth: NumericStyling;
+	coordinatePointOutlineColor: HexColorStyling;
+	coordinatePointOutlineOpacity: NumericStyling;
 };
 
 interface Cursors {
@@ -81,6 +88,7 @@ interface TerraDrawAngledRectangleModeOptions<
 	pointerDistance?: number;
 	keyEvents?: TerraDrawPolygonModeKeyEvents | null;
 	cursors?: Cursors;
+	showCoordinatePoints?: boolean;
 }
 
 export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonStyling> {
@@ -91,10 +99,12 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 	private keyEvents: TerraDrawPolygonModeKeyEvents = defaultKeyEvents;
 	private cursors: Required<Cursors> = defaultCursors;
 	private mouseMove = false;
+	private showCoordinatePoints = false;
 
 	// Behaviors
 	private mutateFeature!: MutateFeatureBehavior;
 	private readFeature!: ReadFeatureBehavior;
+	private coordinatePoints!: CoordinatePointBehavior;
 
 	constructor(options?: TerraDrawAngledRectangleModeOptions<PolygonStyling>) {
 		super(options, true);
@@ -117,6 +127,11 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
 		}
+
+		if (isBoolean(options?.showCoordinatePoints)) {
+			this.showCoordinatePoints = options.showCoordinatePoints;
+			this.coordinatePoints?.setEnabled(this.showCoordinatePoints);
+		}
 	}
 
 	private close() {
@@ -134,6 +149,13 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 
 		if (!updated) {
 			return;
+		}
+
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
 		}
 
 		const featureId = this.currentId;
@@ -184,11 +206,18 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			return;
 		}
 
-		this.mutateFeature.updatePolygon({
+		const updated = this.mutateFeature.updatePolygon({
 			featureId: this.currentId,
 			coordinateMutations,
 			context: { updateType: UpdateTypes.Provisional },
 		});
+
+		if (updated && this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
+		}
 	}
 
 	private getUpdateForSecondCoordinate(
@@ -320,7 +349,7 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			this.mouseMove = false;
 
 			if (this.currentCoordinate === 0) {
-				const { id: newId } = this.mutateFeature.createPolygon({
+				const created = this.mutateFeature.createPolygon({
 					coordinates: [
 						[event.lng, event.lat],
 						[event.lng, event.lat],
@@ -333,8 +362,15 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 						[COMMON_PROPERTIES.CURRENTLY_DRAWING]: true,
 					},
 				});
-				this.currentId = newId;
+				this.currentId = created.id;
 				this.currentCoordinate++;
+
+				if (this.showCoordinatePoints) {
+					this.coordinatePoints.createOrUpdate({
+						featureId: created.id,
+						featureCoordinates: created.geometry.coordinates,
+					});
+				}
 
 				// Ensure the state is updated to reflect drawing has started
 				this.setDrawing();
@@ -372,6 +408,13 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 
 				if (!updated) {
 					return;
+				}
+
+				if (this.showCoordinatePoints) {
+					this.coordinatePoints.createOrUpdate({
+						featureId: this.currentId,
+						featureCoordinates: updated.geometry.coordinates,
+					});
 				}
 
 				this.currentCoordinate++;
@@ -417,6 +460,10 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 			this.setStarted();
 		}
 
+		if (currentId && this.showCoordinatePoints) {
+			this.coordinatePoints.deletePointsByFeatureIds([currentId]);
+		}
+
 		this.mutateFeature.deleteFeatureIfPresent(currentId);
 	}
 
@@ -457,6 +504,41 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 				);
 
 				styles.zIndex = Z_INDEX.LAYER_ONE;
+			} else if (
+				feature.geometry.type === "Point" &&
+				feature.properties[COMMON_PROPERTIES.COORDINATE_POINT]
+			) {
+				styles.pointWidth = this.getNumericStylingValue(
+					this.styles.coordinatePointWidth,
+					styles.pointWidth,
+					feature,
+				);
+				styles.pointColor = this.getHexColorStylingValue(
+					this.styles.coordinatePointColor,
+					styles.pointColor,
+					feature,
+				);
+				styles.pointOpacity = this.getNumericStylingValue(
+					this.styles.coordinatePointOpacity,
+					1,
+					feature,
+				);
+				styles.pointOutlineWidth = this.getNumericStylingValue(
+					this.styles.coordinatePointOutlineWidth,
+					2,
+					feature,
+				);
+				styles.pointOutlineColor = this.getHexColorStylingValue(
+					this.styles.coordinatePointOutlineColor,
+					styles.pointOutlineColor,
+					feature,
+				);
+				styles.pointOutlineOpacity = this.getNumericStylingValue(
+					this.styles.coordinatePointOutlineOpacity,
+					1,
+					feature,
+				);
+				styles.zIndex = Z_INDEX.LAYER_TWO;
 			}
 		}
 
@@ -473,6 +555,13 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 	}
 
 	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		if (this.showCoordinatePoints && feature.geometry.type === "Polygon") {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+
 		// If we are in the middle of drawing a rectangle and the feature being updated is the current rectangle,
 		// we need to reset the drawing state
 		if (this.currentId === feature.id) {
@@ -484,10 +573,24 @@ export class TerraDrawAngledRectangleMode extends TerraDrawBaseDrawMode<PolygonS
 		}
 	}
 
+	afterFeatureAdded(feature: GeoJSONStoreFeatures): void {
+		if (this.showCoordinatePoints && feature.geometry.type === "Polygon") {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+	}
+
 	registerBehaviors(config: BehaviorConfig) {
 		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
 		});
+		this.coordinatePoints = new CoordinatePointBehavior(
+			config,
+			this.readFeature,
+			this.mutateFeature,
+		);
 	}
 }

--- a/packages/terra-draw/src/modes/linestring/linestring.mode.ts
+++ b/packages/terra-draw/src/modes/linestring/linestring.mode.ts
@@ -199,35 +199,7 @@ export class TerraDrawLineStringMode extends TerraDrawBaseDrawMode<LineStringSty
 
 		if (options?.showCoordinatePoints !== undefined) {
 			this.showCoordinatePoints = options.showCoordinatePoints;
-
-			// If we are showing coordinate points, we need to add them all
-			if (this.coordinatePoints && options.showCoordinatePoints === true) {
-				const features = this.store.copyAllWhere(
-					(properties) => properties.mode === this.mode,
-				);
-				features.forEach((feature) => {
-					this.coordinatePoints.createOrUpdate({
-						featureId: feature.id as FeatureId,
-						featureCoordinates: feature.geometry.coordinates as Position[],
-					});
-				});
-			} else if (this.coordinatePoints && this.showCoordinatePoints === false) {
-				const featuresWithCoordinates = this.store.copyAllWhere(
-					(properties) =>
-						properties.mode === this.mode &&
-						Boolean(
-							(
-								properties[
-									COMMON_PROPERTIES.COORDINATE_POINT_IDS
-								] as FeatureId[]
-							)?.length,
-						),
-				);
-
-				this.coordinatePoints.deletePointsByFeatureIds(
-					featuresWithCoordinates.map((f) => f.id as FeatureId),
-				);
-			}
+			this.coordinatePoints?.setEnabled(this.showCoordinatePoints);
 		}
 	}
 

--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -185,36 +185,7 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 
 		if (isBoolean(options?.showCoordinatePoints)) {
 			this.showCoordinatePoints = options.showCoordinatePoints;
-
-			// If we are not showing coordinate points, we need to add them all
-			if (this.coordinatePoints && options.showCoordinatePoints === true) {
-				const polygonFeatures = this.store
-					.copyAllWhere((properties) => properties.mode === this.mode)
-					.filter((feature) => feature.geometry.type === "Polygon");
-
-				polygonFeatures.forEach((feature) => {
-					this.coordinatePoints.createOrUpdate({
-						featureId: feature.id as FeatureId,
-						featureCoordinates: feature.geometry.coordinates as Position[][],
-					});
-				});
-			} else if (this.coordinatePoints && this.showCoordinatePoints === false) {
-				const featuresWithCoordinates = this.store
-					.copyAllWhere(
-						(properties) =>
-							properties.mode === this.mode &&
-							Boolean(
-								properties[
-									COMMON_PROPERTIES.COORDINATE_POINT_IDS
-								] as FeatureId[],
-							),
-					)
-					.filter((feature) => feature.geometry.type === "Polygon");
-
-				this.coordinatePoints.deletePointsByFeatureIds(
-					featuresWithCoordinates.map((f) => f.id as FeatureId),
-				);
-			}
+			this.coordinatePoints?.setEnabled(this.showCoordinatePoints);
 		}
 	}
 

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.spec.ts
@@ -36,6 +36,20 @@ describe("TerraDrawPolyLineMode", () => {
 			});
 			expect(polyLineMode.mode).toBe("custom-polyline");
 		});
+
+		it("constructs with coordinate point options", () => {
+			new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+				styles: {
+					coordinatePointColor: "#ffffff",
+					coordinatePointWidth: 6,
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineColor: "#000000",
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+		});
 	});
 
 	describe("lifecycle", () => {
@@ -185,6 +199,34 @@ describe("TerraDrawPolyLineMode", () => {
 
 			expect(mockConfig.setCursor).toHaveBeenCalledWith("crosshair");
 		});
+
+		it("can enable and disable coordinate points for existing features", () => {
+			const polyLineMode = new TerraDrawPolyLineMode();
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
+
+			polyLineMode.updateOptions({ showCoordinatePoints: true });
+			expect(
+				config.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(2);
+
+			polyLineMode.updateOptions({ showCoordinatePoints: false });
+			expect(
+				config.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(0);
+		});
 	});
 
 	describe("onMouseMove", () => {
@@ -209,9 +251,70 @@ describe("TerraDrawPolyLineMode", () => {
 				[2, 0],
 			]);
 		});
+
+		it("updates coordinate points while drawing", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 1 }));
+
+			const coordinates = config.store
+				.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				)
+				.map((feature) => feature.geometry.coordinates);
+			expect(coordinates).toStrictEqual([
+				[0, 0],
+				[2, 1],
+			]);
+		});
 	});
 
 	describe("onClick", () => {
+		it("keeps coordinate points when converting to a Polygon", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			polyLineMode.start();
+
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 0 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 1, lat: 1 }));
+			polyLineMode.onMouseMove(MockCursorEvent({ lng: 0, lat: 0 }));
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			const parent = config.store.copyAllWhere(
+				(properties) =>
+					properties.mode === polyLineMode.mode &&
+					!properties[COMMON_PROPERTIES.COORDINATE_POINT] &&
+					!properties[COMMON_PROPERTIES.CLOSING_POINT],
+			)[0];
+			const coordinatePoints = config.store.copyAllWhere(
+				(properties) =>
+					properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+			);
+
+			expect(parent.geometry.type).toBe("Polygon");
+			expect(coordinatePoints).toHaveLength(3);
+			expect(
+				coordinatePoints.every(
+					(point) =>
+						point.properties[COMMON_PROPERTIES.COORDINATE_POINT_FEATURE_ID] ===
+						parent.id,
+				),
+			).toBe(true);
+		});
+
 		it("converts to a Polygon when closing on the starting point", () => {
 			const polyLineMode = new TerraDrawPolyLineMode();
 			const config = MockModeConfig(polyLineMode.mode);
@@ -280,7 +383,9 @@ describe("TerraDrawPolyLineMode", () => {
 
 	describe("onKeyUp", () => {
 		it("finishes as a LineString when finish key is used", () => {
-			const polyLineMode = new TerraDrawPolyLineMode();
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
 			const config = MockModeConfig(polyLineMode.mode);
 
 			polyLineMode.register(config);
@@ -294,8 +399,12 @@ describe("TerraDrawPolyLineMode", () => {
 
 			polyLineMode.onKeyUp(MockKeyboardEvent({ key: "Enter" }));
 
-			const features = config.store.copyAllWhere(
-				(properties) => properties.mode === polyLineMode.mode,
+			const features = config.store
+				.copyAllWhere((properties) => properties.mode === polyLineMode.mode)
+				.filter((feature) => feature.geometry.type === "LineString");
+			const coordinatePoints = config.store.copyAllWhere(
+				(properties) =>
+					properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
 			);
 
 			expect(features).toHaveLength(1);
@@ -305,6 +414,7 @@ describe("TerraDrawPolyLineMode", () => {
 				[1, 0],
 				[2, 0],
 			]);
+			expect(coordinatePoints).toHaveLength(3);
 			expect(config.onFinish).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -330,9 +440,55 @@ describe("TerraDrawPolyLineMode", () => {
 			);
 			expect(features).toHaveLength(0);
 		});
+
+		it("removes coordinate points for the in-progress feature", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			polyLineMode.start();
+			polyLineMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			polyLineMode.cleanUp();
+
+			expect(config.store.copyAll()).toHaveLength(0);
+		});
 	});
 
 	describe("styleFeature", () => {
+		it("styles coordinate points", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				styles: {
+					coordinatePointColor: "#ffffff",
+					coordinatePointWidth: 6,
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineColor: "#111111",
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+			const feature = {
+				id: "test",
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [0, 0] },
+				properties: {
+					mode: "polyline",
+					[COMMON_PROPERTIES.COORDINATE_POINT]: true,
+				},
+			} as GeoJSONStoreFeatures;
+
+			expect(polyLineMode.styleFeature(feature)).toMatchObject({
+				pointColor: "#ffffff",
+				pointWidth: 6,
+				pointOpacity: 0.8,
+				pointOutlineColor: "#111111",
+				pointOutlineWidth: 2,
+				pointOutlineOpacity: 0.5,
+				zIndex: 20,
+			});
+		});
+
 		it("styles a closing point with a white default outline", () => {
 			const polyLineMode = new TerraDrawPolyLineMode();
 			const feature = {
@@ -415,9 +571,83 @@ describe("TerraDrawPolyLineMode", () => {
 				polyLineMode.afterFeatureAdded(MockLineString() as any);
 			}).not.toThrow();
 		});
+
+		it("adds coordinate points when enabled", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			const [featureId] = config.store.create([
+				{
+					geometry: {
+						type: "LineString",
+						coordinates: [
+							[0, 0],
+							[1, 1],
+						],
+					},
+					properties: { mode: polyLineMode.mode },
+				},
+			]);
+
+			polyLineMode.afterFeatureAdded(config.store.copy(featureId));
+
+			expect(
+				config.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(2);
+		});
 	});
 
 	describe("afterFeatureUpdated", () => {
+		it("updates coordinate points when enabled", () => {
+			const polyLineMode = new TerraDrawPolyLineMode({
+				showCoordinatePoints: true,
+			});
+			const config = MockModeConfig(polyLineMode.mode);
+			polyLineMode.register(config);
+			const [featureId] = config.store.create([
+				{
+					geometry: {
+						type: "LineString",
+						coordinates: [
+							[0, 0],
+							[1, 1],
+						],
+					},
+					properties: { mode: polyLineMode.mode },
+				},
+			]);
+			const feature = config.store.copy(featureId);
+			polyLineMode.afterFeatureAdded(feature);
+
+			polyLineMode.afterFeatureUpdated({
+				...feature,
+				geometry: {
+					type: "LineString",
+					coordinates: [
+						[2, 2],
+						[3, 3],
+					],
+				},
+			});
+
+			expect(
+				config.store
+					.copyAllWhere(
+						(properties) =>
+							properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+					)
+					.map((point) => point.geometry.coordinates),
+			).toStrictEqual([
+				[2, 2],
+				[3, 3],
+			]);
+		});
+
 		it("resets drawing state when the current drawing feature is externally updated", () => {
 			const polyLineMode = new TerraDrawPolyLineMode();
 			const config = MockModeConfig(polyLineMode.mode);

--- a/packages/terra-draw/src/modes/polyline/polyline.mode.ts
+++ b/packages/terra-draw/src/modes/polyline/polyline.mode.ts
@@ -39,7 +39,8 @@ import { ClosingPointsBehavior } from "../closing-points.behavior";
 import { DegreeSnappingBehavior } from "../degree-snapping.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../read-feature.behavior";
-import { isNonNullObject, isNull } from "../../common/checks";
+import { isBoolean, isNonNullObject, isNull } from "../../common/checks";
+import { CoordinatePointBehavior } from "../select/behaviors/coordinate-point.behavior";
 
 type TerraDrawPolyLineModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
@@ -73,6 +74,12 @@ type PolyLineStyling = {
 	snappingPointOutlineColor: HexColorStyling;
 	snappingPointOutlineWidth: NumericStyling;
 	snappingPointOutlineOpacity: NumericStyling;
+	coordinatePointColor: HexColorStyling;
+	coordinatePointWidth: NumericStyling;
+	coordinatePointOpacity: NumericStyling;
+	coordinatePointOutlineColor: HexColorStyling;
+	coordinatePointOutlineWidth: NumericStyling;
+	coordinatePointOutlineOpacity: NumericStyling;
 };
 
 interface Cursors {
@@ -91,6 +98,7 @@ interface TerraDrawPolyLineModeOptions<
 	snapping?: Snapping;
 	keyEvents?: TerraDrawPolyLineModeKeyEvents | null;
 	cursors?: Cursors;
+	showCoordinatePoints?: boolean;
 }
 
 export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling> {
@@ -103,6 +111,7 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 	private mouseMove = false;
 	private snapping: Snapping | undefined;
 	private snappedPointId: FeatureId | undefined;
+	private showCoordinatePoints = false;
 
 	private mutateFeature!: MutateFeatureBehavior;
 	private readFeature!: ReadFeatureBehavior;
@@ -113,6 +122,7 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 	private coordinateSnapping!: CoordinateSnappingBehavior;
 	private featureSnapping!: FeatureSnappingBehavior;
 	private degreeSnapping!: DegreeSnappingBehavior;
+	private coordinatePoints!: CoordinatePointBehavior;
 
 	constructor(options?: TerraDrawPolyLineModeOptions<PolyLineStyling>) {
 		super(options, true);
@@ -136,6 +146,11 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			this.keyEvents = { cancel: null, finish: null };
 		} else if (isNonNullObject(options?.keyEvents)) {
 			this.keyEvents = { ...this.keyEvents, ...options.keyEvents };
+		}
+
+		if (isBoolean(options?.showCoordinatePoints)) {
+			this.showCoordinatePoints = options.showCoordinatePoints;
+			this.coordinatePoints?.setEnabled(this.showCoordinatePoints);
 		}
 	}
 
@@ -168,6 +183,11 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			this.mutateFeature,
 			this.readFeature,
 		);
+		this.coordinatePoints = new CoordinatePointBehavior(
+			config,
+			this.readFeature,
+			this.mutateFeature,
+		);
 	}
 
 	/** @internal */
@@ -199,6 +219,13 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 
 		if (!updated) {
 			return;
+		}
+
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
 		}
 
 		const featureId = this.currentId;
@@ -253,6 +280,14 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			return;
 		}
 
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.deletePointsByFeatureIds([featureIdToRemove]);
+			this.coordinatePoints.createOrUpdate({
+				featureId: created.id,
+				featureCoordinates: created.geometry.coordinates,
+			});
+		}
+
 		this.mutateFeature.deleteFeatureIfPresent(featureIdToRemove);
 
 		this.currentCoordinate = 0;
@@ -297,6 +332,13 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			return;
 		}
 
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
+		}
+
 		const { isClosing, isPreviousClosing } =
 			this.closingPoints.isPolygonClosingPoints(event);
 		if (
@@ -322,6 +364,14 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 
 			this.currentId = created.id as FeatureId;
 			this.currentCoordinate = 1;
+
+			if (this.showCoordinatePoints) {
+				this.coordinatePoints.createOrUpdate({
+					featureId: created.id,
+					featureCoordinates: created.geometry.coordinates,
+				});
+			}
+
 			this.setDrawing();
 			return;
 		}
@@ -360,6 +410,13 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 		}
 
 		this.currentCoordinate++;
+
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
+		}
 
 		if (this.currentCoordinate >= 2) {
 			const polygonLikeCoordinates = this.toPolygonLikeCoordinates(
@@ -417,6 +474,10 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 
 		if (this.state === "drawing") {
 			this.setStarted();
+		}
+
+		if (currentId && this.showCoordinatePoints) {
+			this.coordinatePoints.deletePointsByFeatureIds([currentId]);
 		}
 
 		this.mutateFeature.deleteFeatureIfPresent(currentId);
@@ -611,15 +672,19 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 				feature.properties[COMMON_PROPERTIES.CLOSING_POINT] === true;
 			const snappingPoint =
 				feature.properties[COMMON_PROPERTIES.SNAPPING_POINT] === true;
+			const coordinatePoint =
+				feature.properties[COMMON_PROPERTIES.COORDINATE_POINT] === true;
 
-			if (!closingPoint && !snappingPoint) {
+			if (!closingPoint && !snappingPoint && !coordinatePoint) {
 				return styles;
 			}
 
 			styles.pointColor = this.getHexColorStylingValue(
 				closingPoint
 					? this.styles.closingPointColor
-					: this.styles.snappingPointColor,
+					: snappingPoint
+						? this.styles.snappingPointColor
+						: this.styles.coordinatePointColor,
 				styles.pointColor,
 				feature,
 			);
@@ -627,7 +692,9 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.pointWidth = this.getNumericStylingValue(
 				closingPoint
 					? this.styles.closingPointWidth
-					: this.styles.snappingPointWidth,
+					: snappingPoint
+						? this.styles.snappingPointWidth
+						: this.styles.coordinatePointWidth,
 				styles.pointWidth,
 				feature,
 			);
@@ -635,7 +702,9 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.pointOpacity = this.getNumericStylingValue(
 				closingPoint
 					? this.styles.closingPointOpacity
-					: this.styles.snappingPointOpacity,
+					: snappingPoint
+						? this.styles.snappingPointOpacity
+						: this.styles.coordinatePointOpacity,
 				1,
 				feature,
 			);
@@ -643,7 +712,9 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.pointOutlineColor = this.getHexColorStylingValue(
 				closingPoint
 					? this.styles.closingPointOutlineColor
-					: this.styles.snappingPointOutlineColor,
+					: snappingPoint
+						? this.styles.snappingPointOutlineColor
+						: this.styles.coordinatePointOutlineColor,
 				styles.pointOutlineColor,
 				feature,
 			);
@@ -651,7 +722,9 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.pointOutlineWidth = this.getNumericStylingValue(
 				closingPoint
 					? this.styles.closingPointOutlineWidth
-					: this.styles.snappingPointOutlineWidth,
+					: snappingPoint
+						? this.styles.snappingPointOutlineWidth
+						: this.styles.coordinatePointOutlineWidth,
 				2,
 				feature,
 			);
@@ -659,20 +732,44 @@ export class TerraDrawPolyLineMode extends TerraDrawBaseDrawMode<PolyLineStyling
 			styles.pointOutlineOpacity = this.getNumericStylingValue(
 				closingPoint
 					? this.styles.closingPointOutlineOpacity
-					: this.styles.snappingPointOutlineOpacity,
+					: snappingPoint
+						? this.styles.snappingPointOutlineOpacity
+						: this.styles.coordinatePointOutlineOpacity,
 				1,
 				feature,
 			);
 
-			styles.zIndex = Z_INDEX.LAYER_THREE;
+			styles.zIndex = coordinatePoint ? Z_INDEX.LAYER_TWO : Z_INDEX.LAYER_THREE;
 		}
 
 		return styles;
 	}
 
-	afterFeatureAdded(_feature: GeoJSONStoreFeatures) {}
+	afterFeatureAdded(feature: GeoJSONStoreFeatures) {
+		if (
+			this.showCoordinatePoints &&
+			(feature.geometry.type === "LineString" ||
+				feature.geometry.type === "Polygon")
+		) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+	}
 
 	afterFeatureUpdated(feature: GeoJSONStoreFeatures) {
+		if (
+			this.showCoordinatePoints &&
+			(feature.geometry.type === "LineString" ||
+				feature.geometry.type === "Polygon")
+		) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+
 		if (this.snappedPointId) {
 			this.mutateFeature.deleteFeatureIfPresent(this.snappedPointId);
 			this.snappedPointId = undefined;

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.spec.ts
@@ -59,6 +59,80 @@ describe("TerraDrawRectangleMode", () => {
 				drawInteraction: "click-move-or-drag",
 			});
 		});
+
+		it("constructs with coordinate point options", () => {
+			new TerraDrawRectangleMode({
+				showCoordinatePoints: true,
+				styles: {
+					coordinatePointWidth: 6,
+					coordinatePointColor: "#ffffff",
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineColor: "#000000",
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+		});
+	});
+
+	describe("showCoordinatePoints", () => {
+		it("creates and updates a point for each rectangle coordinate", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			rectangleMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 1 }));
+			rectangleMode.onClick(MockCursorEvent({ lng: 2, lat: 1 }));
+
+			const coordinatePoints = mockConfig.store
+				.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				)
+				.map((feature) => feature.geometry.coordinates);
+
+			expect(coordinatePoints).toStrictEqual([
+				[0, 0],
+				[2, 0],
+				[2, 1],
+				[0, 1],
+			]);
+		});
+
+		it("can be enabled and disabled for existing rectangles", () => {
+			const rectangleMode = new TerraDrawRectangleMode();
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+			rectangleMode.onMouseMove(MockCursorEvent({ lng: 2, lat: 1 }));
+			rectangleMode.onClick(MockCursorEvent({ lng: 2, lat: 1 }));
+
+			rectangleMode.updateOptions({ showCoordinatePoints: true });
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
+
+			expect(() =>
+				rectangleMode.updateOptions({ showCoordinatePoints: true }),
+			).not.toThrow();
+
+			rectangleMode.updateOptions({ showCoordinatePoints: false });
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(0);
+		});
 	});
 
 	describe("lifecycle", () => {
@@ -506,6 +580,7 @@ describe("TerraDrawRectangleMode", () => {
 	describe("cleanUp", () => {
 		let rectangleMode: TerraDrawRectangleMode;
 		let onChange: jest.Mock;
+		let store: TerraDrawGeoJSONStore;
 
 		beforeEach(() => {
 			rectangleMode = new TerraDrawRectangleMode();
@@ -513,6 +588,7 @@ describe("TerraDrawRectangleMode", () => {
 			const mockConfig = MockModeConfig(rectangleMode.mode);
 
 			onChange = mockConfig.onChange;
+			store = mockConfig.store;
 
 			rectangleMode.register(mockConfig);
 			rectangleMode.start();
@@ -535,6 +611,15 @@ describe("TerraDrawRectangleMode", () => {
 				"delete",
 				undefined,
 			);
+		});
+
+		it("deletes coordinate points for the rectangle being drawn", () => {
+			rectangleMode.updateOptions({ showCoordinatePoints: true });
+			rectangleMode.onClick(MockCursorEvent({ lng: 0, lat: 0 }));
+
+			rectangleMode.cleanUp();
+
+			expect(store.copyAll()).toHaveLength(0);
 		});
 	});
 
@@ -1063,6 +1148,38 @@ describe("TerraDrawRectangleMode", () => {
 				polygonFillOpacity: 0.5,
 			});
 		});
+
+		it("returns the correct styles for a coordinate point", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				styles: {
+					coordinatePointWidth: 6,
+					coordinatePointColor: "#ffffff",
+					coordinatePointOpacity: 0.8,
+					coordinatePointOutlineWidth: 2,
+					coordinatePointOutlineColor: "#111111",
+					coordinatePointOutlineOpacity: 0.5,
+				},
+			});
+
+			expect(
+				rectangleMode.styleFeature({
+					type: "Feature",
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: {
+						mode: "rectangle",
+						[COMMON_PROPERTIES.COORDINATE_POINT]: true,
+					},
+				}),
+			).toMatchObject({
+				pointWidth: 6,
+				pointColor: "#ffffff",
+				pointOpacity: 0.8,
+				pointOutlineWidth: 2,
+				pointOutlineColor: "#111111",
+				pointOutlineOpacity: 0.5,
+				zIndex: 20,
+			});
+		});
 	});
 
 	describe("validateFeature", () => {
@@ -1205,6 +1322,43 @@ describe("TerraDrawRectangleMode", () => {
 	});
 
 	describe("afterFeatureUpdated", () => {
+		it("adds coordinate points when showCoordinatePoints is true", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			const [featureId] = mockConfig.store.create([
+				{
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[1, 0],
+								[1, 1],
+								[0, 1],
+								[0, 0],
+							],
+						],
+					},
+					properties: { mode: "rectangle" },
+				},
+			]);
+			const feature = mockConfig.store.copy(featureId);
+
+			rectangleMode.afterFeatureUpdated(feature);
+
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
+		});
+
 		it("does nothing when update is not for the currently drawn polygon", () => {
 			const rectangleMode = new TerraDrawRectangleMode();
 			const mockConfig = MockModeConfig(rectangleMode.mode);
@@ -1252,6 +1406,44 @@ describe("TerraDrawRectangleMode", () => {
 			});
 
 			expect(mockConfig.setDoubleClickToZoom).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("afterFeatureAdded", () => {
+		it("adds coordinate points when showCoordinatePoints is true", () => {
+			const rectangleMode = new TerraDrawRectangleMode({
+				showCoordinatePoints: true,
+			});
+			const mockConfig = MockModeConfig(rectangleMode.mode);
+			rectangleMode.register(mockConfig);
+			rectangleMode.start();
+
+			const [featureId] = mockConfig.store.create([
+				{
+					geometry: {
+						type: "Polygon",
+						coordinates: [
+							[
+								[0, 0],
+								[1, 0],
+								[1, 1],
+								[0, 1],
+								[0, 0],
+							],
+						],
+					},
+					properties: { mode: "rectangle" },
+				},
+			]);
+
+			rectangleMode.afterFeatureAdded(mockConfig.store.copy(featureId));
+
+			expect(
+				mockConfig.store.copyAllWhere(
+					(properties) =>
+						properties[COMMON_PROPERTIES.COORDINATE_POINT] as boolean,
+				),
+			).toHaveLength(4);
 		});
 	});
 });

--- a/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
+++ b/packages/terra-draw/src/modes/rectangle/rectangle.mode.ts
@@ -31,10 +31,13 @@ import { ValidateNonIntersectingPolygonFeature } from "../../validations/polygon
 import { BehaviorConfig } from "../base.behavior";
 import { MutateFeatureBehavior, Mutations } from "../mutate-feature.behavior";
 import {
+	isBoolean,
 	isDrawInteraction,
 	isNonNullObject,
 	isNull,
 } from "../../common/checks";
+import { CoordinatePointBehavior } from "../select/behaviors/coordinate-point.behavior";
+import { ReadFeatureBehavior } from "../read-feature.behavior";
 
 type TerraDrawRectangleModeKeyEvents = {
 	cancel: KeyboardEvent["key"] | null;
@@ -52,6 +55,12 @@ type RectanglePolygonStyling = {
 	outlineColor: HexColorStyling;
 	outlineOpacity: NumericStyling;
 	outlineWidth: NumericStyling;
+	coordinatePointWidth: NumericStyling;
+	coordinatePointColor: HexColorStyling;
+	coordinatePointOpacity: NumericStyling;
+	coordinatePointOutlineWidth: NumericStyling;
+	coordinatePointOutlineColor: HexColorStyling;
+	coordinatePointOutlineOpacity: NumericStyling;
 };
 
 interface Cursors {
@@ -68,6 +77,7 @@ interface TerraDrawRectangleModeOptions<
 	keyEvents?: TerraDrawRectangleModeKeyEvents | null;
 	cursors?: Cursors;
 	drawInteraction?: DrawInteractions;
+	showCoordinatePoints?: boolean;
 }
 
 export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolygonStyling> {
@@ -79,9 +89,12 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	private cursors: Required<Cursors> = defaultCursors;
 	private drawInteraction = "click-move";
 	private drawType: DrawType | undefined;
+	private showCoordinatePoints = false;
 
 	// Behaviors
 	private mutateFeature!: MutateFeatureBehavior;
+	private readFeature!: ReadFeatureBehavior;
+	private coordinatePoints!: CoordinatePointBehavior;
 
 	constructor(
 		options?: TerraDrawRectangleModeOptions<RectanglePolygonStyling>,
@@ -110,6 +123,11 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 		if (isDrawInteraction(options?.drawInteraction)) {
 			this.drawInteraction = options.drawInteraction;
 		}
+
+		if (isBoolean(options?.showCoordinatePoints)) {
+			this.showCoordinatePoints = options.showCoordinatePoints;
+			this.coordinatePoints?.setEnabled(this.showCoordinatePoints);
+		}
 	}
 
 	private updateRectangle(endPosition: Position, updateType: UpdateTypes) {
@@ -119,7 +137,7 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 		const isFinish = updateType === UpdateTypes.Finish;
 
-		return this.mutateFeature.updatePolygon({
+		const updated = this.mutateFeature.updatePolygon({
 			featureId: this.currentRectangleId,
 			coordinateMutations: [
 				{
@@ -150,6 +168,15 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 					}
 				: { updateType },
 		});
+
+		if (updated && this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: this.currentRectangleId,
+				featureCoordinates: updated.geometry.coordinates,
+			});
+		}
+
+		return updated;
 	}
 
 	private close() {
@@ -200,6 +227,13 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			},
 		});
 		this.currentRectangleId = feature.id;
+
+		if (this.showCoordinatePoints) {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
 
 		this.drawType = drawType;
 		this.setDrawing();
@@ -338,6 +372,10 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			this.setStarted();
 		}
 
+		if (cleanUpId && this.showCoordinatePoints) {
+			this.coordinatePoints.deletePointsByFeatureIds([cleanUpId]);
+		}
+
 		this.mutateFeature.deleteFeatureIfPresent(cleanUpId);
 	}
 
@@ -347,8 +385,8 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 
 		if (
 			feature.type === "Feature" &&
-			feature.geometry.type === "Polygon" &&
-			feature.properties.mode === this.mode
+			feature.properties.mode === this.mode &&
+			feature.geometry.type === "Polygon"
 		) {
 			styles.polygonFillColor = this.getHexColorStylingValue(
 				this.styles.fillColor,
@@ -383,6 +421,45 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 			styles.zIndex = Z_INDEX.LAYER_ONE;
 
 			return styles;
+		} else if (
+			feature.type === "Feature" &&
+			feature.properties.mode === this.mode &&
+			feature.geometry.type === "Point" &&
+			feature.properties[COMMON_PROPERTIES.COORDINATE_POINT]
+		) {
+			styles.pointWidth = this.getNumericStylingValue(
+				this.styles.coordinatePointWidth,
+				styles.pointWidth,
+				feature,
+			);
+			styles.pointColor = this.getHexColorStylingValue(
+				this.styles.coordinatePointColor,
+				styles.pointColor,
+				feature,
+			);
+			styles.pointOpacity = this.getNumericStylingValue(
+				this.styles.coordinatePointOpacity,
+				1,
+				feature,
+			);
+			styles.pointOutlineWidth = this.getNumericStylingValue(
+				this.styles.coordinatePointOutlineWidth,
+				2,
+				feature,
+			);
+			styles.pointOutlineColor = this.getHexColorStylingValue(
+				this.styles.coordinatePointOutlineColor,
+				styles.pointOutlineColor,
+				feature,
+			);
+			styles.pointOutlineOpacity = this.getNumericStylingValue(
+				this.styles.coordinatePointOutlineOpacity,
+				1,
+				feature,
+			);
+			styles.zIndex = Z_INDEX.LAYER_TWO;
+
+			return styles;
 		}
 
 		return styles;
@@ -398,6 +475,13 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 	}
 
 	afterFeatureUpdated(feature: GeoJSONStoreFeatures): void {
+		if (this.showCoordinatePoints && feature.geometry.type === "Polygon") {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+
 		// If we are in the middle of drawing a rectangle and the feature being updated is the current rectangle,
 		// we need to reset the drawing state
 		if (this.currentRectangleId === feature.id) {
@@ -410,9 +494,24 @@ export class TerraDrawRectangleMode extends TerraDrawBaseDrawMode<RectanglePolyg
 		}
 	}
 
+	afterFeatureAdded(feature: GeoJSONStoreFeatures): void {
+		if (this.showCoordinatePoints && feature.geometry.type === "Polygon") {
+			this.coordinatePoints.createOrUpdate({
+				featureId: feature.id as FeatureId,
+				featureCoordinates: feature.geometry.coordinates,
+			});
+		}
+	}
+
 	registerBehaviors(config: BehaviorConfig) {
+		this.readFeature = new ReadFeatureBehavior(config);
 		this.mutateFeature = new MutateFeatureBehavior(config, {
 			validate: this.validate,
 		});
+		this.coordinatePoints = new CoordinatePointBehavior(
+			config,
+			this.readFeature,
+			this.mutateFeature,
+		);
 	}
 }

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.spec.ts
@@ -2,7 +2,7 @@ import { Position } from "geojson";
 import { COMMON_PROPERTIES } from "../../../common";
 import { JSONObject } from "../../../store/store";
 import { MockBehaviorConfig } from "../../../test/mock-behavior-config";
-import { MockPolygonSquare } from "../../../test/mock-features";
+import { MockLineString, MockPolygonSquare } from "../../../test/mock-features";
 import { CoordinatePointBehavior } from "./coordinate-point.behavior";
 import { MutateFeatureBehavior } from "../../mutate-feature.behavior";
 import { ReadFeatureBehavior } from "../../read-feature.behavior";
@@ -41,6 +41,136 @@ describe("CoordinatePointBehavior", () => {
 					validate: jest.fn(() => ({ valid: true })),
 				}),
 			);
+		});
+
+		it("setEnabled creates and removes points for supported mode features", () => {
+			const mockPolygon = MockPolygonSquare();
+			const mockLineString = MockLineString();
+			const [polygonId, lineStringId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: { mode: "test" },
+				},
+				{
+					geometry: mockLineString.geometry,
+					properties: { mode: "test" },
+				},
+				{
+					geometry: mockLineString.geometry,
+					properties: { mode: "other" },
+				},
+				{
+					geometry: { type: "Point", coordinates: [0, 0] },
+					properties: { mode: "test" },
+				},
+			]);
+
+			coordinatePointBehavior.setEnabled(true);
+
+			// Ensure all coordinate points are created
+			expect(
+				config.store.copyAllWhere((properties) =>
+					Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+				),
+			).toHaveLength(6);
+
+			// Ensure the coordinate point ids are set on the parent features
+			expect(
+				config.store.getPropertiesCopy(polygonId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toHaveLength(4);
+
+			// Ensure the coordinate point ids are set on the parent features
+			expect(
+				config.store.getPropertiesCopy(lineStringId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toHaveLength(2);
+
+			coordinatePointBehavior.setEnabled(false);
+
+			// Ensure all coordinate points are removed
+			expect(
+				config.store.copyAllWhere((properties) =>
+					Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+				),
+			).toHaveLength(0);
+
+			// Ensure the coordinate point ids are removed from the parent features
+			expect(
+				config.store.getPropertiesCopy(polygonId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toBeNull();
+
+			// Ensure the coordinate point ids are removed from the parent features
+			expect(
+				config.store.getPropertiesCopy(lineStringId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toBeNull();
+		});
+
+		it("setEnabled does not duplicate or replace points when repeatedly enabled", () => {
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: { mode: "test" },
+				},
+			]);
+
+			coordinatePointBehavior.setEnabled(true);
+			const coordinatePointIds = config.store.getPropertiesCopy(featureId)[
+				COMMON_PROPERTIES.COORDINATE_POINT_IDS
+			] as string[];
+
+			coordinatePointBehavior.setEnabled(true);
+
+			// Ensure the coordinate point ids have not changed
+			expect(
+				config.store.getPropertiesCopy(featureId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toStrictEqual(coordinatePointIds);
+
+			// Ensure all coordinate points are created
+			expect(
+				config.store.copyAllWhere((properties) =>
+					Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+				),
+			).toHaveLength(4);
+		});
+
+		it("setEnabled remains disabled when repeatedly disabled", () => {
+			const mockPolygon = MockPolygonSquare();
+			const [featureId] = config.store.create([
+				{
+					geometry: mockPolygon.geometry,
+					properties: { mode: "test" },
+				},
+			]);
+
+			coordinatePointBehavior.setEnabled(true);
+			coordinatePointBehavior.setEnabled(false);
+
+			expect(() => coordinatePointBehavior.setEnabled(false)).not.toThrow();
+			expect(
+				config.store.getPropertiesCopy(featureId)[
+					COMMON_PROPERTIES.COORDINATE_POINT_IDS
+				],
+			).toBeNull();
+			expect(
+				config.store.copyAllWhere((properties) =>
+					Boolean(properties[COMMON_PROPERTIES.COORDINATE_POINT]),
+				),
+			).toHaveLength(0);
+		});
+
+		it("setEnabled handles a mode without supported features", () => {
+			expect(() => coordinatePointBehavior.setEnabled(true)).not.toThrow();
+			expect(() => coordinatePointBehavior.setEnabled(false)).not.toThrow();
 		});
 
 		it("createOrUpdate", () => {

--- a/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
+++ b/packages/terra-draw/src/modes/select/behaviors/coordinate-point.behavior.ts
@@ -15,6 +15,36 @@ export class CoordinatePointBehavior extends TerraDrawModeBehavior {
 		super(config);
 	}
 
+	public setEnabled(enabled: boolean) {
+		const features = this.store
+			.copyAllWhere((properties) => properties.mode === this.mode)
+			.filter(
+				(feature) =>
+					feature.geometry.type === "LineString" ||
+					feature.geometry.type === "Polygon",
+			);
+
+		if (enabled) {
+			features.forEach((feature) => {
+				this.createOrUpdate({
+					featureId: feature.id as FeatureId,
+					featureCoordinates: feature.geometry.coordinates as
+						| Position[]
+						| Position[][],
+				});
+			});
+			return;
+		} else {
+			this.deletePointsByFeatureIds(
+				features
+					.filter((feature) =>
+						Boolean(feature.properties[COMMON_PROPERTIES.COORDINATE_POINT_IDS]),
+					)
+					.map((feature) => feature.id as FeatureId),
+			);
+		}
+	}
+
 	public createOrUpdate({
 		featureId,
 		featureCoordinates,


### PR DESCRIPTION
## Description of Changes

This PR adds support for `showCoordinatePoints` for Rectangle, Angled Rectangle and Polyline modes

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [x] If there are behaviour changes these are documented 